### PR TITLE
fix: preserve multi-return local slots

### DIFF
--- a/crates/glua_code_analysis/src/compilation/analyzer/decl/stats.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/decl/stats.rs
@@ -8,7 +8,7 @@ use crate::{
     LuaDeclExtra, LuaMemberFeature, LuaMemberId, LuaSemanticDeclId, LuaSignatureId, LuaType,
     LuaTypeCache,
     compilation::analyzer::common::bind_type,
-    db_index::{LocalAttribute, LuaDecl, LuaMember, LuaMemberKey},
+    db_index::{LocalAttribute, LuaDecl, LuaDeclInitializer, LuaMember, LuaMemberKey},
 };
 
 use super::{DeclAnalyzer, members::find_index_owner};
@@ -38,8 +38,20 @@ pub fn analyze_local_stat(analyzer: &mut DeclAnalyzer, stat: LuaLocalStat) -> Op
         let file_id = analyzer.get_file_id();
         let range = local_name.get_range();
         let expr_id = value_expr_list.get(index).map(|expr| expr.get_syntax_id());
+        let last_value_index = value_expr_list.len().saturating_sub(1);
+        let initializer = if value_expr_list.is_empty() {
+            None
+        } else if index < last_value_index {
+            value_expr_list
+                .get(index)
+                .map(|expr| LuaDeclInitializer::new(expr.get_syntax_id(), 0))
+        } else {
+            value_expr_list
+                .last()
+                .map(|expr| LuaDeclInitializer::new(expr.get_syntax_id(), index - last_value_index))
+        };
 
-        let decl = LuaDecl::new(
+        let mut decl = LuaDecl::new(
             &name,
             file_id,
             range,
@@ -49,6 +61,7 @@ pub fn analyze_local_stat(analyzer: &mut DeclAnalyzer, stat: LuaLocalStat) -> Op
             },
             expr_id,
         );
+        decl.set_initializer(initializer);
         analyzer.add_decl(decl);
     }
 

--- a/crates/glua_code_analysis/src/compilation/analyzer/lua/call.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/lua/call.rs
@@ -906,7 +906,7 @@ fn resolve_cached_decl_type(
         return Ok(Some(type_cache.as_type().clone()));
     }
 
-    if decl.get_value_syntax_id().is_some() {
+    if decl.has_initializer() {
         return Err(InferFailReason::UnResolveDeclType(decl_id));
     }
 

--- a/crates/glua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/glua_code_analysis/src/compilation/test/flow.rs
@@ -2751,6 +2751,29 @@ _2 = a[1]
     }
 
     #[gtest]
