### PR TITLE
fix: preserve generic identity during infer matching

### DIFF
--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
@@ -149,7 +149,7 @@ impl FileGenericIndex {
             if let Some(params) = self.generic_params.get(*params_id)
                 && let Some((id, param)) = params.params.get(name)
             {
-                let tpl_id = param.tpl_id.unwrap_or_else(|| {
+                let tpl_id = param.tpl_id.unwrap_or({
                     if params.is_func {
                         GenericTplId::Func(*id as u32)
                     } else {

--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
@@ -51,16 +51,25 @@ impl FileGenericIndex {
         params_id
     }
 
-    pub fn append_generic_param(&mut self, scope_id: GenericParamId, param: GenericParam) {
-        if let Some(scope) = self.generic_params.get_mut(scope_id.id) {
-            scope.insert_param(param);
-        }
+    pub fn append_generic_param(
+        &mut self,
+        scope_id: GenericParamId,
+        param: GenericParam,
+    ) -> Option<GenericParam> {
+        self.generic_params
+            .get_mut(scope_id.id)
+            .map(|scope| scope.insert_param(param))
     }
 
-    pub fn append_generic_params(&mut self, scope_id: GenericParamId, params: Vec<GenericParam>) {
-        for param in params {
-            self.append_generic_param(scope_id, param);
-        }
+    pub fn append_generic_params(
+        &mut self,
+        scope_id: GenericParamId,
+        params: Vec<GenericParam>,
+    ) -> Vec<GenericParam> {
+        params
+            .into_iter()
+            .filter_map(|param| self.append_generic_param(scope_id, param))
+            .collect()
     }
 
     pub fn set_param_constraint(
@@ -140,11 +149,13 @@ impl FileGenericIndex {
             if let Some(params) = self.generic_params.get(*params_id)
                 && let Some((id, param)) = params.params.get(name)
             {
-                let tpl_id = if params.is_func {
-                    GenericTplId::Func(*id as u32)
-                } else {
-                    GenericTplId::Type(*id as u32)
-                };
+                let tpl_id = param.tpl_id.unwrap_or_else(|| {
+                    if params.is_func {
+                        GenericTplId::Func(*id as u32)
+                    } else {
+                        GenericTplId::Type(*id as u32)
+                    }
+                });
                 return Some((tpl_id, param.type_constraint.clone()));
             }
         }
@@ -233,10 +244,17 @@ impl TagGenericParams {
         }
     }
 
-    fn insert_param(&mut self, param: GenericParam) {
+    fn insert_param(&mut self, param: GenericParam) -> GenericParam {
         let current_index = self.next_index;
         self.next_index += 1;
+        let tpl_id = if self.is_func {
+            GenericTplId::Func(current_index as u32)
+        } else {
+            GenericTplId::Type(current_index as u32)
+        };
+        let param = param.with_tpl_id(tpl_id);
         self.params
-            .insert(param.name.to_string(), (current_index, param));
+            .insert(param.name.to_string(), (current_index, param.clone()));
+        param
     }
 }

--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
@@ -829,11 +829,10 @@ fn infer_mapped_type(
     let scope_id = analyzer
         .generic_index
         .add_generic_scope(vec![mapped_type.get_range()], false);
-    analyzer
+    let param = analyzer
         .generic_index
-        .append_generic_param(scope_id, param.clone());
-    let position = mapped_type.get_range().start();
-    let (id, _) = analyzer.generic_index.find_generic(position, name)?;
+        .append_generic_param(scope_id, param)?;
+    let id = param.tpl_id?;
 
     let doc_type = mapped_type.get_value_type()?;
     let value_type = infer_type(analyzer, doc_type);

--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/type_def_tags.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/type_def_tags.rs
@@ -35,13 +35,11 @@ pub fn analyze_class(analyzer: &mut DocAnalyzer, tag: LuaDocTagClass) -> Option<
     analyzer.current_type_id = Some(class_decl_id.clone());
     if let Some(generic_params) = tag.get_generic_decl() {
         let generic_params = get_generic_params(analyzer, generic_params);
-
+        let generic_params = add_generic_index(analyzer, generic_params, &tag);
         analyzer
             .db
             .get_type_index_mut()
-            .add_generic_params(class_decl_id.clone(), generic_params.clone());
-
-        add_generic_index(analyzer, generic_params, &tag);
+            .add_generic_params(class_decl_id.clone(), generic_params);
     }
 
     if let Some(supers) = tag.get_supers() {
@@ -145,15 +143,15 @@ pub fn analyze_alias(analyzer: &mut DocAnalyzer, tag: LuaDocTagAlias) -> Option<
     if let Some(generic_params) = tag.get_generic_decl_list() {
         let generic_params = get_generic_params(analyzer, generic_params);
 
+        let range = analyzer.comment.get_range();
+        let scope_id = analyzer.generic_index.add_generic_scope(vec![range], false);
+        let generic_params = analyzer
+            .generic_index
+            .append_generic_params(scope_id, generic_params);
         analyzer
             .db
             .get_type_index_mut()
-            .add_generic_params(alias_decl_id.clone(), generic_params.clone());
-        let range = analyzer.comment.get_range();
-        let scope_id = analyzer.generic_index.add_generic_scope(vec![range], false);
-        analyzer
-            .generic_index
-            .append_generic_params(scope_id, generic_params);
+            .add_generic_params(alias_decl_id.clone(), generic_params);
     }
 
     let origin_type = infer_type(analyzer, tag.get_type()?);
@@ -221,7 +219,7 @@ fn add_generic_index(
     analyzer: &mut DocAnalyzer,
     generic_params: Vec<GenericParam>,
     tag: &LuaDocTagClass,
-) {
+) -> Vec<GenericParam> {
     let mut ranges = Vec::new();
     ranges.push(tag.get_effective_range());
     if let Some(comment_owner) = analyzer.comment.get_owner() {
@@ -245,7 +243,7 @@ fn add_generic_index(
     let scope_id = analyzer.generic_index.add_generic_scope(ranges, false);
     analyzer
         .generic_index
-        .append_generic_params(scope_id, generic_params);
+        .append_generic_params(scope_id, generic_params)
 }
 
 fn get_local_stat_reference_ranges(

--- a/crates/glua_code_analysis/src/compilation/analyzer/unresolve/find_decl_function.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/unresolve/find_decl_function.rs
@@ -396,7 +396,11 @@ fn find_generic_member(
     let base_type = generic_type.get_base_type();
 
     let generic_params = generic_type.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor = if let LuaType::Ref(base_type_decl_id) = &base_type {
+        TypeSubstitutor::from_type_decl(db, generic_params.clone(), base_type_decl_id.clone())
+    } else {
+        TypeSubstitutor::from_type_array(generic_params.clone())
+    };
     if let LuaType::Ref(base_type_decl_id) = &base_type {
         let result = index_generic_members_from_super_generics(
             db,
@@ -769,17 +773,20 @@ fn find_member_by_index_generic(
         return Err(InferFailReason::None);
     };
     let generic_params = generic.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor =
+        TypeSubstitutor::from_type_decl(db, generic_params.clone(), type_decl_id.clone());
     let type_index = db.get_type_index();
     let type_decl = type_index
         .get_type_decl(&type_decl_id)
         .ok_or(InferFailReason::None)?;
     if type_decl.is_alias() {
-        if let Some(origin_type) = type_decl.get_alias_origin(db, Some(&substitutor)) {
+        let alias_substitutor =
+            TypeSubstitutor::from_alias(db, generic_params.clone(), type_decl_id.clone());
+        if let Some(origin_type) = type_decl.get_alias_origin(db, Some(&alias_substitutor)) {
             return find_function_type_by_operator(
                 db,
                 cache,
-                &instantiate_type_generic(db, &origin_type, &substitutor),
+                &instantiate_type_generic(db, &origin_type, &alias_substitutor),
                 index_expr.clone(),
                 &infer_guard.fork(),
                 deep_guard,

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -438,6 +438,496 @@ mod test {
     }
 
     #[test]
+    fn test_mapped_infer_from_generic_function_table_literal() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+
+            ---@alias InferShape<T> { [K in keyof T]: T[K] extends Schema<infer U> and U or unknown; }
+
+            ---@return Schema<string>
+            function mk_string() end
+
+            ---@return Schema<number>
+            function mk_number() end
+
+            ---@generic T
+            ---@param schema T
+            ---@return InferShape<T>
+            function object(schema) end
+
+            result = object({
+                name = mk_string(),
+                age = mk_number(),
+            })
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("result.name");
+        let age_ty = ws.expr_ty("result.age");
+        assert_eq!(ws.humanize_type(name_ty), "string");
+        assert_eq!(ws.humanize_type(age_ty), "number");
+    }
+
+    #[test]
+    fn test_mapped_infer_from_generic_function_table_variable() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+
+            ---@alias InferShape<T> { [K in keyof T]: T[K] extends Schema<infer U> and U or unknown; }
+
+            ---@return Schema<string>
+            function mk_string() end
+
+            ---@return Schema<number>
+            function mk_number() end
+
+            ---@generic T
+            ---@param schema T
+            ---@return InferShape<T>
+            function object(schema) end
+
+            local shape = {
+                name = mk_string(),
+                age = mk_number(),
+            }
+            result = object(shape)
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("result.name");
+        let age_ty = ws.expr_ty("result.age");
+        assert_eq!(ws.humanize_type(name_ty), "string");
+        assert_eq!(ws.humanize_type(age_ty), "number");
+    }
+
+    #[test]
+    fn test_conditional_infer_from_concrete_class_super_generic() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+            ---@class StringSchema: Schema<string>
+            ---@class NumberSchema: Schema<number>
+
+            ---@alias Infer<T> T extends Schema<infer U> and U or unknown
+            ---@alias InferShape<T> { [K in keyof T]: Infer<T[K]>; }
+
+            ---@return StringSchema
+            function mk_string() end
+
+            ---@return NumberSchema
+            function mk_number() end
+
+            ---@generic T
+            ---@param schema T
+            ---@return InferShape<T>
+            function object(schema) end
+
+            result = object({
+                name = mk_string(),
+                age = mk_number(),
+            })
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("result.name");
+        let age_ty = ws.expr_ty("result.age");
+        assert_eq!(ws.humanize_type(name_ty), "string");
+        assert_eq!(ws.humanize_type(age_ty), "number");
+    }
+
+    #[test]
+    fn test_conditional_infer_from_generic_alias_source() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+            ---@alias Wrapped<T> Schema<T>
+            ---@alias Infer<T> T extends Schema<infer U> and U or unknown
+
+            ---@generic T
+            ---@param schema T
+            ---@return Infer<T>
+            function infer(schema) end
+
+            ---@type Wrapped<string>
+            local wrapped
+
+            value = infer(wrapped)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "string");
+    }
+
+    #[test]
+    fn test_generic_identity_table_literal_still_allows_later_field_inference() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return T
+            function identity(value) end
+
+            local result = identity({})
+            result.name = "abc"
+            value = result.name
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "\"abc\"");
+    }
+
+    #[test]
+    fn test_generic_identity_object_literal_still_allows_later_field_inference() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return T
+            function identity(value) end
+
+            result = identity({ name = "abc" })
+            "#,
+        );
+        ws.def(
+            r#"
+            function add_field()
+                result.age = 1
+            end
+            value = result.age
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "1");
+    }
+
+    #[test]
+    fn test_generic_identity_object_literal_preserves_raw_table_when_structural_field_fails() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return T
+            function identity(value) end
+
+            ---@type unknown
+            local source
+
+            result = identity({ name = source.missing })
+            "#,
+        );
+        ws.def(
+            r#"
+            function add_field()
+                result.age = 1
+            end
+            value = result.age
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "1");
+    }
+
+    #[test]
+    fn test_generic_nullable_identity_object_literal_still_allows_later_field_inference() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return T?
+            function identity(value) end
+
+            result = identity({ name = "abc" })
+            "#,
+        );
+        ws.def(
+            r#"
+            function add_field()
+                result.age = 1
+            end
+            value = result.age
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "1");
+    }
+
+    #[test]
+    fn test_generic_nullable_param_identity_object_literal_still_allows_later_field_inference() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T?
+            ---@return T?
+            function identity(value) end
+
+            result = identity({ name = "abc" })
+            "#,
+        );
+        ws.def(
+            r#"
+            function add_field()
+                result.age = 1
+            end
+            value = result.age
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "1");
+    }
+
+    #[test]
+    fn test_alias_generic_does_not_replace_shadowed_mapped_key() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@alias Shadow<T> { [T in "name"]: T; }
+
+            ---@type Shadow<number>
+            local shadow
+
+            shadowName = shadow.name
+            "#,
+        );
+
+        let shadow_name_ty = ws.expr_ty("shadowName");
+        assert_eq!(ws.humanize_type(shadow_name_ty), "string");
+    }
+
+    #[test]
+    fn test_conditional_infer_requires_generic_base_match() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+            ---@field parse fun(self: Schema<T>, value: unknown): T
+            ---@class ObjectSchema<T>: Schema<T>
+            ---@class ArraySchema<T>: Schema<T[]>
+            ---@class OptionalSchema<T>: Schema<T>
+
+            ---@alias InferShape<T> { [K in keyof T]: T[K] extends ArraySchema<infer U> and U[] or T[K] extends ObjectSchema<infer U> and U or T[K] extends OptionalSchema<infer U> and U or T[K] extends Schema<infer U> and U or unknown; }
+
+            ---@return Schema<string>
+            function mk_string() end
+
+            ---@return Schema<number>
+            function mk_number() end
+
+            ---@return Schema<boolean>
+            function mk_boolean() end
+
+            ---@generic T
+            ---@param schema T
+            ---@return ObjectSchema<InferShape<T>>
+            function object(schema) end
+
+            ---@generic T
+            ---@param schema Schema<T>
+            ---@return ArraySchema<T>
+            function array(schema) end
+
+            ---@generic T
+            ---@param schema Schema<T>
+            ---@return OptionalSchema<T|nil>
+            function optional(schema) end
+
+            ---@generic T
+            ---@param schema T
+            ---@return InferShape<T>
+            function infer_shape(schema) end
+
+            schema = object({
+                name = mk_string(),
+                age = mk_number(),
+                admin = mk_boolean(),
+                tags = array(mk_string()),
+                profile = object({
+                    id = mk_string(),
+                    score = optional(mk_number()),
+                }),
+            })
+
+            parsed = schema:parse({})
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("parsed.name");
+        let age_ty = ws.expr_ty("parsed.age");
+        let admin_ty = ws.expr_ty("parsed.admin");
+        let profile_ty = ws.expr_ty("parsed.profile");
+        let id_ty = ws.expr_ty("parsed.profile.id");
+        let score_ty = ws.expr_ty("parsed.profile.score");
+        let tags_ty = ws.expr_ty("parsed.tags");
+        assert_eq!(ws.humanize_type(name_ty), "string");
+        assert_eq!(ws.humanize_type(age_ty), "number");
+        assert_eq!(ws.humanize_type(admin_ty), "boolean");
+        assert_eq!(
+            ws.humanize_type(profile_ty),
+            "{ id: string, score: number? }"
+        );
+        assert_eq!(ws.humanize_type(id_ty), "string");
+        assert_eq!(ws.humanize_type(score_ty), "number?");
+        assert_eq!(ws.humanize_type(tags_ty), "string[]");
+    }
+
+    #[test]
+    fn test_zod_like_namespace_method_chain_and_variable_shape_infer_parse_result() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+            ---@field parse fun(self: Schema<T>, value: unknown): T
+            ---@field optional fun(self: Schema<T>): OptionalSchema<T|nil>
+            ---@class StringSchema: Schema<string>
+            ---@class NumberSchema: Schema<number>
+            ---@class BooleanSchema: Schema<boolean>
+            ---@class ObjectSchema<T>: Schema<T>
+            ---@class ArraySchema<T>: Schema<T[]>
+            ---@class OptionalSchema<T>: Schema<T>
+
+            ---@alias InferShape<T> { [K in keyof T]: T[K] extends ArraySchema<infer U> and U[] or T[K] extends ObjectSchema<infer U> and U or T[K] extends OptionalSchema<infer U> and U or T[K] extends Schema<infer U> and U or unknown; }
+
+            ---@class Z
+            ---@field string fun(): StringSchema
+            ---@field number fun(): NumberSchema
+            ---@field boolean fun(): BooleanSchema
+            ---@field array fun<T>(schema: Schema<T>): ArraySchema<T>
+            ---@field object fun<T>(shape: T): ObjectSchema<InferShape<T>>
+
+            ---@type Z
+            local z
+
+            local inline_schema = z.object({
+                name = z.string(),
+                age = z.number(),
+                admin = z.boolean(),
+                tags = z.array(z.string()),
+                profile = z.object({
+                    id = z.string(),
+                    score = z.number():optional(),
+                }),
+            })
+            parsed_inline = inline_schema:parse({})
+
+            local shape = {
+                profile = z.object({
+                    id = z.string(),
+                    score = z.number():optional(),
+                }),
+            }
+            local variable_schema = z.object(shape)
+            parsed_variable = variable_schema:parse({})
+            "#,
+        );
+
+        let inline_name_ty = ws.expr_ty("parsed_inline.name");
+        let inline_age_ty = ws.expr_ty("parsed_inline.age");
+        let inline_admin_ty = ws.expr_ty("parsed_inline.admin");
+        let inline_tags_ty = ws.expr_ty("parsed_inline.tags");
+        let inline_profile_ty = ws.expr_ty("parsed_inline.profile");
+        let inline_id_ty = ws.expr_ty("parsed_inline.profile.id");
+        let inline_score_ty = ws.expr_ty("parsed_inline.profile.score");
+        let variable_id_ty = ws.expr_ty("parsed_variable.profile.id");
+        let variable_score_ty = ws.expr_ty("parsed_variable.profile.score");
+        assert_eq!(ws.humanize_type(inline_name_ty), "string");
+        assert_eq!(ws.humanize_type(inline_age_ty), "number");
+        assert_eq!(ws.humanize_type(inline_admin_ty), "boolean");
+        assert_eq!(ws.humanize_type(inline_tags_ty), "string[]");
+        assert_eq!(
+            ws.humanize_type(inline_profile_ty),
+            "{ id: string, score: number? }"
+        );
+        assert_eq!(ws.humanize_type(inline_id_ty), "string");
+        assert_eq!(ws.humanize_type(inline_score_ty), "number?");
+        assert_eq!(ws.humanize_type(variable_id_ty), "string");
+        assert_eq!(ws.humanize_type(variable_score_ty), "number?");
+    }
+
+    #[test]
+    fn test_conditional_infer_instantiates_nested_generic_super_with_decl_tpl_id() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Pair<A, B>
+
+            ---@generic Outer
+            function setup()
+                ---@class Nested<Inner>: Pair<Outer, Inner>
+            end
+
+            ---@alias ExtractInner<T> T extends Pair<any, infer U> and U or unknown
+
+            ---@type ExtractInner<Nested<string>>
+            value = nil
+            "#,
+        );
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param value number
+            function take_number(value) end
+
+            take_number(value)
+            "#,
+        ));
+    }
+
+    #[test]
+    fn test_nested_generic_super_member_instantiates_decl_tpl_id() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Base<T>
+            ---@field value T
+
+            ---@generic Outer
+            function setup()
+                ---@class Nested<Inner>: Base<Inner>
+            end
+
+            ---@type Nested<string>
+            local nested
+
+            value = nested.value
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "string");
+    }
+
+    #[test]
     fn test_infer_new_constructor() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/db_index/type/generic_param.rs