+    fn test_multi_return_local_slot_is_not_treated_as_uninitialized() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@return string, number
+            local function get_size()
+                return "", 1
+            end
+
+            local _, height = get_size()
+            if true then
+                height = height
+            end
+            a = height
+            "#,
+        );
+
+        let a = ws.expr_ty("a");
+        let desc = ws.humanize_type(a);
+        assert_that!(desc, eq("number"));
+    }
+
+    #[gtest]
     fn test_isfunction_narrows_uninitialized_local() {
         // After isfunction(testFunc), testFunc should be non-nil (callable without need-check-nil)
         let mut ws = VirtualWorkspace::new();

--- a/crates/glua_code_analysis/src/db_index/declaration/decl.rs
+++ b/crates/glua_code_analysis/src/db_index/declaration/decl.rs
@@ -12,12 +12,33 @@ pub struct LuaDecl {
     file_id: FileId,
     range: TextRange,
     expr_id: Option<LuaSyntaxId>,
+    initializer: Option<LuaDeclInitializer>,
     pub extra: LuaDeclExtra,
     /// True when this declaration was synthetically injected by the language server
     /// (e.g. the scoped-class variable `GM`/`ENT`/`SWEP` seeded into gamemode/entity files).
     /// Such decls are not present in the user's source and must be excluded from
     /// diagnostics that rely on user-written variable declarations (e.g. `unused`, `redefined-local`).
     is_seeded_class_local: bool,
+}
+
+#[derive(Eq, PartialEq, Hash, Debug, Clone, Copy)]
+pub struct LuaDeclInitializer {
+    expr_id: LuaSyntaxId,
+    ret_idx: usize,
+}
+
+impl LuaDeclInitializer {
+    pub fn new(expr_id: LuaSyntaxId, ret_idx: usize) -> Self {
+        Self { expr_id, ret_idx }
+    }
+
+    pub fn get_expr_syntax_id(&self) -> LuaSyntaxId {
+        self.expr_id
+    }
+
+    pub fn get_ret_idx(&self) -> usize {
+        self.ret_idx
+    }
 }
 
 #[derive(Eq, PartialEq, Hash, Debug, Clone)]
@@ -56,6 +77,7 @@ impl LuaDecl {
             file_id,
             range,
             expr_id,
+            initializer: expr_id.map(|expr_id| LuaDeclInitializer::new(expr_id, 0)),
             extra,
             is_seeded_class_local: false,
         }
@@ -96,6 +118,14 @@ impl LuaDecl {
 
     pub fn get_value_syntax_id(&self) -> Option<LuaSyntaxId> {
         self.expr_id
+    }
+
+    pub fn get_initializer(&self) -> Option<LuaDeclInitializer> {
+        self.initializer
+    }
+
+    pub fn set_initializer(&mut self, initializer: Option<LuaDeclInitializer>) {
+        self.initializer = initializer;
     }
 
     pub fn is_local(&self) -> bool {

--- a/crates/glua_code_analysis/src/db_index/declaration/decl.rs
+++ b/crates/glua_code_analysis/src/db_index/declaration/decl.rs
@@ -124,6 +124,10 @@ impl LuaDecl {
         self.initializer
     }
 
+    pub fn has_initializer(&self) -> bool {
+        self.initializer.is_some()
+    }
+
     pub fn set_initializer(&mut self, initializer: Option<LuaDeclInitializer>) {
         self.initializer = initializer;
     }

--- a/crates/glua_code_analysis/src/db_index/declaration/mod.rs
+++ b/crates/glua_code_analysis/src/db_index/declaration/mod.rs
@@ -4,7 +4,7 @@ mod decl_tree;
 mod scope;
 
 pub use decl::LuaDeclExtra;
-pub use decl::{LocalAttribute, LuaDecl};
+pub use decl::{LocalAttribute, LuaDecl, LuaDeclInitializer};
 pub use decl_id::LuaDeclId;
 pub use decl_tree::{LuaDeclOrMemberId, LuaDeclarationTree};
 pub use scope::{LuaScope, LuaScopeId, LuaScopeKind, ScopeOrDeclId};

--- a/crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
@@ -233,6 +233,44 @@ mod tests {
     }
 
     #[test]
+    fn test_multi_return_local_after_unrelated_branch_assignment() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.check_code_for_namespace(
+            DiagnosticCode::AssignTypeMismatch,
+            r#"
+                local _, height = get_size()
+
+                local x; if true then x = x end
+
+                ---@type { h: number }
+                local ghost = { h = height }
+
+                ---@return string, number
+                function get_size() return "", 1 end
+            "#
+        ));
+    }
+
+    #[test]
+    fn test_three_return_local_after_unrelated_branch_assignment() {
+        let mut ws = VirtualWorkspace::new();
+        assert!(ws.check_code_for_namespace(
+            DiagnosticCode::AssignTypeMismatch,
+            r#"
+                local _, _, height = get_size()
+
+                local x; if true then x = x end
+
+                ---@type { h: number }
+                local ghost = { h = height }
+
+                ---@return string, boolean, number
+                function get_size() return "", false, 1 end
+            "#
+        ));
+    }
+
+    #[test]
     fn test_issue_193() {
         let mut ws = VirtualWorkspace::new();
         assert!(ws.check_code_for_namespace(

--- a/crates/glua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -1008,11 +1008,11 @@ fn try_infer_decl_initializer_type(
         .get_decl(&decl_id)
         .ok_or(InferFailReason::None)?;
 
-    let Some(value_syntax_id) = decl.get_value_syntax_id() else {
+    let Some(initializer) = decl.get_initializer() else {
         return Ok(None);
     };
 
-    let Some(node) = value_syntax_id.to_node_from_root(root.syntax()) else {
+    let Some(node) = initializer.get_expr_syntax_id().to_node_from_root(root.syntax()) else {
         return Ok(None);
     };
 
@@ -1020,11 +1020,6 @@ fn try_infer_decl_initializer_type(
         return Ok(None);
     };
 
-    let expr_type = infer_expr(db, cache, expr.clone())?;
-    let init_type = match expr_type {
-        LuaType::Variadic(variadic) => variadic.get_type(0).cloned(),
-        ty => Some(ty),
-    };
-
-    Ok(init_type)
+    infer_expr_list_value_type_at(db, cache, &[expr], initializer.get_ret_idx())
+        .map(|typ| Some(typ.unwrap_or(LuaType::Nil)))
 }

--- a/crates/glua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -478,7 +478,7 @@ fn should_treat_unresolved_decl_as_nil(db: &DbIndex, decl_id: crate::LuaDeclId) 
         return false;
     }
 
-    if decl.get_value_syntax_id().is_some() {
+    if decl.has_initializer() {
         return false;
     }
 
@@ -497,7 +497,7 @@ fn should_defer_uninitialized_local_decl_type(db: &DbIndex, decl_id: crate::LuaD
         return false;
     }
 
-    if decl.get_value_syntax_id().is_some() {
+    if decl.has_initializer() {
         return false;
     }
 
@@ -1020,6 +1020,12 @@ fn try_infer_decl_initializer_type(
         return Ok(None);
     };
 
-    infer_expr_list_value_type_at(db, cache, &[expr], initializer.get_ret_idx())
-        .map(|typ| Some(typ.unwrap_or(LuaType::Nil)))
+    let ret_idx = initializer.get_ret_idx();
+    let init_type = match infer_expr(db, cache, expr)? {
+        LuaType::Variadic(variadic) => variadic.get_type(ret_idx).cloned().unwrap_or(LuaType::Nil),
+        ty if ret_idx == 0 => ty,
+        _ => LuaType::Nil,
+    };
+
+    Ok(Some(init_type))
 }


### PR DESCRIPTION
fixes a weird false warning with multi-return locals

example:

```lua
local _, height = get_size()

local x; if true then x = x end

---@type { h: number }
local ghost = { h = height }

---@return string, number
function get_size() return "", 1 end
```

`height` should be the second return from `get_size()`, but after walking through a branch the checker could lose track of which return value it came from