+++ b/crates/glua_code_analysis/src/db_index/type/generic_param.rs
@@ -1,12 +1,13 @@
 use smol_str::SmolStr;
 
-use crate::{LuaAttributeUse, LuaType};
+use crate::{GenericTplId, LuaAttributeUse, LuaType};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GenericParam {
     pub name: SmolStr,
     pub type_constraint: Option<LuaType>,
     pub attributes: Option<Vec<LuaAttributeUse>>,
+    pub tpl_id: Option<GenericTplId>,
 }
 
 impl GenericParam {
@@ -19,6 +20,12 @@ impl GenericParam {
             name,
             type_constraint,
             attributes,
+            tpl_id: None,
         }
+    }
+
+    pub fn with_tpl_id(mut self, tpl_id: GenericTplId) -> Self {
+        self.tpl_id = Some(tpl_id);
+        self
     }
 }

--- a/crates/glua_code_analysis/src/db_index/type/humanize_type.rs
+++ b/crates/glua_code_analysis/src/db_index/type/humanize_type.rs
@@ -552,7 +552,8 @@ fn humanize_generic_type(db: &DbIndex, generic: &LuaGenericType, level: RenderLe
         RenderLevel::Documentation | RenderLevel::CustomDetailed(_) | RenderLevel::Detailed
     ) && type_decl.is_alias()
     {
-        let substituor = TypeSubstitutor::from_type_array(generic.get_params().clone());
+        let substituor =
+            TypeSubstitutor::from_alias(db, generic.get_params().clone(), base_id.clone());
         if let Some(origin_type) = type_decl.get_alias_origin(db, Some(&substituor)) {
             // prevent infinite recursion
             let origin_type_str = humanize_type(db, &origin_type, level.next_level());

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -1,13 +1,17 @@
-use std::{collections::HashSet, ops::Deref, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Deref,
+    sync::Arc,
+};
 
 use glua_parser::{LuaAstNode, LuaDocTypeList};
-use glua_parser::{LuaCallExpr, LuaExpr};
+use glua_parser::{LuaCallExpr, LuaExpr, LuaIndexKey, LuaTableExpr, NumberResult};
 use internment::ArcIntern;
 
 use crate::{
     DocTypeInferContext, FileId, GenericTpl, GenericTplId, LuaFunctionType, LuaGenericType,
-    TypeVisitTrait,
-    db_index::{DbIndex, LuaType},
+    TypeVisitTrait, VariadicType,
+    db_index::{DbIndex, LuaMemberKey, LuaObjectType, LuaType},
     infer_doc_type,
     semantic::{
         LuaInferCache,
@@ -15,7 +19,7 @@ use crate::{
             instantiate_type::instantiate_doc_function,
             tpl_context::TplContext,
             tpl_pattern::{
-                multi_param_tpl_pattern_match_multi_return, tpl_pattern_match,
+                escape_alias, multi_param_tpl_pattern_match_multi_return, tpl_pattern_match,
                 variadic_tpl_pattern_match,
             },
         },
@@ -161,19 +165,19 @@ fn infer_generic_types_from_call(
             continue;
         }
 
-        let arg_type = match infer_expr(db, context.cache, call_arg_expr.clone()) {
+        let arg_type = match infer_generic_arg_type(db, context.cache, call_arg_expr.clone()) {
             Ok(t) => t,
-            Err(InferFailReason::FieldNotFound) => LuaType::Nil, // 对于未找到的字段, 我们认为是 nil 以执行后续推断
+            Err(InferFailReason::FieldNotFound) => GenericArgType::from_raw(LuaType::Nil), // 对于未找到的字段, 我们认为是 nil 以执行后续推断
             Err(e) => return Err(e),
         };
-        match (func_param_type, &arg_type) {
+        match (func_param_type, &arg_type.raw) {
             (LuaType::Variadic(variadic), _) => {
                 let mut arg_types = vec![];
                 for arg_expr in &arg_exprs[i..] {
-                    let arg_type = infer_expr(db, context.cache, arg_expr.clone())?;
+                    let arg_type = infer_generic_arg_type(db, context.cache, arg_expr.clone())?;
                     arg_types.push(arg_type);
                 }
-                variadic_tpl_pattern_match(context, variadic, &arg_types)?;
+                variadic_tpl_pattern_match_generic_args(context, variadic, &arg_types)?;
                 break;
             }
             (_, LuaType::Variadic(variadic)) => {
@@ -186,7 +190,7 @@ fn infer_generic_types_from_call(
                 break;
             }
             _ => {
-                tpl_pattern_match(context, func_param_type, &arg_type)?;
+                tpl_pattern_match_generic_arg(context, func_param_type, &arg_type)?;
             }
         }
     }
@@ -200,6 +204,213 @@ fn infer_generic_types_from_call(
     }
 
     Ok(())
+}
+
+fn infer_generic_arg_type(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    expr: LuaExpr,
+) -> Result<GenericArgType, InferFailReason> {
+    let raw = infer_expr(db, cache, expr.clone())?;
+    let structural = if let LuaExpr::TableExpr(table) = &expr
+        && table.is_object()
+    {
+        Some(infer_object_table_arg_type(db, cache, table.clone())?)
+    } else {
+        None
+    };
+
+    Ok(GenericArgType { raw, structural })
+}
+
+struct GenericArgType {
+    raw: LuaType,
+    structural: Option<LuaType>,
+}
+
+impl GenericArgType {
+    fn from_raw(raw: LuaType) -> Self {
+        Self {
+            raw,
+            structural: None,
+        }
+    }
+
+    fn match_type(&self) -> &LuaType {
+        self.structural.as_ref().unwrap_or(&self.raw)
+    }
+}
+
+fn tpl_pattern_match_generic_arg(
+    context: &mut TplContext,
+    pattern: &LuaType,
+    target: &GenericArgType,
+) -> Result<(), InferFailReason> {
+    if !pattern.contain_tpl() {
+        return Ok(());
+    }
+
+    match pattern {
+        LuaType::TplRef(tpl) if tpl.get_tpl_id().is_func() => {
+            insert_generic_arg(context, tpl.get_tpl_id(), target, true);
+        }
+        LuaType::ConstTplRef(tpl) if tpl.get_tpl_id().is_func() => {
+            insert_generic_arg(context, tpl.get_tpl_id(), target, false);
+        }
+        LuaType::Union(union) => {
+            let union_types = union.into_vec();
+            let mut error_count = 0;
+            let mut last_error = InferFailReason::None;
+            for union_type in &union_types {
+                match tpl_pattern_match_generic_arg(context, union_type, target) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        error_count += 1;
+                        last_error = e;
+                    }
+                }
+            }
+
+            if error_count == union_types.len() {
+                return Err(last_error);
+            }
+        }
+        _ => tpl_pattern_match(context, pattern, target.match_type())?,
+    }
+
+    Ok(())
+}
+
+fn variadic_tpl_pattern_match_generic_args(
+    context: &mut TplContext,
+    tpl: &VariadicType,
+    target_rest_types: &[GenericArgType],
+) -> Result<(), InferFailReason> {
+    let raw_target_types = || {
+        target_rest_types
+            .iter()
+            .map(|target| target.raw.clone())
+            .collect::<Vec<_>>()
+    };
+
+    match tpl {
+        VariadicType::Base(base) => match base {
+            LuaType::TplRef(tpl_ref) => match target_rest_types {
+                [] => {
+                    context
+                        .substitutor
+                        .insert_type(tpl_ref.get_tpl_id(), LuaType::Nil, true);
+                }
+                [target] if !matches!(target.raw, LuaType::Variadic(_)) => {
+                    insert_generic_arg(context, tpl_ref.get_tpl_id(), target, true);
+                }
+                _ => variadic_tpl_pattern_match(context, tpl, &raw_target_types())?,
+            },
+            LuaType::ConstTplRef(tpl_ref) => match target_rest_types {
+                [] => {
+                    context
+                        .substitutor
+                        .insert_type(tpl_ref.get_tpl_id(), LuaType::Nil, false);
+                }
+                [target] if !matches!(target.raw, LuaType::Variadic(_)) => {
+                    insert_generic_arg(context, tpl_ref.get_tpl_id(), target, false);
+                }
+                _ => variadic_tpl_pattern_match(context, tpl, &raw_target_types())?,
+            },
+            _ => variadic_tpl_pattern_match(context, tpl, &raw_target_types())?,
+        },
+        VariadicType::Multi(multi) => {
+            for (i, ret_type) in multi.iter().enumerate() {
+                match ret_type {
+                    LuaType::Variadic(inner) => {
+                        if i < target_rest_types.len() {
+                            variadic_tpl_pattern_match_generic_args(
+                                context,
+                                inner,
+                                &target_rest_types[i..],
+                            )?;
+                        }
+
+                        break;
+                    }
+                    _ => {
+                        let Some(target) = target_rest_types.get(i) else {
+                            break;
+                        };
+                        tpl_pattern_match_generic_arg(context, ret_type, target)?;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn insert_generic_arg(
+    context: &mut TplContext,
+    tpl_id: GenericTplId,
+    target: &GenericArgType,
+    decay: bool,
+) {
+    let raw = escape_alias(context.db, &target.raw);
+    if let Some(structural) = &target.structural {
+        context
+            .substitutor
+            .insert_type_with_structural(tpl_id, raw, structural.clone(), decay);
+    } else {
+        context.substitutor.insert_type(tpl_id, raw, decay);
+    }
+}
+
+fn infer_object_table_arg_type(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    table: LuaTableExpr,
+) -> Result<LuaType, InferFailReason> {
+    // Structural inference is a best-effort sidecar; the raw TableConst remains authoritative.
+    let mut fields = HashMap::new();
+
+    for field in table.get_fields() {
+        let Some(field_key) = field.get_field_key() else {
+            continue;
+        };
+        let member_key = match field_key {
+            LuaIndexKey::Name(name) => LuaMemberKey::Name(name.get_name_text().into()),
+            LuaIndexKey::String(str) => LuaMemberKey::Name(str.get_value().into()),
+            LuaIndexKey::Integer(i) => match i.get_number_value() {
+                NumberResult::Int(idx) => LuaMemberKey::Integer(idx),
+                _ => continue,
+            },
+            LuaIndexKey::Idx(idx) => LuaMemberKey::Integer(idx as i64),
+            LuaIndexKey::Expr(expr) => match infer_expr(db, cache, expr) {
+                Ok(LuaType::StringConst(s) | LuaType::DocStringConst(s)) => {
+                    LuaMemberKey::Name((*s).clone())
+                }
+                Ok(LuaType::IntegerConst(i) | LuaType::DocIntegerConst(i)) => {
+                    LuaMemberKey::Integer(i)
+                }
+                Ok(typ) => LuaMemberKey::ExprType(typ),
+                Err(InferFailReason::FieldNotFound) => continue,
+                Err(reason) => return Err(reason),
+            },
+        };
+
+        let Some(value_expr) = field.get_value_expr() else {
+            continue;
+        };
+        let value_type = match infer_expr(db, cache, value_expr) {
+            Ok(LuaType::Def(ref_id)) => LuaType::Ref(ref_id),
+            Ok(other) => other,
+            Err(InferFailReason::FieldNotFound) => LuaType::Unknown,
+            Err(reason) => return Err(reason),
+        };
+        fields.insert(member_key, value_type);
+    }
+
+    Ok(LuaType::Object(
+        LuaObjectType::new_with_fields(fields, Vec::new()).into(),
+    ))
 }
 
 pub fn build_self_type(db: &DbIndex, self_type: &LuaType) -> LuaType {

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_special_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_special_generic.rs
@@ -43,7 +43,9 @@ pub fn instantiate_alias_call(
                 return LuaType::Unknown;
             }
 
-            let members = get_keyof_members(db, &operands[0]).unwrap_or_default();
+            let owner = resolve_structural_operand(operand_exprs.first(), substitutor)
+                .unwrap_or_else(|| operands[0].clone());
+            let members = get_keyof_members(db, &owner).unwrap_or_default();
             let member_key_types = members
                 .iter()
                 .filter_map(|m| match &m.key {
@@ -76,20 +78,24 @@ pub fn instantiate_alias_call(
                 return LuaType::Unknown;
             }
 
+            let owner = resolve_structural_operand(operand_exprs.first(), substitutor)
+                .unwrap_or_else(|| operands[0].clone());
             let key = resolve_literal_operand(operand_exprs.get(1), substitutor)
                 .unwrap_or_else(|| operands[1].clone());
 
-            instantiate_rawget_call(db, &operands[0], &key)
+            instantiate_rawget_call(db, &owner, &key)
         }
         LuaAliasCallKind::Index => {
             if operands.len() != 2 {
                 return LuaType::Unknown;
             }
 
+            let owner = resolve_structural_operand(operand_exprs.first(), substitutor)
+                .unwrap_or_else(|| operands[0].clone());
             let key = resolve_literal_operand(operand_exprs.get(1), substitutor)
                 .unwrap_or_else(|| operands[1].clone());
 
-            instantiate_index_call(db, &operands[0], &key)
+            instantiate_index_call(db, &owner, &key)
         }
         LuaAliasCallKind::Merge => instantiate_merge_call(db, &operands),
     }
@@ -131,6 +137,18 @@ fn resolve_literal_operand(
     match operand {
         Some(LuaType::TplRef(tpl_ref)) | Some(LuaType::ConstTplRef(tpl_ref)) => {
             substitutor.get_raw_type(tpl_ref.get_tpl_id()).cloned()
+        }
+        _ => None,
+    }
+}
+
+fn resolve_structural_operand(
+    operand: Option<&LuaType>,
+    substitutor: &TypeSubstitutor,
+) -> Option<LuaType> {
+    match operand {
+        Some(LuaType::TplRef(tpl_ref)) | Some(LuaType::ConstTplRef(tpl_ref)) => {
+            substitutor.get_structural_type(tpl_ref.get_tpl_id()).cloned()
         }
         _ => None,
     }

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -293,8 +293,16 @@ pub fn instantiate_generic(
 ) -> LuaType {
     let generic_params = generic.get_params();
     let mut new_params = Vec::new();
+    let mut new_params_with_structural = Vec::new();
     for param in generic_params {
         let new_param = instantiate_type_generic(db, param, substitutor);
+        let structural_param = match param {
+            LuaType::TplRef(tpl) | LuaType::ConstTplRef(tpl) => {
+                substitutor.get_structural_type(tpl.get_tpl_id()).cloned()
+            }
+            _ => None,
+        };
+        new_params_with_structural.push((new_param.clone(), structural_param));
         new_params.push(new_param);
     }
 
@@ -309,7 +317,11 @@ pub fn instantiate_generic(
         && let Some(type_decl) = db.get_type_index().get_type_decl(&type_decl_id)
         && type_decl.is_alias()
     {
-        let new_substitutor = TypeSubstitutor::from_alias(new_params.clone(), type_decl_id.clone());
+        let new_substitutor = TypeSubstitutor::from_alias_with_structural(
+            db,
+            new_params_with_structural,
+            type_decl_id.clone(),
+        );
         if let Some(origin) = type_decl.get_alias_origin(db, Some(&new_substitutor)) {
             return origin;
         }
@@ -584,23 +596,18 @@ fn collect_infer_assignments(
         LuaType::ConditionalInfer(name) => {
             insert_infer_assignment(assignments, name.as_str(), source)
         }
-        LuaType::Generic(pattern_generic) => {
-            if let LuaType::Generic(source_generic) = source {
-                let pattern_params = pattern_generic.get_params();
-                let source_params = source_generic.get_params();
-                if pattern_params.len() != source_params.len() {
-                    return false;
-                }
-                for (pattern_param, source_param) in pattern_params.iter().zip(source_params) {
-                    if !collect_infer_assignments(db, source_param, pattern_param, assignments) {
-                        return false;
-                    }
-                }
-                true
-            } else {
-                false
+        LuaType::Generic(pattern_generic) => match source {
+            LuaType::Generic(source_generic) => collect_infer_from_generic_to_generic(
+                db,
+                source_generic,
+                pattern_generic,
+                assignments,
+            ),
+            LuaType::Ref(type_id) | LuaType::Def(type_id) => {
+                collect_infer_from_ref_to_generic(db, type_id, pattern_generic, assignments)
             }
-        }
+            _ => false,
+        },
         LuaType::DocFunction(pattern_func) => {
             match source {
                 LuaType::DocFunction(source_func) => {
@@ -771,6 +778,128 @@ fn collect_infer_assignments(
             }
         }
     }
+}
+
+fn collect_infer_from_generic_to_generic(
+    db: &DbIndex,
+    source_generic: &LuaGenericType,
+    pattern_generic: &LuaGenericType,
+    assignments: &mut HashMap<String, LuaType>,
+) -> bool {
+    // Generic conditional inference is nominal first, not just arity-based.
+    // Otherwise unrelated generics with the same number of parameters both
+    // look compatible, letting an earlier conditional branch infer from the
+    // wrong generic declaration.
+    if source_generic.get_base_type_id_ref() == pattern_generic.get_base_type_id_ref() {
+        return collect_infer_from_generic_params(
+            db,
+            source_generic.get_params(),
+            pattern_generic.get_params(),
+            assignments,
+        );
+    }
+
+    if let Some(source_decl) = db
+        .get_type_index()
+        .get_type_decl(source_generic.get_base_type_id_ref())
+        && source_decl.is_alias()
+    {
+        let substitutor = TypeSubstitutor::from_alias(
+            db,
+            source_generic.get_params().clone(),
+            source_generic.get_base_type_id_ref().clone(),
+        );
+        if let Some(alias_origin) = source_decl.get_alias_origin(db, Some(&substitutor)) {
+            let mut candidate_assignments = assignments.clone();
+            if collect_infer_assignments(
+                db,
+                &alias_origin,
+                &LuaType::Generic(pattern_generic.clone().into()),
+                &mut candidate_assignments,
+            ) {
+                *assignments = candidate_assignments;
+                return true;
+            }
+        }
+    }
+
+    if let Some(super_types) = db
+        .get_type_index()
+        .get_super_types(source_generic.get_base_type_id_ref())
+    {
+        let substitutor = TypeSubstitutor::from_type_decl(
+            db,
+            source_generic.get_params().clone(),
+            source_generic.get_base_type_id_ref().clone(),
+        );
+        for super_type in super_types {
+            let super_type = instantiate_type_generic(db, &super_type, &substitutor);
+            let mut candidate_assignments = assignments.clone();
+            // Only commit inferred bindings after the whole super-type match
+            // succeeds; a failed branch may have collected partial `infer`s.
+            if collect_infer_assignments(
+                db,
+                &super_type,
+                &LuaType::Generic(pattern_generic.clone().into()),
+                &mut candidate_assignments,
+            ) {
+                *assignments = candidate_assignments;
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn collect_infer_from_ref_to_generic(
+    db: &DbIndex,
+    source_type_id: &LuaTypeDeclId,
+    pattern_generic: &LuaGenericType,
+    assignments: &mut HashMap<String, LuaType>,
+) -> bool {
+    let Some(super_types) = db.get_type_index().get_super_types(source_type_id) else {
+        return false;
+    };
+
+    for super_type in super_types {
+        let mut candidate_assignments = assignments.clone();
+        // Concrete classes can still satisfy generic patterns through their
+        // declared super types, e.g. `Concrete: Base<string>` should allow
+        // `Base<infer T>` to bind `T = string`.
+        if collect_infer_assignments(
+            db,
+            &super_type,
+            &LuaType::Generic(pattern_generic.clone().into()),
+            &mut candidate_assignments,
+        ) {
+            *assignments = candidate_assignments;
+            return true;
+        }
+    }
+
+    false
+}
+
+fn collect_infer_from_generic_params(
+    db: &DbIndex,
+    source_params: &[LuaType],
+    pattern_params: &[LuaType],
+    assignments: &mut HashMap<String, LuaType>,
+) -> bool {
+    if pattern_params.len() != source_params.len() {
+        return false;
+    }
+
+    let mut candidate_assignments = assignments.clone();
+    for (pattern_param, source_param) in pattern_params.iter().zip(source_params) {
+        if !collect_infer_assignments(db, source_param, pattern_param, &mut candidate_assignments) {
+            return false;
+        }
+    }
+
+    *assignments = candidate_assignments;
+    true
 }
 
 /// Match object literal to object pattern, extracting infer types from fields

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/generic_tpl_pattern.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/generic_tpl_pattern.rs
@@ -49,6 +49,7 @@ fn generic_tpl_pattern_match_inner(
                 .ok_or(InferFailReason::None)?;
             if target_decl.is_alias() {
                 let substitutor = TypeSubstitutor::from_alias(
+                    context.db,
                     target_generic.get_params().clone(),
                     target_base.clone(),
                 );
@@ -67,8 +68,11 @@ fn generic_tpl_pattern_match_inner(
             {
                 for mut super_type in super_types {
                     if super_type.contain_tpl() {
-                        let substitutor =
-                            TypeSubstitutor::from_type_array(target_generic.get_params().clone());
+                        let substitutor = TypeSubstitutor::from_type_decl(
+                            context.db,
+                            target_generic.get_params().clone(),
+                            target_base.clone(),
+                        );
                         super_type =
                             instantiate_type_generic(context.db, &super_type, &substitutor);
                     }

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -979,7 +979,7 @@ fn tuple_tpl_pattern_match(
     Ok(())
 }
 
-fn escape_alias(db: &DbIndex, may_alias: &LuaType) -> LuaType {
+pub(super) fn escape_alias(db: &DbIndex, may_alias: &LuaType) -> LuaType {
     if let LuaType::Ref(type_id) = may_alias
         && let Some(type_decl) = db.get_type_index().get_type_decl(type_id)
         && type_decl.is_alias()

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::tpl_pattern::constant_decay;
-use crate::{GenericTplId, LuaType, LuaTypeDeclId};
+use crate::{DbIndex, GenericTplId, LuaType, LuaTypeDeclId};
 
 #[derive(Debug, Clone)]
 pub struct TypeSubstitutor {
@@ -40,17 +40,73 @@ impl TypeSubstitutor {
         }
     }
 
-    pub fn from_alias(type_array: Vec<LuaType>, alias_type_id: LuaTypeDeclId) -> Self {
+    pub fn from_type_decl(
+        db: &DbIndex,
+        type_array: Vec<LuaType>,
+        type_decl_id: LuaTypeDeclId,
+    ) -> Self {
+        let type_array = type_array.into_iter().map(|ty| (ty, None)).collect();
+        Self::from_decl_generic_params(db, type_array, type_decl_id, None)
+    }
+
+    pub fn from_alias(
+        db: &DbIndex,
+        type_array: Vec<LuaType>,
+        alias_type_id: LuaTypeDeclId,
+    ) -> Self {
+        let type_array = type_array.into_iter().map(|ty| (ty, None)).collect();
+        Self::from_decl_generic_params(db, type_array, alias_type_id.clone(), Some(alias_type_id))
+    }
+
+    pub fn from_alias_with_structural(
+        db: &DbIndex,
+        type_array: Vec<(LuaType, Option<LuaType>)>,
+        alias_type_id: LuaTypeDeclId,
+    ) -> Self {
+        Self::from_decl_generic_params(db, type_array, alias_type_id.clone(), Some(alias_type_id))
+    }
+
+    fn from_decl_generic_params(
+        db: &DbIndex,
+        type_array: Vec<(LuaType, Option<LuaType>)>,
+        type_decl_id: LuaTypeDeclId,
+        alias_type_id: Option<LuaTypeDeclId>,
+    ) -> Self {
         let mut tpl_replace_map = HashMap::new();
-        for (i, ty) in type_array.into_iter().enumerate() {
-            tpl_replace_map.insert(
-                GenericTplId::Type(i as u32),
-                SubstitutorValue::Type(SubstitutorTypeValue::new(ty, true)),
-            );
+        // Prefer the declaration's stored template ids over positional Type(0),
+        // Type(1), ... ids. Alias generics can be declared inside another
+        // generic scope, so positional ids alone may accidentally substitute an
+        // outer or shadowed template that happens to share the same index.
+        let decl_tpl_ids = db
+            .get_type_index()
+            .get_generic_params(&type_decl_id)
+            .and_then(|generic_params| {
+                let mut tpl_ids = Vec::with_capacity(type_array.len());
+                for param in generic_params.iter().take(type_array.len()) {
+                    tpl_ids.push(param.tpl_id?);
+                }
+
+                (tpl_ids.len() == type_array.len()).then_some(tpl_ids)
+            });
+
+        if let Some(tpl_ids) = decl_tpl_ids {
+            for (tpl_id, (ty, structural)) in tpl_ids.into_iter().zip(type_array) {
+                tpl_replace_map.insert(tpl_id, substitutor_type_value(ty, structural, true));
+            }
+        } else {
+            // Older/incomplete indexes may not carry template ids yet. Keep the
+            // historical positional behavior as a fallback for those cases.
+            for (i, (ty, structural)) in type_array.into_iter().enumerate() {
+                tpl_replace_map.insert(
+                    GenericTplId::Type(i as u32),
+                    substitutor_type_value(ty, structural, true),
+                );
+            }
         }
+
         Self {
             tpl_replace_map,
-            alias_type_id: Some(alias_type_id),
+            alias_type_id,
             self_type: None,
         }
     }
@@ -74,6 +130,19 @@ impl TypeSubstitutor {
 
     pub fn insert_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
         self.insert_type_value(tpl_id, SubstitutorTypeValue::new(replace_type, decay));
+    }
+
+    pub fn insert_type_with_structural(
+        &mut self,
+        tpl_id: GenericTplId,
+        replace_type: LuaType,
+        structural_type: LuaType,
+        decay: bool,
+    ) {
+        self.insert_type_value(
+            tpl_id,
+            SubstitutorTypeValue::new_with_structural(replace_type, structural_type, decay),
+        );
     }
 
     fn insert_type_value(&mut self, tpl_id: GenericTplId, value: SubstitutorTypeValue) {
@@ -136,6 +205,13 @@ impl TypeSubstitutor {
         }
     }
 
+    pub fn get_structural_type(&self, tpl_id: GenericTplId) -> Option<&LuaType> {
+        match self.tpl_replace_map.get(&tpl_id) {
+            Some(SubstitutorValue::Type(ty)) => ty.structural(),
+            _ => None,
+        }
+    }
+
     pub fn check_recursion(&self, type_id: &LuaTypeDeclId) -> bool {
         if let Some(alias_type_id) = &self.alias_type_id
             && alias_type_id == type_id
@@ -159,6 +235,7 @@ impl TypeSubstitutor {
 pub struct SubstitutorTypeValue {
     raw: LuaType,
     default: LuaType,
+    structural: Option<LuaType>,
 }
 
 impl SubstitutorTypeValue {
@@ -169,7 +246,17 @@ impl SubstitutorTypeValue {
         } else {
             raw.clone()
         };
-        Self { raw, default }
+        Self {
+            raw,
+            default,
+            structural: None,
+        }
+    }
+
+    pub fn new_with_structural(raw: LuaType, structural: LuaType, decay: bool) -> Self {
+        let mut value = Self::new(raw, decay);
+        value.structural = Some(into_ref_type(structural));
+        value
     }
 
     pub fn raw(&self) -> &LuaType {
@@ -178,6 +265,10 @@ impl SubstitutorTypeValue {
 
     pub fn default(&self) -> &LuaType {
         &self.default
+    }
+
+    pub fn structural(&self) -> Option<&LuaType> {
+        self.structural.as_ref()
     }
 }
 
@@ -194,6 +285,18 @@ impl SubstitutorValue {
     pub fn is_none(&self) -> bool {
         matches!(self, SubstitutorValue::None)
     }
+}
+
+fn substitutor_type_value(
+    ty: LuaType,
+    structural: Option<LuaType>,
+    decay: bool,
+) -> SubstitutorValue {
+    let value = match structural {
+        Some(structural) => SubstitutorTypeValue::new_with_structural(ty, structural, decay),
+        None => SubstitutorTypeValue::new(ty, decay),
+    };
+    SubstitutorValue::Type(value)
 }
 
 fn into_ref_type(ty: LuaType) -> LuaType {

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -451,13 +451,14 @@ fn infer_generic_type_doc_function(
     let type_id = generic.get_base_type_id();
     infer_guard.check(&type_id)?;
     let generic_params = generic.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor = TypeSubstitutor::from_type_decl(db, generic_params.clone(), type_id.clone());
 
     let type_decl = db
         .get_type_index()
         .get_type_decl(&type_id)
         .ok_or_else(|| InferFailReason::UnResolveTypeDecl(type_id.clone()))?;
     if type_decl.is_alias() {
+        let substitutor = TypeSubstitutor::from_alias(db, generic_params.clone(), type_id.clone());
         let origin_type = type_decl
             .get_alias_origin(db, Some(&substitutor))
             .ok_or(InferFailReason::None)?;

--- a/crates/glua_code_analysis/src/semantic/infer/infer_index/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_index/mod.rs
@@ -764,21 +764,28 @@ fn infer_generic_member(
     let base_type = generic_type.get_base_type();
 
     let generic_params = generic_type.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor = if let LuaType::Ref(base_type_decl_id) = &base_type {
+        TypeSubstitutor::from_type_decl(db, generic_params.clone(), base_type_decl_id.clone())
+    } else {
+        TypeSubstitutor::from_type_array(generic_params.clone())
+    };
 
     if let LuaType::Ref(base_type_decl_id) = &base_type {
         let type_index = db.get_type_index();
         if let Some(type_decl) = type_index.get_type_decl(base_type_decl_id)
             && type_decl.is_alias()
-            && let Some(origin_type) = type_decl.get_alias_origin(db, Some(&substitutor))
         {
-            return infer_member_by_member_key(
-                db,
-                cache,
-                &origin_type,
-                index_expr,
-                &infer_guard.fork(),
-            );
+            let alias_substitutor =
+                TypeSubstitutor::from_alias(db, generic_params.clone(), base_type_decl_id.clone());
+            if let Some(origin_type) = type_decl.get_alias_origin(db, Some(&alias_substitutor)) {
+                return infer_member_by_member_key(
+                    db,
+                    cache,
+                    &origin_type,
+                    index_expr,
+                    &infer_guard.fork(),
+                );
+            }
         }
 
         let result = infer_generic_members_from_super_generics(
@@ -1135,12 +1142,15 @@ fn infer_member_by_index_generic(
         return Err(InferFailReason::None);
     };
     let generic_params = generic.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor =
+        TypeSubstitutor::from_type_decl(db, generic_params.clone(), type_decl_id.clone());
     let type_index = db.get_type_index();
     let type_decl = type_index
         .get_type_decl(&type_decl_id)
         .ok_or(InferFailReason::None)?;
     if type_decl.is_alias() {
+        let substitutor =
+            TypeSubstitutor::from_alias(db, generic_params.clone(), type_decl_id.clone());
         if let Some(origin_type) = type_decl.get_alias_origin(db, Some(&substitutor)) {
             return infer_member_by_operator(
                 db,

--- a/crates/glua_code_analysis/src/semantic/member/find_index.rs
+++ b/crates/glua_code_analysis/src/semantic/member/find_index.rs
@@ -308,13 +308,16 @@ fn find_index_generic(
     };
 
     let generic_params = generic.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor =
+        TypeSubstitutor::from_type_decl(db, generic_params.clone(), type_decl_id.clone());
     let type_index = db.get_type_index();
     let type_decl = type_index.get_type_decl(&type_decl_id)?;
 
     if type_decl.is_alias() {
-        if let Some(origin_type) = type_decl.get_alias_origin(db, Some(&substitutor)) {
-            let instantiated_type = instantiate_type_generic(db, &origin_type, &substitutor);
+        let alias_substitutor =
+            TypeSubstitutor::from_alias(db, generic_params.clone(), type_decl_id.clone());
+        if let Some(origin_type) = type_decl.get_alias_origin(db, Some(&alias_substitutor)) {
+            let instantiated_type = instantiate_type_generic(db, &origin_type, &alias_substitutor);
             return find_index_operations_guard(db, &instantiated_type, infer_guard);
         }
         return None;

--- a/crates/glua_code_analysis/src/semantic/member/find_members.rs
+++ b/crates/glua_code_analysis/src/semantic/member/find_members.rs
@@ -694,11 +694,17 @@ fn find_generic_members(
         .iter()
         .map(|param| ctx.instantiate_type(db, param))
         .collect();
-    let substitutor = TypeSubstitutor::from_type_array(instantiated_params);
     let type_decl = db.get_type_index().get_type_decl(&base_ref_id)?;
+    let substitutor = if type_decl.is_alias() {
+        TypeSubstitutor::from_alias(db, instantiated_params, base_ref_id.clone())
+    } else {
+        TypeSubstitutor::from_type_decl(db, instantiated_params, base_ref_id.clone())
+    };
     let ctx_with_substitutor = ctx.with_substitutor(substitutor.clone());
-    if let Some(origin) = type_decl.get_alias_origin(db, Some(&substitutor)) {
-        return find_members_guard(db, &origin, &ctx_with_substitutor, filter);
+    if type_decl.is_alias() {
+        if let Some(origin) = type_decl.get_alias_origin(db, Some(&substitutor)) {
+            return find_members_guard(db, &origin, &ctx_with_substitutor, filter);
+        }
     }
 
     find_members_guard(

--- a/crates/glua_code_analysis/src/semantic/member/infer_raw_member.rs
+++ b/crates/glua_code_analysis/src/semantic/member/infer_raw_member.rs
@@ -275,14 +275,19 @@ fn infer_generic_raw_member_type(
 ) -> RawGetMemberTypeResult {
     let base_ref_id = generic_type.get_base_type_id_ref();
     let generic_params = generic_type.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor =
+        TypeSubstitutor::from_type_decl(db, generic_params.clone(), base_ref_id.clone());
     let type_decl = db
         .get_type_index()
         .get_type_decl(&base_ref_id)
         .ok_or(InferFailReason::None)?;
 
-    if let Some(origin) = type_decl.get_alias_origin(db, Some(&substitutor)) {
-        return infer_raw_member_type(db, &origin, member_key);
+    if type_decl.is_alias() {
+        let alias_substitutor =
+            TypeSubstitutor::from_alias(db, generic_params.clone(), base_ref_id.clone());
+        if let Some(origin) = type_decl.get_alias_origin(db, Some(&alias_substitutor)) {
+            return infer_raw_member_type(db, &origin, member_key);
+        }
     }
 
     let base_ref_type = LuaType::Ref(base_ref_id.clone());

--- a/crates/glua_code_analysis/src/semantic/type_check/complex_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/complex_type/mod.rs
@@ -37,8 +37,11 @@ pub fn check_complex_type_compact(
             if let Some(decl) = context.db.get_type_index().get_type_decl(&base_id)
                 && decl.is_alias()
             {
-                let substitutor =
-                    TypeSubstitutor::from_alias(generic.get_params().clone(), base_id.clone());
+                let substitutor = TypeSubstitutor::from_alias(
+                    context.db,
+                    generic.get_params().clone(),
+                    base_id.clone(),
+                );
                 if let Some(alias_origin) = decl.get_alias_origin(context.db, Some(&substitutor)) {
                     return check_general_type_compact(
                         context,

--- a/crates/glua_code_analysis/src/semantic/type_check/func_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/func_type.rs
@@ -23,8 +23,11 @@ pub fn check_doc_func_type_compact(
             if let Some(decl) = context.db.get_type_index().get_type_decl(&base_id)
                 && decl.is_alias()
             {
-                let substitutor =
-                    TypeSubstitutor::from_alias(generic.get_params().clone(), base_id.clone());
+                let substitutor = TypeSubstitutor::from_alias(
+                    context.db,
+                    generic.get_params().clone(),
+                    base_id.clone(),
+                );
                 if let Some(alias_origin) = decl.get_alias_origin(context.db, Some(&substitutor)) {
                     return check_general_type_compact(
                         context,

--- a/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
@@ -24,8 +24,11 @@ pub fn check_generic_type_compact(
         .get_type_decl(&source_generic.get_base_type_id())
         && decl.is_alias()
     {
-        let substitutor =
-            TypeSubstitutor::from_alias(source_generic.get_params().clone(), base_id.clone());
+        let substitutor = TypeSubstitutor::from_alias(
+            context.db,
+            source_generic.get_params().clone(),
+            base_id.clone(),
+        );
         if let Some(alias_origin) = decl.get_alias_origin(context.db, Some(&substitutor)) {
             return check_general_type_compact(
                 context,
@@ -61,8 +64,11 @@ pub fn check_generic_type_compact(
             {
                 for mut super_type in supers {
                     if super_type.contain_tpl() {
-                        let substitutor =
-                            TypeSubstitutor::from_type_array(compact_generic.get_params().clone());
+                        let substitutor = TypeSubstitutor::from_type_decl(
+                            context.db,
+                            compact_generic.get_params().clone(),
+                            compact_generic.get_base_type_id(),
+                        );
                         super_type =
                             instantiate_type_generic(context.db, &super_type, &substitutor);
                     }

--- a/crates/glua_code_analysis/src/semantic/type_check/simple_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/simple_type.rs
@@ -315,8 +315,11 @@ pub fn check_simple_type_compact(
                 if let Some(decl) = context.db.get_type_index().get_type_decl(&base_id)
                     && decl.is_alias()
                 {
-                    let substitutor =
-                        TypeSubstitutor::from_alias(generic.get_params().clone(), base_id.clone());
+                    let substitutor = TypeSubstitutor::from_alias(
+                        context.db,
+                        generic.get_params().clone(),
+                        base_id.clone(),
+                    );
                     if let Some(alias_origin) =
                         decl.get_alias_origin(context.db, Some(&substitutor))
                     {


### PR DESCRIPTION
fix generic inference for builder-style table apis

### problem

code like this did not infer all fields correctly:

```lua
local value = object({
    name = string(),
    age = number(),
})

local parsed = value:parse({})

-- expected:
-- parsed.name -> string
-- parsed.age -> number
```

some fields could become `unknown`.

this happened because table arguments were converted too early into a temporary object shape. after that, later generic `infer` logic no longer had enough information to connect each input field with the final output type.

### what changed

this keeps two views of a table argument during generic inference:

- the original/raw table type, so simple generic calls still work
- the field shape, so mapped and conditional types can read fields correctly

this fixes builder-style apis such as:

```lua
local builder = object({
    name = string(),
    age = number(),
    tags = array(string()),
    profile = object({
        id = string(),
        score = optional(number()),
    }),
})

local parsed = builder:parse({})
```

now the parsed result keeps the expected field types:

```lua
parsed.name          -- string
parsed.age           -- number
parsed.tags          -- string[]
parsed.profile.id    -- string
parsed.profile.score -- number?
```

it also keeps generic pass-through calls working:

```lua
local result = identity({ name = "abc" })
result.age = 1

-- result.age -> 1
```

### also fixed

- conditional `infer` now checks the actual generic base type, not only the number of generic params
- `infer` can work through generic aliases and generic super classes
- nested generic params use their real template ids, which avoids replacing the wrong generic in nested scopes
- mapped keys with the same name as an outer generic no longer get replaced incorrectly

### tests

added tests for inline and variable table shapes, nested objects, arrays, optional fields, method chains, generic aliases, nested generic supers, generic identity calls, nullable identity calls, and shadowed mapped keys.

---

**this pr was llm-assisted, so please review it carefully**
