### PR TITLE
typescript-like generic infer

### DIFF
--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
@@ -75,6 +75,16 @@ impl FileGenericIndex {
         assigned_params
     }
 
+    pub fn update_generic_param_constraint(
+        &mut self,
+        scope_id: GenericParamId,
+        name: &str,
+        constraint: Option<LuaType>,
+    ) -> Option<GenericParam> {
+        let scope = self.generic_params.get_mut(scope_id.id)?;
+        scope.update_param_constraint(name, constraint)
+    }
+
     fn try_add_range_to_effect_node(
         &mut self,
         range: TextRange,
@@ -226,6 +236,16 @@ impl TagGenericParams {
         self.params
             .insert(param.name.to_string(), (current_index, param.clone()));
         param
+    }
+
+    fn update_param_constraint(
+        &mut self,
+        name: &str,
+        constraint: Option<LuaType>,
+    ) -> Option<GenericParam> {
+        let (_, param) = self.params.get_mut(name)?;
+        param.type_constraint = constraint;
+        Some(param.clone())
     }
 
     fn tpl_id_for_idx(&self, idx: usize) -> GenericTplId {

--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/file_generic_index.rs
@@ -22,9 +22,8 @@ impl FileGenericIndex {
 
     pub fn add_generic_scope(&mut self, ranges: Vec<TextRange>, is_func: bool) -> GenericParamId {
         let params_index = self.generic_params.len();
-        let start = self.get_start(&ranges).unwrap_or(0);
         self.generic_params
-            .push(TagGenericParams::new(is_func, start));
+            .push(TagGenericParams::new(is_func, params_index as u32));
         let params_id = GenericParamId::new(params_index);
         let root_node_ids: Vec<_> = self.root_node_ids.clone();
         for range in ranges {
@@ -51,40 +50,29 @@ impl FileGenericIndex {
         params_id
     }
 
-    pub fn append_generic_param(&mut self, scope_id: GenericParamId, param: GenericParam) {
-        if let Some(scope) = self.generic_params.get_mut(scope_id.id) {
-            scope.insert_param(param);
-        }
-    }
-
-    pub fn append_generic_params(&mut self, scope_id: GenericParamId, params: Vec<GenericParam>) {
-        for param in params {
-            self.append_generic_param(scope_id, param);
-        }
-    }
-
-    pub fn set_param_constraint(
+    pub fn append_generic_param(
         &mut self,
         scope_id: GenericParamId,
-        name: &str,
-        constraint: Option<LuaType>,
-    ) {
-        if let Some(scope) = self.generic_params.get_mut(scope_id.id)
-            && let Some((_idx, stored_param)) = scope.params.get_mut(name)
-        {
-            stored_param.type_constraint = constraint;
+        param: GenericParam,
+    ) -> Option<GenericParam> {
+        if let Some(scope) = self.generic_params.get_mut(scope_id.id) {
+            return Some(scope.insert_param(param));
         }
+        None
     }
 
-    fn get_start(&self, ranges: &[TextRange]) -> Option<usize> {
-        let params_ids = self.find_generic_params(ranges.first()?.start())?;
-        let mut start = 0;
-        for params_id in params_ids.iter() {
-            if let Some(params) = self.generic_params.get(*params_id) {
-                start += params.params.len();
+    pub fn append_generic_params(
+        &mut self,
+        scope_id: GenericParamId,
+        params: Vec<GenericParam>,
+    ) -> Vec<GenericParam> {
+        let mut assigned_params = Vec::new();
+        for param in params {
+            if let Some(param) = self.append_generic_param(scope_id, param) {
+                assigned_params.push(param);
             }
         }
-        Some(start)
+        assigned_params
     }
 
     fn try_add_range_to_effect_node(
@@ -140,11 +128,7 @@ impl FileGenericIndex {
             if let Some(params) = self.generic_params.get(*params_id)
                 && let Some((id, param)) = params.params.get(name)
             {
-                let tpl_id = if params.is_func {
-                    GenericTplId::Func(*id as u32)
-                } else {
-                    GenericTplId::Type(*id as u32)
-                };
+                let tpl_id = param.tpl_id.unwrap_or_else(|| params.tpl_id_for_idx(*id));
                 return Some((tpl_id, param.type_constraint.clone()));
             }
         }
@@ -221,22 +205,34 @@ impl GenericEffectId {
 pub struct TagGenericParams {
     params: HashMap<String, (usize, GenericParam)>,
     is_func: bool,
+    scope_id: u32,
     next_index: usize,
 }
 
 impl TagGenericParams {
-    pub fn new(is_func: bool, start: usize) -> Self {
+    pub fn new(is_func: bool, scope_id: u32) -> Self {
         Self {
             params: HashMap::new(),
             is_func,
-            next_index: start,
+            scope_id,
+            next_index: 0,
         }
     }
 
-    fn insert_param(&mut self, param: GenericParam) {
+    fn insert_param(&mut self, param: GenericParam) -> GenericParam {
         let current_index = self.next_index;
         self.next_index += 1;
+        let param = param.with_tpl_id(self.tpl_id_for_idx(current_index));
         self.params
-            .insert(param.name.to_string(), (current_index, param));
+            .insert(param.name.to_string(), (current_index, param.clone()));
+        param
+    }
+
+    fn tpl_id_for_idx(&self, idx: usize) -> GenericTplId {
+        if self.is_func {
+            GenericTplId::Func(idx as u32)
+        } else {
+            GenericTplId::scoped_type(self.scope_id, idx as u32)
+        }
     }
 }

--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
@@ -777,9 +777,21 @@ fn infer_conditional_type(
             let scope_id = analyzer
                 .generic_index
                 .add_generic_scope(vec![true_range], false);
-            analyzer
+            let infer_params = analyzer
                 .generic_index
-                .append_generic_params(scope_id, infer_params.clone());
+                .append_generic_params(scope_id, infer_params);
+            let condition_type = infer_type(analyzer, condition);
+            let true_type = infer_type(analyzer, when_true);
+            let false_type = infer_type(analyzer, when_false);
+
+            return LuaConditionalType::new(
+                condition_type,
+                true_type,
+                false_type,
+                infer_params,
+                cond_type.has_new().unwrap_or(false),
+            )
+            .into();
         }
 
         // 处理条件和分支类型
@@ -829,11 +841,10 @@ fn infer_mapped_type(
     let scope_id = analyzer
         .generic_index
         .add_generic_scope(vec![mapped_type.get_range()], false);
-    analyzer
+    let param = analyzer
         .generic_index
-        .append_generic_param(scope_id, param.clone());
-    let position = mapped_type.get_range().start();
-    let (id, _) = analyzer.generic_index.find_generic(position, name)?;
+        .append_generic_param(scope_id, param)?;
+    let id = param.tpl_id?;
 
     let doc_type = mapped_type.get_value_type()?;
     let value_type = infer_type(analyzer, doc_type);

--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/infer_type.rs
@@ -583,29 +583,38 @@ fn register_inline_func_generics(
     func: &LuaDocFuncType,
     generic_list: LuaDocGenericDeclList,
 ) {
-    let mut generics = Vec::new();
-    for param in generic_list.get_generic_decl() {
-        let Some(name_token) = param.get_name_token() else {
-            continue;
-        };
-
-        let constraint = param.get_type().map(|ty| infer_type(analyzer, ty));
-        generics.push(GenericParam::new(
-            SmolStr::new(name_token.get_name_text()),
-            constraint,
-            None,
-        ));
-    }
-    if generics.is_empty() {
+    let generic_decls = generic_list.get_generic_decl().collect::<Vec<_>>();
+    if generic_decls.is_empty() {
         return;
     }
 
     let scope_id = analyzer
         .generic_index
         .add_generic_scope(vec![func.get_range()], true);
-    analyzer
-        .generic_index
-        .append_generic_params(scope_id, generics);
+
+    for param in generic_decls.iter() {
+        let Some(name_token) = param.get_name_token() else {
+            continue;
+        };
+
+        analyzer.generic_index.append_generic_param(
+            scope_id,
+            GenericParam::new(SmolStr::new(name_token.get_name_text()), None, None),
+        );
+    }
+
+    for param in generic_decls {
+        let Some(name_token) = param.get_name_token() else {
+            continue;
+        };
+
+        let constraint = param.get_type().map(|ty| infer_type(analyzer, ty));
+        analyzer.generic_index.update_generic_param_constraint(
+            scope_id,
+            name_token.get_name_text(),
+            constraint,
+        );
+    }
 }
 
 fn get_colon_define(analyzer: &mut DocAnalyzer) -> Option<bool> {

--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/type_def_tags.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/type_def_tags.rs
@@ -34,7 +34,6 @@ pub fn analyze_class(analyzer: &mut DocAnalyzer, tag: LuaDocTagClass) -> Option<
     let class_decl_id = class_decl.get_id();
     analyzer.current_type_id = Some(class_decl_id.clone());
     if let Some(generic_params) = tag.get_generic_decl() {
-        let generic_params = get_generic_params(analyzer, generic_params);
         let generic_params = add_generic_index(analyzer, generic_params, &tag);
 
         analyzer
@@ -142,12 +141,9 @@ pub fn analyze_alias(analyzer: &mut DocAnalyzer, tag: LuaDocTagAlias) -> Option<
     };
 
     if let Some(generic_params) = tag.get_generic_decl_list() {
-        let generic_params = get_generic_params(analyzer, generic_params);
         let range = tag.get_range();
         let scope_id = analyzer.generic_index.add_generic_scope(vec![range], false);
-        let generic_params = analyzer
-            .generic_index
-            .append_generic_params(scope_id, generic_params);
+        let generic_params = append_generic_params_with_scope(analyzer, scope_id, generic_params);
         analyzer
             .db
             .get_type_index_mut()
@@ -194,12 +190,25 @@ pub fn analyze_attribute(analyzer: &mut DocAnalyzer, tag: LuaDocTagAttribute) ->
     Some(())
 }
 
-fn get_generic_params(
+fn append_generic_params_with_scope(
     analyzer: &mut DocAnalyzer,
+    scope_id: super::file_generic_index::GenericParamId,
     params: LuaDocGenericDeclList,
 ) -> Vec<GenericParam> {
     let mut params_result = Vec::new();
-    for param in params.get_generic_decl() {
+    let generic_decls = params.get_generic_decl().collect::<Vec<_>>();
+    for param in generic_decls.iter() {
+        let name = if let Some(param) = param.get_name_token() {
+            SmolStr::new(param.get_name_text())
+        } else {
+            continue;
+        };
+        analyzer
+            .generic_index
+            .append_generic_param(scope_id, GenericParam::new(name, None, None));
+    }
+
+    for param in generic_decls {
         let name = if let Some(param) = param.get_name_token() {
             SmolStr::new(param.get_name_text())
         } else {
@@ -209,7 +218,12 @@ fn get_generic_params(
             .get_type()
             .map(|type_ref| infer_type(analyzer, type_ref));
 
-        params_result.push(GenericParam::new(name, type_ref, None));
+        if let Some(param) = analyzer
+            .generic_index
+            .update_generic_param_constraint(scope_id, &name, type_ref)
+        {
+            params_result.push(param);
+        }
     }
 
     params_result
@@ -217,7 +231,7 @@ fn get_generic_params(
 
 fn add_generic_index(
     analyzer: &mut DocAnalyzer,
-    generic_params: Vec<GenericParam>,
+    generic_params: LuaDocGenericDeclList,
     tag: &LuaDocTagClass,
 ) -> Vec<GenericParam> {
     let mut ranges = Vec::new();
@@ -241,9 +255,7 @@ fn add_generic_index(
     }
 
     let scope_id = analyzer.generic_index.add_generic_scope(ranges, false);
-    analyzer
-        .generic_index
-        .append_generic_params(scope_id, generic_params)
+    append_generic_params_with_scope(analyzer, scope_id, generic_params)
 }
 
 fn get_local_stat_reference_ranges(
@@ -343,19 +355,31 @@ pub fn analyze_func_generic(analyzer: &mut DocAnalyzer, tag: LuaDocTagGeneric) -
 
     let mut param_info = Vec::new();
     if let Some(params_list) = tag.get_generic_decl_list() {
-        for param in params_list.get_generic_decl() {
+        let generic_decls = params_list.get_generic_decl().collect::<Vec<_>>();
+        for param in generic_decls.iter() {
             let Some(name_token) = param.get_name_token() else {
                 continue;
             };
             let name_text = name_token.get_name_text().to_string();
             let smol_name = SmolStr::new(name_text.as_str());
+            analyzer
+                .generic_index
+                .append_generic_param(scope_id, GenericParam::new(smol_name, None, None));
+        }
+
+        for param in generic_decls {
+            let Some(name_token) = param.get_name_token() else {
+                continue;
+            };
+            let name_text = name_token.get_name_text().to_string();
             let type_ref = param
                 .get_type()
                 .map(|type_ref| infer_type(analyzer, type_ref));
 
-            analyzer.generic_index.append_generic_param(
+            analyzer.generic_index.update_generic_param_constraint(
                 scope_id,
-                GenericParam::new(smol_name.clone(), type_ref.clone(), None),
+                &name_text,
+                type_ref.clone(),
             );
 
             param_info.push(Arc::new(LuaGenericParamInfo::new(

--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/type_def_tags.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/type_def_tags.rs
@@ -35,13 +35,12 @@ pub fn analyze_class(analyzer: &mut DocAnalyzer, tag: LuaDocTagClass) -> Option<
     analyzer.current_type_id = Some(class_decl_id.clone());
     if let Some(generic_params) = tag.get_generic_decl() {
         let generic_params = get_generic_params(analyzer, generic_params);
+        let generic_params = add_generic_index(analyzer, generic_params, &tag);
 
         analyzer
             .db
             .get_type_index_mut()
             .add_generic_params(class_decl_id.clone(), generic_params.clone());
-
-        add_generic_index(analyzer, generic_params, &tag);
     }
 
     if let Some(supers) = tag.get_supers() {
@@ -144,16 +143,15 @@ pub fn analyze_alias(analyzer: &mut DocAnalyzer, tag: LuaDocTagAlias) -> Option<
 
     if let Some(generic_params) = tag.get_generic_decl_list() {
         let generic_params = get_generic_params(analyzer, generic_params);
-
+        let range = tag.get_range();
+        let scope_id = analyzer.generic_index.add_generic_scope(vec![range], false);
+        let generic_params = analyzer
+            .generic_index
+            .append_generic_params(scope_id, generic_params);
         analyzer
             .db
             .get_type_index_mut()
-            .add_generic_params(alias_decl_id.clone(), generic_params.clone());
-        let range = analyzer.comment.get_range();
-        let scope_id = analyzer.generic_index.add_generic_scope(vec![range], false);
-        analyzer
-            .generic_index
-            .append_generic_params(scope_id, generic_params);
+            .add_generic_params(alias_decl_id.clone(), generic_params);
     }
 
     let origin_type = infer_type(analyzer, tag.get_type()?);
@@ -221,7 +219,7 @@ fn add_generic_index(
     analyzer: &mut DocAnalyzer,
     generic_params: Vec<GenericParam>,
     tag: &LuaDocTagClass,
-) {
+) -> Vec<GenericParam> {
     let mut ranges = Vec::new();
     ranges.push(tag.get_effective_range());
     if let Some(comment_owner) = analyzer.comment.get_owner() {
@@ -245,7 +243,7 @@ fn add_generic_index(
     let scope_id = analyzer.generic_index.add_generic_scope(ranges, false);
     analyzer
         .generic_index
-        .append_generic_params(scope_id, generic_params);
+        .append_generic_params(scope_id, generic_params)
 }
 
 fn get_local_stat_reference_ranges(
@@ -351,18 +349,13 @@ pub fn analyze_func_generic(analyzer: &mut DocAnalyzer, tag: LuaDocTagGeneric) -
             };
             let name_text = name_token.get_name_text().to_string();
             let smol_name = SmolStr::new(name_text.as_str());
-            analyzer
-                .generic_index
-                .append_generic_param(scope_id, GenericParam::new(smol_name.clone(), None, None));
-
             let type_ref = param
                 .get_type()
                 .map(|type_ref| infer_type(analyzer, type_ref));
 
-            analyzer.generic_index.set_param_constraint(
+            analyzer.generic_index.append_generic_param(
                 scope_id,
-                name_text.as_str(),
-                type_ref.clone(),
+                GenericParam::new(smol_name.clone(), type_ref.clone(), None),
             );
 
             param_info.push(Arc::new(LuaGenericParamInfo::new(

--- a/crates/glua_code_analysis/src/compilation/analyzer/lua/for_range_stat.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/lua/for_range_stat.rs
@@ -155,7 +155,7 @@ pub fn infer_for_range_iter_expr_func(
         let mut context = TplContext {
             db,
             cache,
-            substitutor: &mut inference,
+            inference: &mut inference,
             call_expr: None,
         };
         tpl_pattern_match_args(&mut context, &params, &[status_param])?;

--- a/crates/glua_code_analysis/src/compilation/analyzer/lua/for_range_stat.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/lua/for_range_stat.rs
@@ -1,8 +1,8 @@
 use glua_parser::{LuaAstToken, LuaExpr, LuaForRangeStat};
 
 use crate::{
-    DbIndex, InferFailReason, LuaDeclId, LuaInferCache, LuaOperatorMetaMethod, LuaType,
-    LuaTypeCache, TplContext, TypeOps, TypeSubstitutor, VariadicType,
+    DbIndex, InferFailReason, InferenceContext, LuaDeclId, LuaInferCache, LuaOperatorMetaMethod,
+    LuaType, LuaTypeCache, TplContext, TypeOps, VariadicType,
     compilation::analyzer::unresolve::UnResolveIterVar, infer_expr, instantiate_doc_function,
     tpl_pattern_match_args,
 };
@@ -144,23 +144,25 @@ pub fn infer_for_range_iter_expr_func(
     let Some(status_param) = status_param else {
         return Ok(doc_function.get_variadic_ret());
     };
-    let mut substitutor = TypeSubstitutor::new();
-    let mut context = TplContext {
-        db,
-        cache,
-        substitutor: &mut substitutor,
-        call_expr: None,
-    };
+    let mut inference = InferenceContext::new();
     let params = doc_function
         .get_params()
         .iter()
         .map(|(_, opt_ty)| opt_ty.clone().unwrap_or(LuaType::Any))
         .collect::<Vec<_>>();
 
-    tpl_pattern_match_args(&mut context, &params, &[status_param])?;
+    {
+        let mut context = TplContext {
+            db,
+            cache,
+            substitutor: &mut inference,
+            call_expr: None,
+        };
+        tpl_pattern_match_args(&mut context, &params, &[status_param])?;
+    }
 
     let instantiate_func = if let LuaType::DocFunction(f) =
-        instantiate_doc_function(db, &doc_function, &substitutor)
+        instantiate_doc_function(db, &doc_function, inference.substitutor())
     {
         f
     } else {

--- a/crates/glua_code_analysis/src/compilation/analyzer/lua/mod.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/lua/mod.rs
@@ -14,6 +14,7 @@ pub use closure::analyze_return_point;
 use for_range_stat::analyze_for_range_stat;
 pub use for_range_stat::infer_for_range_iter_expr_func;
 pub use func_body::LuaReturnPoint;
+pub use func_body::analyze_func_body_returns;
 use glua_parser::{LuaAst, LuaAstNode, LuaExpr};
 use metatable::analyze_setmetatable;
 use module::analyze_chunk_return;

--- a/crates/glua_code_analysis/src/compilation/analyzer/mod.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/mod.rs
@@ -8,6 +8,8 @@ mod infer_cache_manager;
 mod lua;
 pub(crate) mod unresolve;
 
+pub(crate) use lua::{LuaReturnPoint, analyze_func_body_returns};
+
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,

--- a/crates/glua_code_analysis/src/compilation/analyzer/unresolve/find_decl_function.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/unresolve/find_decl_function.rs
@@ -396,7 +396,12 @@ fn find_generic_member(
     let base_type = generic_type.get_base_type();
 
     let generic_params = generic_type.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor = match &base_type {
+        LuaType::Ref(base_type_decl_id) => {
+            TypeSubstitutor::from_type_array_for_type(db, base_type_decl_id, generic_params.clone())
+        }
+        _ => TypeSubstitutor::from_type_array(generic_params.clone()),
+    };
     if let LuaType::Ref(base_type_decl_id) = &base_type {
         let result = index_generic_members_from_super_generics(
             db,
@@ -769,7 +774,8 @@ fn find_member_by_index_generic(
         return Err(InferFailReason::None);
     };
     let generic_params = generic.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor =
+        TypeSubstitutor::from_type_array_for_type(db, &type_decl_id, generic_params.clone());
     let type_index = db.get_type_index();
     let type_decl = type_index
         .get_type_decl(&type_decl_id)

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1453,6 +1453,67 @@ mod test {
     }
 
     #[test]
+    fn test_reverse_mapped_infer_through_tuple_source() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@field value T
+
+            ---@alias Boxified<T> { [K in keyof T]: Box<T[K]>; }
+
+            ---@generic T
+            ---@param value T
+            ---@return Box<T>
+            function box(value) end
+
+            ---@generic T
+            ---@param values Boxified<T>
+            ---@return T
+            function unboxify(values) end
+
+            result = unboxify({
+                box(1),
+                box("two"),
+            })
+            "#,
+        );
+
+        let first_ty = ws.expr_ty("result[1]");
+        let second_ty = ws.expr_ty("result[2]");
+        assert_eq!(ws.humanize_type(first_ty), "integer");
+        assert_eq!(ws.humanize_type(second_ty), "string");
+    }
+
+    #[test]
+    fn test_reverse_mapped_infer_through_array_source() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@field value T
+
+            ---@alias Boxified<T> { [K in keyof T]: Box<T[K]>; }
+
+            ---@generic T
+            ---@param values Boxified<T>
+            ---@return T
+            function unboxify(values) end
+
+            ---@type Box<number>[]
+            local values
+
+            result = unboxify(values)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("result[1]");
+        assert_eq!(ws.humanize_type(value_ty), "number");
+    }
+
+    #[test]
     fn test_mapped_inference_is_lower_priority_than_direct_inference() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -530,6 +530,37 @@ mod test {
     }
 
     #[test]
+    fn test_generic_return_context_combines_repeated_candidates() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Dog
+            ---@class Cat
+            ---@class Pair<A, B>
+
+            ---@generic T
+            ---@return Pair<T, T>
+            function make_pair() end
+
+            ---@type Pair<Dog, Cat>
+            local pair = make_pair()
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("Pair<Dog|Cat, Dog|Cat>");
+        assert_eq!(call_ty, expected);
+    }
+
+    #[test]
     fn test_generic_return_context_flows_into_callback_param() {
         let mut ws = VirtualWorkspace::new();
         let file_id = ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1285,6 +1285,104 @@ mod test {
     }
 
     #[test]
+    fn test_reverse_mapped_infer_from_reducer_table_variable() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Action
+            ---@field type string
+
+            ---@alias Reducer<S> fun(state: S, action: Action): S
+            ---@alias Reducers<S> { [K in keyof S]: Reducer<S[K]>; }
+
+            ---@generic S
+            ---@param reducers Reducers<S>
+            ---@return Reducer<S>
+            function combine_reducers(reducers) end
+
+            ---@param state string
+            ---@param action Action
+            ---@return string
+            local function name(state, action)
+                return "dummy"
+            end
+
+            local reducers = {
+                name = name,
+            }
+
+            local reducer = combine_reducers(reducers)
+            result = reducer(nil, nil).name
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        assert_eq!(ws.humanize_type(result_ty), "string");
+    }
+
+    #[test]
+    fn test_reverse_mapped_infer_with_rawget_alias() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@alias std.RawGet<T, K> unknown
+            ---@alias RawMirror<T> { [K in keyof T]: std.RawGet<T, K>; }
+
+            ---@generic T
+            ---@param values RawMirror<T>
+            ---@return T
+            function raw_unmirror(values) end
+
+            result = raw_unmirror({
+                name = "Ada",
+                age = 42,
+            })
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("result.name");
+        let age_ty = ws.expr_ty("result.age");
+        assert_eq!(ws.humanize_type(name_ty), "\"Ada\"");
+        assert_eq!(ws.humanize_type(age_ty), "42");
+    }
+
+    #[test]
+    fn test_reverse_mapped_infer_through_generic_wrapper() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@field value T
+
+            ---@alias Boxified<T> { [K in keyof T]: Box<T[K]>; }
+
+            ---@generic T
+            ---@param value T
+            ---@return Box<T>
+            function box(value) end
+
+            ---@generic T
+            ---@param obj Boxified<T>
+            ---@return T
+            function unboxify(obj) end
+
+            result = unboxify({
+                is_perfect = box(true),
+                weight = box(42),
+            })
+            "#,
+        );
+
+        let is_perfect_ty = ws.expr_ty("result.is_perfect");
+        let weight_ty = ws.expr_ty("result.weight");
+        assert_eq!(ws.humanize_type(is_perfect_ty), "boolean");
+        assert_eq!(ws.humanize_type(weight_ty), "integer");
+    }
+
+    #[test]
     fn test_mapped_inference_is_lower_priority_than_direct_inference() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -615,6 +615,43 @@ mod test {
     }
 
     #[test]
+    fn test_conditional_infer_generic_params_use_independent_guard() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@class Source<T>: Box<T>
+            ---@class Pair<A, B>
+
+            ---@alias ExtractFirst<T> T extends Pair<Box<infer A>, Box<infer B>> and A or unknown
+            ---@alias ExtractSecond<T> T extends Pair<Box<infer A>, Box<infer B>> and B or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return ExtractFirst<T>
+            function extract_first(value) end
+
+            ---@generic T
+            ---@param value T
+            ---@return ExtractSecond<T>
+            function extract_second(value) end
+
+            ---@type Pair<Source<string>, Source<number>>
+            local pair
+
+            first = extract_first(pair)
+            second = extract_second(pair)
+            "#,
+        );
+
+        let first_ty = ws.expr_ty("first");
+        let second_ty = ws.expr_ty("second");
+        assert_eq!(ws.humanize_type(first_ty), "string");
+        assert_eq!(ws.humanize_type(second_ty), "number");
+    }
+
+    #[test]
     fn test_generic_identity_table_literal_still_allows_later_field_inference() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -725,6 +725,47 @@ mod test {
     }
 
     #[test]
+    fn test_contextual_generic_function_field_does_not_type_closure_param() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class GenericCallable
+            ---@field f fun<T>(value: T): T
+
+            ---@type GenericCallable
+            local callable = {
+                f = function(value)
+                    contextual_generic_field_seen = value
+                    return value
+                end
+            }
+            "#,
+        );
+
+        let seen_ty = ws.expr_ty("contextual_generic_field_seen");
+        assert_eq!(seen_ty, ws.ty("unknown"));
+    }
+
+    #[test]
+    fn test_contextual_generic_function_arg_does_not_type_closure_param() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@param callback fun<T>(value: T): T
+            local function use_generic_callback(callback) end
+
+            use_generic_callback(function(value)
+                contextual_generic_arg_seen = value
+                return value
+            end)
+            "#,
+        );
+
+        let seen_ty = ws.expr_ty("contextual_generic_arg_seen");
+        assert_eq!(seen_ty, ws.ty("unknown"));
+    }
+
+    #[test]
     fn test_generic_return_context_does_not_override_arg_inference() {
         let mut ws = VirtualWorkspace::new();
         let file_id = ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -703,6 +703,56 @@ mod test {
     }
 
     #[test]
+    fn test_conditional_infer_pattern_union_prefers_structural_match_over_naked_infer() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@alias Extract<T> T extends (Box<infer U>|infer U) and U or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return Extract<T>
+            function extract(value) end
+
+            ---@type Box<string>
+            local source
+
+            value = extract(source)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "string");
+    }
+
+    #[test]
+    fn test_conditional_infer_pattern_union_uses_naked_infer_for_unmatched_source_member() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@alias Extract<T> T extends (Box<infer U>|infer U) and U or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return Extract<T>
+            function extract(value) end
+
+            ---@type Box<string>|number
+            local source
+
+            value = extract(source)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "(string|number)");
+    }
+
+    #[test]
     fn test_generic_identity_table_literal_still_allows_later_field_inference() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -502,6 +502,201 @@ mod test {
     }
 
     #[test]
+    fn test_generic_receiver_method_return_context_flows_into_callback_param() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class WrappedArray<T>
+            ---@field map fun<U>(self: WrappedArray<T>, cb: fun(value: T): U): WrappedArray<U>
+
+            ---@type WrappedArray<string>
+            local array = {}
+
+            ---@type WrappedArray<number>
+            local mapped = array:map(function(value)
+                receiver_seen = value
+                return 1
+            end)
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("WrappedArray<number>");
+        assert_eq!(call_ty, expected);
+
+        let seen_ty = ws.expr_ty("receiver_seen");
+        assert_eq!(seen_ty, ws.ty("string"));
+    }
+
+    #[test]
+    fn test_generic_combinator_uses_first_arg_to_type_callback_params() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Collection<T, U>
+            local Collection = {}
+
+            ---@generic T, U, V
+            ---@param c Collection<T, U>
+            ---@param cb fun(x: T, y: U): V
+            ---@return Collection<T, V>
+            function map(c, cb)
+            end
+
+            ---@type Collection<number, string>
+            local collection = {}
+
+            local result = map(collection, function(x, y)
+                combinator_x = x
+                combinator_y = y
+                return y
+            end)
+            "#,
+        );
+
+        let tree = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .expect("Tree must exist");
+        let call_expr = tree
+            .get_chunk_node()
+            .descendants::<LuaCallExpr>()
+            .last()
+            .expect("call expression must exist");
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        assert_eq!(call_ty, ws.ty("Collection<number, string>"));
+
+        let x_ty = ws.expr_ty("combinator_x");
+        let y_ty = ws.expr_ty("combinator_y");
+        assert_eq!(x_ty, ws.ty("number"));
+        assert_eq!(y_ty, ws.ty("string"));
+    }
+
+    #[test]
+    fn test_generic_field_combinator_uses_first_arg_to_type_callback_params() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Collection<T, U>
+            local Collection = {}
+
+            ---@class Combinators
+            ---@field map fun<T, U, V>(c: Collection<T, U>, cb: fun(x: T, y: U): V): Collection<T, V>
+
+            ---@type Combinators
+            local combinators = {}
+
+            ---@type Collection<number, string>
+            local collection = {}
+
+            local result = combinators.map(collection, function(x, y)
+                field_combinator_x = x
+                field_combinator_y = y
+                return y
+            end)
+            "#,
+        );
+
+        let tree = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .expect("Tree must exist");
+        let call_expr = tree
+            .get_chunk_node()
+            .descendants::<LuaCallExpr>()
+            .last()
+            .expect("call expression must exist");
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        assert_eq!(call_ty, ws.ty("Collection<number, string>"));
+
+        let x_ty = ws.expr_ty("field_combinator_x");
+        let y_ty = ws.expr_ty("field_combinator_y");
+        assert_eq!(x_ty, ws.ty("number"));
+        assert_eq!(y_ty, ws.ty("string"));
+    }
+
+    #[test]
+    fn test_generic_field_combinator_prefers_specific_overload() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Collection<T, U>
+            local Collection = {}
+
+            ---@class Combinators
+            ---@field map (fun<T, U, V>(c: Collection<T, U>, cb: fun(x: T, y: U): V): Collection<T, V>) | (fun<T, U>(c: Collection<T, U>, cb: fun(x: T, y: U): any): Collection<any, any>)
+
+            ---@type Combinators
+            local combinators = {}
+
+            ---@type Collection<number, string>
+            local collection = {}
+
+            local result = combinators.map(collection, function(x, y)
+                overloaded_combinator_x = x
+                overloaded_combinator_y = y
+                return y
+            end)
+            "#,
+        );
+
+        let tree = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .expect("Tree must exist");
+        let call_expr = tree
+            .get_chunk_node()
+            .descendants::<LuaCallExpr>()
+            .last()
+            .expect("call expression must exist");
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        assert_eq!(call_ty, ws.ty("Collection<number, string>"));
+
+        let x_ty = ws.expr_ty("overloaded_combinator_x");
+        let y_ty = ws.expr_ty("overloaded_combinator_y");
+        assert_eq!(x_ty, ws.ty("number"));
+        assert_eq!(y_ty, ws.ty("string"));
+    }
+
+    #[test]
     fn test_issue_646() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -151,6 +151,34 @@ mod test {
     }
 
     #[test]
+    fn test_generic_direct_candidates_use_common_supertype() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Animal
+            ---@class Dog: Animal
+            ---@class Cat: Animal
+
+            ---@generic T
+            ---@param first T
+            ---@param second T
+            ---@return T
+            function choose(first, second) end
+
+            ---@type Dog
+            local dog
+            ---@type Cat
+            local cat
+            animal = choose(dog, cat)
+            "#,
+        );
+
+        let animal_ty = ws.expr_ty("animal");
+        let expected = ws.ty("Animal");
+        assert_eq!(animal_ty, expected);
+    }
+
+    #[test]
     fn test_issue_646() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -158,7 +158,7 @@ mod test {
     }
 
     #[test]
-    fn test_generic_inference_combines_multiple_candidates() {
+    fn test_generic_inference_keeps_leftmost_conflicting_direct_candidate() {
         let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
@@ -174,8 +174,9 @@ mod test {
         );
 
         let value_ty = ws.expr_ty("value");
-        let expected = ws.ty("string|integer");
+        let expected = ws.ty("string");
         assert_eq!(value_ty, expected);
+        assert!(!ws.check_code_for(DiagnosticCode::ParamTypeMismatch, r#"choose("name", 1)"#));
 
         let other_ty = ws.expr_ty("other");
         let expected = ws.ty("string");
@@ -211,7 +212,7 @@ mod test {
     }
 
     #[test]
-    fn test_generic_direct_candidates_use_union() {
+    fn test_generic_direct_conflicting_nominal_candidates_keep_leftmost() {
         let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
@@ -234,12 +235,12 @@ mod test {
         );
 
         let animal_ty = ws.expr_ty("animal");
-        let expected = ws.ty("Dog|Cat");
+        let expected = ws.ty("Dog");
         assert_eq!(animal_ty, expected);
     }
 
     #[test]
-    fn test_generic_direct_candidates_use_union_for_generic_subclasses() {
+    fn test_generic_direct_conflicting_generic_subclasses_keep_leftmost() {
         let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
@@ -262,8 +263,35 @@ mod test {
         );
 
         let box_ty = ws.expr_ty("box");
-        let expected = ws.ty("StringBox|NumberBox");
+        let expected = ws.ty("StringBox");
         assert_eq!(box_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_direct_subtype_candidate_uses_supertype_candidate() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Animal
+            ---@class Dog: Animal
+
+            ---@generic T
+            ---@param first T
+            ---@param second T
+            ---@return T
+            function choose(first, second) end
+
+            ---@type Animal
+            local animal
+            ---@type Dog
+            local dog
+            result = choose(animal, dog)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        let expected = ws.ty("Animal");
+        assert_eq!(result_ty, expected);
     }
 
     #[test]
@@ -296,7 +324,7 @@ mod test {
     }
 
     #[test]
-    fn test_generic_function_return_candidates_use_union() {
+    fn test_generic_function_return_conflicting_candidates_keep_leftmost() {
         let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
@@ -321,7 +349,7 @@ mod test {
         );
 
         let animal_ty = ws.expr_ty("animal");
-        let expected = ws.ty("Dog|Cat");
+        let expected = ws.ty("Dog");
         assert_eq!(animal_ty, expected);
     }
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -388,6 +388,72 @@ mod test {
     }
 
     #[test]
+    fn test_generic_overload_return_context_flows_into_callback_param() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Wrap
+            ---@overload fun<T, U>(cb: fun(value: T): U): fun(value: T): U
+            local wrap = {}
+
+            ---@type fun(value: string): number
+            local mapped = wrap(function(value)
+                overloaded_seen = value
+                return 1
+            end)
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("fun(value: string): number");
+        assert_eq!(call_ty, expected);
+
+        let seen_ty = ws.expr_ty("overloaded_seen");
+        assert_eq!(seen_ty, ws.ty("string"));
+    }
+
+    #[test]
+    fn test_generic_union_return_context_flows_into_callback_param() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Mapper
+            ---@field map (fun<T, U>(cb: fun(value: T): U): fun(value: T): U) | (fun(label: string): string)
+            local mapper = {}
+
+            ---@type fun(value: string): number
+            local mapped = mapper.map(function(value)
+                union_seen = value
+                return 1
+            end)
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("fun(value: string): number");
+        assert_eq!(call_ty, expected);
+
+        let seen_ty = ws.expr_ty("union_seen");
+        assert_eq!(seen_ty, ws.ty("string"));
+    }
+
+    #[test]
     fn test_issue_646() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -766,6 +766,28 @@ mod test {
     }
 
     #[test]
+    fn test_contextual_generic_function_member_assignment_does_not_type_closure_param() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class GenericHolder
+            ---@field f fun<T>(value: T): T
+
+            ---@type GenericHolder
+            local holder = {}
+
+            holder.f = function(value)
+                contextual_generic_member_seen = value
+                return value
+            end
+            "#,
+        );
+
+        let seen_ty = ws.expr_ty("contextual_generic_member_seen");
+        assert_eq!(seen_ty, ws.ty("unknown"));
+    }
+
+    #[test]
     fn test_generic_return_context_does_not_override_arg_inference() {
         let mut ws = VirtualWorkspace::new();
         let file_id = ws.def(
@@ -973,6 +995,39 @@ mod test {
         assert_eq!(call_ty, expected);
 
         let seen_ty = ws.expr_ty("receiver_seen");
+        assert_eq!(seen_ty, ws.ty("string"));
+    }
+
+    #[test]
+    fn test_generic_method_call_infers_callback_return_without_context() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class WrappedArray<T>
+            ---@field map fun<U>(self: WrappedArray<T>, iterator: fun(value: T): U): U[]
+
+            ---@type WrappedArray<string>
+            local array = {}
+
+            local mapped = array:map(function(value)
+                method_map_seen = value
+                return 1
+            end)
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        assert_eq!(call_ty, ws.ty("integer[]"));
+
+        let seen_ty = ws.expr_ty("method_map_seen");
         assert_eq!(seen_ty, ws.ty("string"));
     }
 
@@ -1238,6 +1293,35 @@ mod test {
 
         let seen_ty = ws.expr_ty("explicit_callback_seen");
         assert_eq!(seen_ty, ws.ty("number"));
+    }
+
+    #[test]
+    fn test_generic_combinator_explicit_type_args_check_callback_return() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Collection<T, U>
+            local Collection = {}
+
+            ---@class Combinators
+            ---@field map fun<T, U, V>(c: Collection<T, U>, cb: fun(x: T, y: U): V): Collection<T, V>
+
+            ---@type Combinators
+            local combinators = {}
+
+            ---@type Collection<number, string>
+            local collection = {}
+            "#,
+        );
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            local result = combinators.map--[[@<number, string, boolean>]](collection, function(x, y)
+                return ""
+            end)
+            "#,
+        ));
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -179,6 +179,34 @@ mod test {
     }
 
     #[test]
+    fn test_generic_direct_candidates_preserve_generic_common_supertype() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@class StringBox: Box<string>
+            ---@class NumberBox: Box<number>
+
+            ---@generic T
+            ---@param first T
+            ---@param second T
+            ---@return T
+            function choose(first, second) end
+
+            ---@type StringBox
+            local string_box
+            ---@type NumberBox
+            local number_box
+            box = choose(string_box, number_box)
+            "#,
+        );
+
+        let box_ty = ws.expr_ty("box");
+        let expected = ws.ty("Box<string|number>");
+        assert_eq!(box_ty, expected);
+    }
+
+    #[test]
     fn test_issue_646() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -235,6 +235,97 @@ mod test {
     }
 
     #[test]
+    fn test_generic_return_infers_from_assignment_doc_context() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@generic T
+            ---@return T
+            function make() end
+
+            ---@type string
+            local value
+            value = make()
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("string");
+        assert_eq!(call_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_return_infers_from_member_doc_context() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Holder
+            ---@field value string
+
+            ---@generic T
+            ---@return T
+            function make() end
+
+            ---@type Holder
+            local holder = {}
+            holder.value = make()
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("string");
+        assert_eq!(call_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_return_infers_from_table_field_doc_context() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Holder
+            ---@field value string
+
+            ---@generic T
+            ---@return T
+            function make() end
+
+            ---@type Holder
+            local holder = {
+                value = make()
+            }
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("string");
+        assert_eq!(call_ty, expected);
+    }
+
+    #[test]
     fn test_issue_646() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -652,6 +652,31 @@ mod test {
     }
 
     #[test]
+    fn test_conditional_infer_collects_from_each_source_union_member() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Wrapper<T>
+            ---@alias Unwrap<T> T extends Wrapper<infer U> and U or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return Unwrap<T>
+            function unwrap(value) end
+
+            ---@type Wrapper<string>|Wrapper<number>
+            local wrapped
+
+            value = unwrap(wrapped)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "(string|number)");
+    }
+
+    #[test]
     fn test_generic_identity_table_literal_still_allows_later_field_inference() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -267,6 +267,92 @@ mod test {
     }
 
     #[test]
+    fn test_generic_mixed_function_candidates_prefer_covariant_subtype() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Animal
+            ---@class Dog: Animal
+
+            ---@generic T
+            ---@param value T
+            ---@param callback fun(value: T)
+            ---@return T
+            function use_callback(value, callback) end
+
+            ---@type Dog
+            local dog
+
+            ---@param value Animal
+            local function accepts_animal(value) end
+
+            result = use_callback(dog, accepts_animal)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        let expected = ws.ty("Dog");
+        assert_eq!(result_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_mixed_function_candidates_prefer_contravariant_subtype() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Animal
+            ---@class Dog: Animal
+
+            ---@generic T
+            ---@param value T
+            ---@param callback fun(value: T)
+            ---@return T
+            function use_callback(value, callback) end
+
+            ---@type Animal
+            local animal
+
+            ---@param value Dog
+            local function accepts_dog(value) end
+
+            result = use_callback(animal, accepts_dog)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        let expected = ws.ty("Dog");
+        assert_eq!(result_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_mixed_function_candidates_ignore_any_covariant() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Dog
+
+            ---@generic T
+            ---@param value T
+            ---@param callback fun(value: T)
+            ---@return T
+            function use_callback(value, callback) end
+
+            ---@type any
+            local value
+
+            ---@param value Dog
+            local function accepts_dog(value) end
+
+            result = use_callback(value, accepts_dog)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        let expected = ws.ty("Dog");
+        assert_eq!(result_ty, expected);
+    }
+
+    #[test]
     fn test_generic_return_infers_from_local_doc_context() {
         let mut ws = VirtualWorkspace::new();
         let file_id = ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -70,6 +70,65 @@ mod test {
     }
 
     #[test]
+    fn test_generic_callback_variadic_middle_keeps_fixed_suffix() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param cb fun(head: string, ...: T..., tail: boolean)
+            ---@return fun(...: T...)
+            function drop_edges(cb) end
+
+            ---@param head string
+            ---@param amount integer
+            ---@param label string
+            ---@param tail boolean
+            local function source(head, amount, label, tail) end
+
+            callback = drop_edges(source)
+            "#,
+        );
+
+        let callback_ty = ws.expr_ty("callback");
+        let expected = ws.ty("fun(amount: integer, label: string)");
+        assert_eq!(callback_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_call_variadic_middle_keeps_fixed_suffix() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class CollectMiddle
+            ---@overload fun<T>(head: string, ...: T..., tail: boolean): T...
+            local collect_middle = {}
+
+            first, second, third = collect_middle("head", 1, "two", true)
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("first"), ws.ty("integer"));
+        assert_eq!(ws.expr_ty("second"), ws.ty("string"));
+        assert_eq!(ws.expr_ty("third"), ws.ty("nil"));
+    }
+
+    #[test]
+    fn test_generic_call_variadic_middle_continues_into_generic_suffix() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class CollectTail
+            ---@overload fun<T, U>(head: string, ...: T..., tail: U): U
+            local collect_tail = {}
+
+            tail = collect_tail("head", 1, "two", true)
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("tail"), ws.ty("boolean"));
+    }
+
+    #[test]
     fn test_generic_params() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use crate::{DiagnosticCode, VirtualWorkspace};
+    use crate::{DiagnosticCode, GenericTplId, LuaType, LuaTypeDeclId, VirtualWorkspace};
     use glua_parser::{LuaAstNode, LuaCallExpr, LuaExpr};
 
     #[test]
@@ -471,6 +471,83 @@ mod test {
         let result_ty = ws.expr_ty("result");
         let expected = ws.ty("Animal");
         assert_eq!(result_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_dependent_constraint_can_reference_later_type_param() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Animal
+            ---@class Dog: Animal
+
+            ---@generic T: U, U
+            ---@param value T
+            ---@param upper U
+            ---@return T
+            function keep_specific(value, upper) end
+
+            ---@type Dog
+            local dog
+
+            ---@type Animal
+            local animal
+
+            result = keep_specific(dog, animal)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        let expected = ws.ty("Dog");
+        assert_eq!(result_ty, expected);
+    }
+
+    #[test]
+    fn test_class_generic_constraint_can_reference_later_type_param() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Pair<T: U, U>
+            "#,
+        );
+
+        let db = ws.get_db_mut();
+        let generic_params = db
+            .get_type_index()
+            .get_generic_params(&LuaTypeDeclId::global("Pair"))
+            .expect("Pair generic params must exist");
+        let constraint = generic_params[0]
+            .type_constraint
+            .as_ref()
+            .expect("T constraint must exist");
+        assert!(matches!(
+            constraint,
+            LuaType::TplRef(tpl) if tpl.get_tpl_id() == GenericTplId::scoped_type(0, 1)
+        ));
+    }
+
+    #[test]
+    fn test_alias_generic_constraint_can_reference_later_type_param() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias PairAlias<T: U, U> { value: T, upper: U }
+            "#,
+        );
+
+        let db = ws.get_db_mut();
+        let generic_params = db
+            .get_type_index()
+            .get_generic_params(&LuaTypeDeclId::global("PairAlias"))
+            .expect("PairAlias generic params must exist");
+        let constraint = generic_params[0]
+            .type_constraint
+            .as_ref()
+            .expect("T constraint must exist");
+        assert!(matches!(
+            constraint,
+            LuaType::TplRef(tpl) if tpl.get_tpl_id() == GenericTplId::scoped_type(0, 1)
+        ));
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -98,6 +98,26 @@ mod test {
     }
 
     #[test]
+    fn test_generic_inference_combines_multiple_candidates() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param first T
+            ---@param second T
+            ---@return T
+            function choose(first, second) end
+
+            value = choose("name", 1)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        let expected = ws.ty("string|integer");
+        assert_eq!(value_ty, expected);
+    }
+
+    #[test]
     fn test_issue_646() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod test {
     use crate::{DiagnosticCode, VirtualWorkspace};
-    use glua_parser::{LuaCallExpr, LuaExpr};
+    use glua_parser::{LuaAstNode, LuaCallExpr, LuaExpr};
 
     #[test]
     fn test_issue_586() {
@@ -450,6 +450,54 @@ mod test {
         assert_eq!(call_ty, expected);
 
         let seen_ty = ws.expr_ty("union_seen");
+        assert_eq!(seen_ty, ws.ty("string"));
+    }
+
+    #[test]
+    fn test_generic_metatable_call_return_context_flows_into_callback_param() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@generic T, U
+            ---@param cb fun(value: T): U
+            ---@return fun(value: T): U
+            function meta(cb)
+            end
+
+            local wrapper = setmetatable({}, { __call = meta })
+
+            ---@type fun(value: string): number
+            local mapped = wrapper(function(value)
+                metatable_seen = value
+                return 1
+            end)
+            "#,
+        );
+
+        let tree = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .expect("Tree must exist");
+        let call_expr = tree
+            .get_chunk_node()
+            .descendants::<LuaCallExpr>()
+            .last()
+            .expect("Call expression must exist");
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("fun(value: string): number");
+        assert_eq!(call_ty, expected);
+
+        let seen_ty = ws.expr_ty("metatable_seen");
         assert_eq!(seen_ty, ws.ty("string"));
     }
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -502,6 +502,40 @@ mod test {
     }
 
     #[test]
+    fn test_generic_callable_overload_return_context_flows_into_callback_param() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class WrappedArray<T>
+            ---@overload fun<U>(iterator: fun(value: T): U): U[]
+
+            ---@type WrappedArray<string>
+            local array = {}
+
+            ---@type number[]
+            local mapped = array(function(value)
+                callable_overload_seen = value
+                return 1
+            end)
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        assert_eq!(call_ty, ws.ty("number[]"));
+
+        let seen_ty = ws.expr_ty("callable_overload_seen");
+        assert_eq!(seen_ty, ws.ty("string"));
+    }
+
+    #[test]
     fn test_generic_receiver_method_return_context_flows_into_callback_param() {
         let mut ws = VirtualWorkspace::new();
         let file_id = ws.def(
@@ -1207,6 +1241,47 @@ mod test {
         let age_ty = ws.expr_ty("result.age");
         assert_eq!(ws.humanize_type(name_ty), "string");
         assert_eq!(ws.humanize_type(age_ty), "number");
+    }
+
+    #[test]
+    fn test_reverse_mapped_infer_from_reducer_table_literal() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Action
+            ---@field type string
+
+            ---@alias Reducer<S> fun(state: S, action: Action): S
+            ---@alias Reducers<S> { [K in keyof S]: Reducer<S[K]>; }
+
+            ---@generic S
+            ---@param reducers Reducers<S>
+            ---@return Reducer<S>
+            function combine_reducers(reducers) end
+
+            ---@param state string
+            ---@param action Action
+            ---@return string
+            local function test_inner(state, action)
+                return "dummy"
+            end
+
+            local test = combine_reducers({
+                test_inner = test_inner,
+            })
+
+            local test_outer = combine_reducers({
+                test = test,
+            })
+
+            local state = test_outer(nil, nil)
+            result = state.test.test_inner
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        assert_eq!(ws.humanize_type(result_ty), "string");
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -697,6 +697,110 @@ mod test {
     }
 
     #[test]
+    fn test_generic_field_combinator_infers_from_named_callback() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Collection<T>
+            local Collection = {}
+
+            ---@class Combinators
+            ---@field map (fun<T, U>(c: Collection<T>, cb: fun(x: T): U): Collection<U>) | (fun<T>(c: Collection<T>, cb: fun(x: T): any): Collection<any>)
+
+            ---@type Combinators
+            local combinators = {}
+
+            ---@type Collection<number>
+            local collection = {}
+
+            ---@param value number
+            ---@return string
+            local function stringify(value)
+                named_callback_seen = value
+                return ""
+            end
+
+            local result = combinators.map(collection, stringify)
+            "#,
+        );
+
+        let tree = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .expect("Tree must exist");
+        let call_expr = tree
+            .get_chunk_node()
+            .descendants::<LuaCallExpr>()
+            .last()
+            .expect("call expression must exist");
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        assert_eq!(call_ty, ws.ty("Collection<string>"));
+
+        let seen_ty = ws.expr_ty("named_callback_seen");
+        assert_eq!(seen_ty, ws.ty("number"));
+    }
+
+    #[test]
+    fn test_generic_field_combinator_uses_explicit_type_args_for_callback() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@class Collection<T>
+            local Collection = {}
+
+            ---@class Combinators
+            ---@field map (fun<T, U>(c: Collection<T>, cb: fun(x: T): U): Collection<U>) | (fun<T>(c: Collection<T>, cb: fun(x: T): any): Collection<any>)
+
+            ---@type Combinators
+            local combinators = {}
+
+            ---@type Collection<number>
+            local collection = {}
+
+            local result = combinators.map--[[@<number, string>]](collection, function(value)
+                explicit_callback_seen = value
+                return ""
+            end)
+            "#,
+        );
+
+        let tree = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .expect("Tree must exist");
+        let call_expr = tree
+            .get_chunk_node()
+            .descendants::<LuaCallExpr>()
+            .last()
+            .expect("call expression must exist");
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        assert_eq!(call_ty, ws.ty("Collection<string>"));
+
+        let seen_ty = ws.expr_ty("explicit_callback_seen");
+        assert_eq!(seen_ty, ws.ty("number"));
+    }
+
+    #[test]
     fn test_issue_646() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -211,7 +211,7 @@ mod test {
     }
 
     #[test]
-    fn test_generic_direct_candidates_use_common_supertype() {
+    fn test_generic_direct_candidates_use_union() {
         let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
@@ -234,12 +234,12 @@ mod test {
         );
 
         let animal_ty = ws.expr_ty("animal");
-        let expected = ws.ty("Animal");
+        let expected = ws.ty("Dog|Cat");
         assert_eq!(animal_ty, expected);
     }
 
     #[test]
-    fn test_generic_direct_candidates_preserve_generic_common_supertype() {
+    fn test_generic_direct_candidates_use_union_for_generic_subclasses() {
         let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
@@ -262,7 +262,7 @@ mod test {
         );
 
         let box_ty = ws.expr_ty("box");
-        let expected = ws.ty("Box<string|number>");
+        let expected = ws.ty("StringBox|NumberBox");
         assert_eq!(box_ty, expected);
     }
 
@@ -296,7 +296,7 @@ mod test {
     }
 
     #[test]
-    fn test_generic_function_return_candidates_use_common_supertype() {
+    fn test_generic_function_return_candidates_use_union() {
         let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
@@ -321,7 +321,7 @@ mod test {
         );
 
         let animal_ty = ws.expr_ty("animal");
-        let expected = ws.ty("Animal");
+        let expected = ws.ty("Dog|Cat");
         assert_eq!(animal_ty, expected);
     }
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod test {
     use crate::{DiagnosticCode, VirtualWorkspace};
+    use glua_parser::{LuaCallExpr, LuaExpr};
 
     #[test]
     fn test_issue_586() {
@@ -204,6 +205,33 @@ mod test {
         let box_ty = ws.expr_ty("box");
         let expected = ws.ty("Box<string|number>");
         assert_eq!(box_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_return_infers_from_local_doc_context() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@generic T
+            ---@return T
+            function make() end
+
+            ---@type string
+            local value = make()
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("string");
+        assert_eq!(call_ty, expected);
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1395,6 +1395,83 @@ mod test {
     }
 
     #[test]
+    fn test_mapped_type_parameter_constraint_infers_value_union() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@alias ValueRecord<K extends string, V> { [P in K]: V; }
+
+            ---@generic K extends string, V
+            ---@param values ValueRecord<K, V>
+            ---@return V
+            function record_value(values) end
+
+            result = record_value({
+                name = "Ada",
+                age = 42,
+            })
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("result");
+        let value_ty = ws.humanize_type(value_ty);
+        assert!(
+            matches!(value_ty.as_str(), "(integer|string)" | "(string|integer)"),
+            "{value_ty}"
+        );
+    }
+
+    #[test]
+    fn test_mapped_type_parameter_constraint_infers_key_type() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@alias ValueRecord<K extends string, V> { [P in K]: V; }
+
+            ---@generic K extends string, V
+            ---@param values ValueRecord<K, V>
+            ---@return K
+            function record_key(values) end
+
+            key = record_key({
+                name = "Ada",
+            })
+            "#,
+        );
+
+        let key_ty = ws.expr_ty("key");
+        assert_eq!(ws.humanize_type(key_ty), "\"name\"");
+    }
+
+    #[test]
+    fn test_table_generic_index_infers_from_structural_fields() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic V
+            ---@param values table<string, V>
+            ---@return V
+            function table_value(values) end
+
+            result = table_value({
+                name = "Ada",
+                age = 42,
+            })
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("result");
+        let value_ty = ws.humanize_type(value_ty);
+        assert!(
+            matches!(value_ty.as_str(), "(integer|string)" | "(string|integer)"),
+            "{value_ty}"
+        );
+    }
+
+    #[test]
     fn test_reverse_mapped_partial_strips_optional_from_source_field() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -326,6 +326,68 @@ mod test {
     }
 
     #[test]
+    fn test_generic_return_context_flows_into_callback_param() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@generic T, U
+            ---@param cb fun(value: T): U
+            ---@return fun(value: T): U
+            function wrap(cb) end
+
+            ---@type fun(value: string): number
+            local mapped = wrap(function(value)
+                seen = value
+                return 1
+            end)
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("fun(value: string): number");
+        assert_eq!(call_ty, expected);
+
+        let seen_ty = ws.expr_ty("seen");
+        assert_eq!(seen_ty, ws.ty("string"));
+    }
+
+    #[test]
+    fn test_generic_return_context_does_not_override_arg_inference() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return T
+            function id(value) end
+
+            ---@type string
+            local value = id(1)
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("integer");
+        assert_eq!(call_ty, expected);
+    }
+
+    #[test]
     fn test_issue_646() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1395,6 +1395,30 @@ mod test {
     }
 
     #[test]
+    fn test_reverse_mapped_partial_strips_optional_from_source_field() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@alias Partial<T> { [P in keyof T]?: T[P]; }
+
+            ---@generic T
+            ---@param values Partial<T>
+            ---@return T
+            function restore_partial(values) end
+
+            ---@type {name?: string}
+            local values
+
+            result = restore_partial(values)
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("result.name");
+        assert_eq!(ws.humanize_type(name_ty), "string");
+    }
+
+    #[test]
     fn test_reverse_mapped_infer_through_generic_wrapper() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -615,10 +615,112 @@ mod test {
         let call_ty = semantic_model
             .infer_expr(LuaExpr::CallExpr(call_expr))
             .expect("Call type must resolve");
-        let expected = ws.ty("fun(value: string): number");
+        let expected = ws.ty("fun(value: string): integer");
         assert_eq!(call_ty, expected);
 
         let seen_ty = ws.expr_ty("seen");
+        assert_eq!(seen_ty, ws.ty("string"));
+    }
+
+    #[test]
+    fn test_generic_array_map_return_context_flows_into_callback_param() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@alias ValueBox<T> { value: T }
+
+            ---@generic T, U
+            ---@param cb fun(value: T): U
+            ---@return fun(values: T[]): U[]
+            function array_map(cb) end
+
+            ---@type fun(values: string[]): ValueBox<string>[]
+            local mapped = array_map(function(value)
+                array_map_seen = value
+                return { value = value }
+            end)
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("fun(values: string[]): { value: string }[]");
+        assert_eq!(call_ty, expected);
+
+        let seen_ty = ws.expr_ty("array_map_seen");
+        assert_eq!(seen_ty, ws.ty("string"));
+    }
+
+    #[test]
+    fn test_generic_array_map_generic_return_context_preserves_contextual_type_param() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@alias ValueBox<T> { value: T }
+
+            ---@generic T, U
+            ---@param cb fun(value: T): U
+            ---@return fun(values: T[]): U[]
+            function array_map(cb) end
+
+            ---@type fun<A>(values: A[]): ValueBox<A>[]
+            local mapped = array_map(function(value)
+                return { value = value }
+            end)
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("fun<A>(values: A[]): { value: A }[]");
+        assert_eq!(call_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_array_map_callback_return_overrides_contextual_return_candidate() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@generic T, U
+            ---@param cb fun(value: T): U
+            ---@return fun(values: T[]): U[]
+            function array_map(cb) end
+
+            ---@type fun(values: string[]): number[]
+            local mapped = array_map(function(value)
+                array_map_priority_seen = value
+                return "text"
+            end)
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("fun(values: string[]): string[]");
+        assert_eq!(call_ty, expected);
+
+        let seen_ty = ws.expr_ty("array_map_priority_seen");
         assert_eq!(seen_ty, ws.ty("string"));
     }
 
@@ -676,7 +778,7 @@ mod test {
         let call_ty = semantic_model
             .infer_expr(LuaExpr::CallExpr(call_expr))
             .expect("Call type must resolve");
-        let expected = ws.ty("fun(value: string): number");
+        let expected = ws.ty("fun(value: string): integer");
         assert_eq!(call_ty, expected);
 
         let seen_ty = ws.expr_ty("overloaded_seen");
@@ -709,7 +811,7 @@ mod test {
         let call_ty = semantic_model
             .infer_expr(LuaExpr::CallExpr(call_expr))
             .expect("Call type must resolve");
-        let expected = ws.ty("fun(value: string): number");
+        let expected = ws.ty("fun(value: string): integer");
         assert_eq!(call_ty, expected);
 
         let seen_ty = ws.expr_ty("union_seen");
@@ -757,7 +859,7 @@ mod test {
         let call_ty = semantic_model
             .infer_expr(LuaExpr::CallExpr(call_expr))
             .expect("Call type must resolve");
-        let expected = ws.ty("fun(value: string): number");
+        let expected = ws.ty("fun(value: string): integer");
         assert_eq!(call_ty, expected);
 
         let seen_ty = ws.expr_ty("metatable_seen");
@@ -792,7 +894,7 @@ mod test {
         let call_ty = semantic_model
             .infer_expr(LuaExpr::CallExpr(call_expr))
             .expect("Call type must resolve");
-        assert_eq!(call_ty, ws.ty("number[]"));
+        assert_eq!(call_ty, ws.ty("integer[]"));
 
         let seen_ty = ws.expr_ty("callable_overload_seen");
         assert_eq!(seen_ty, ws.ty("string"));
@@ -826,7 +928,7 @@ mod test {
         let call_ty = semantic_model
             .infer_expr(LuaExpr::CallExpr(call_expr))
             .expect("Call type must resolve");
-        let expected = ws.ty("WrappedArray<number>");
+        let expected = ws.ty("WrappedArray<integer>");
         assert_eq!(call_ty, expected);
 
         let seen_ty = ws.expr_ty("receiver_seen");

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -590,6 +590,31 @@ mod test {
     }
 
     #[test]
+    fn test_conditional_infer_combines_repeated_candidates() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Pair<A, B>
+            ---@alias InferPair<T> T extends Pair<infer U, infer U> and U or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return InferPair<T>
+            function infer_pair(value) end
+
+            ---@type Pair<string, number>
+            local pair
+
+            value = infer_pair(pair)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "(string|number)");
+    }
+
+    #[test]
     fn test_generic_identity_table_literal_still_allows_later_field_inference() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1514,6 +1514,47 @@ mod test {
     }
 
     #[test]
+    fn test_full_reverse_mapped_inference_beats_partial_candidate() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@field value T
+
+            ---@alias Boxified<T> { [K in keyof T]: Box<T[K]>; }
+
+            ---@generic T
+            ---@param value T
+            ---@return Box<T>
+            function box(value) end
+
+            ---@generic T
+            ---@param partial Boxified<T>
+            ---@param full Boxified<T>
+            ---@return T
+            function prefer_full(partial, full) end
+
+            local partial = {
+                stale = box("partial"),
+                skipped = true,
+            }
+
+            local full = {
+                fresh = box(42),
+            }
+
+            result = prefer_full(partial, full)
+            "#,
+        );
+
+        let stale_ty = ws.expr_ty("result.stale");
+        let fresh_ty = ws.expr_ty("result.fresh");
+        assert_eq!(ws.humanize_type(stale_ty), "nil");
+        assert_eq!(ws.humanize_type(fresh_ty), "integer");
+    }
+
+    #[test]
     fn test_mapped_inference_is_lower_priority_than_direct_inference() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1372,6 +1372,29 @@ mod test {
     }
 
     #[test]
+    fn test_reverse_mapped_infer_pick_key_constraint_key_type() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@alias Pick<T, K extends keyof T> { [P in K]: T[P]; }
+
+            ---@generic T, K extends keyof T
+            ---@param values Pick<T, K>
+            ---@return K
+            function picked_key(values) end
+
+            key = picked_key({
+                name = "Ada",
+            })
+            "#,
+        );
+
+        let key_ty = ws.expr_ty("key");
+        assert_eq!(ws.humanize_type(key_ty), "\"name\"");
+    }
+
+    #[test]
     fn test_reverse_mapped_infer_through_generic_wrapper() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -438,6 +438,616 @@ mod test {
     }
 
     #[test]
+    fn test_mapped_infer_from_generic_function_table_literal() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+
+            ---@alias InferShape<T> { [K in keyof T]: T[K] extends Schema<infer U> and U or unknown; }
+
+            ---@return Schema<string>
+            function mk_string() end
+
+            ---@return Schema<number>
+            function mk_number() end
+
+            ---@generic T
+            ---@param schema T
+            ---@return InferShape<T>
+            function object(schema) end
+
+            result = object({
+                name = mk_string(),
+                age = mk_number(),
+            })
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("result.name");
+        let age_ty = ws.expr_ty("result.age");
+        assert_eq!(ws.humanize_type(name_ty), "string");
+        assert_eq!(ws.humanize_type(age_ty), "number");
+    }
+
+    #[test]
+    fn test_mapped_infer_from_generic_function_table_variable() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+
+            ---@alias InferShape<T> { [K in keyof T]: T[K] extends Schema<infer U> and U or unknown; }
+
+            ---@return Schema<string>
+            function mk_string() end
+
+            ---@return Schema<number>
+            function mk_number() end
+
+            ---@generic T
+            ---@param schema T
+            ---@return InferShape<T>
+            function object(schema) end
+
+            local shape = {
+                name = mk_string(),
+                age = mk_number(),
+            }
+            result = object(shape)
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("result.name");
+        let age_ty = ws.expr_ty("result.age");
+        assert_eq!(ws.humanize_type(name_ty), "string");
+        assert_eq!(ws.humanize_type(age_ty), "number");
+    }
+
+    #[test]
+    fn test_conditional_infer_from_concrete_class_super_generic() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+            ---@class StringSchema: Schema<string>
+            ---@class NumberSchema: Schema<number>
+
+            ---@alias Infer<T> T extends Schema<infer U> and U or unknown
+            ---@alias InferShape<T> { [K in keyof T]: Infer<T[K]>; }
+
+            ---@return StringSchema
+            function mk_string() end
+
+            ---@return NumberSchema
+            function mk_number() end
+
+            ---@generic T
+            ---@param schema T
+            ---@return InferShape<T>
+            function object(schema) end
+
+            result = object({
+                name = mk_string(),
+                age = mk_number(),
+            })
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("result.name");
+        let age_ty = ws.expr_ty("result.age");
+        assert_eq!(ws.humanize_type(name_ty), "string");
+        assert_eq!(ws.humanize_type(age_ty), "number");
+    }
+
+    #[test]
+    fn test_conditional_infer_from_generic_alias_source() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+            ---@alias Wrapped<T> Schema<T>
+            ---@alias Infer<T> T extends Schema<infer U> and U or unknown
+
+            ---@generic T
+            ---@param schema T
+            ---@return Infer<T>
+            function infer(schema) end
+
+            ---@type Wrapped<string>
+            local wrapped
+
+            value = infer(wrapped)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "string");
+    }
+
+    #[test]
+    fn test_generic_identity_table_literal_still_allows_later_field_inference() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return T
+            function identity(value) end
+
+            local result = identity({})
+            result.name = "abc"
+            value = result.name
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "\"abc\"");
+    }
+
+    #[test]
+    fn test_generic_identity_object_literal_still_allows_later_field_inference() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return T
+            function identity(value) end
+
+            result = identity({ name = "abc" })
+            "#,
+        );
+        ws.def(
+            r#"
+            function add_field()
+                result.age = 1
+            end
+            value = result.age
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "1");
+    }
+
+    #[test]
+    fn test_generic_identity_object_literal_preserves_raw_table_when_structural_field_fails() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return T
+            function identity(value) end
+
+            ---@type unknown
+            local source
+
+            result = identity({ name = source.missing })
+            "#,
+        );
+        ws.def(
+            r#"
+            function add_field()
+                result.age = 1
+            end
+            value = result.age
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "1");
+    }
+
+    #[test]
+    fn test_generic_identity_object_literal_preserves_raw_table_when_structural_key_fails() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return T
+            function identity(value) end
+
+            result = identity({ [missing_key] = "abc" })
+            "#,
+        );
+        ws.def(
+            r#"
+            function add_field()
+                result.age = 1
+            end
+            value = result.age
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "1");
+    }
+
+    #[test]
+    fn test_generic_nullable_identity_object_literal_still_allows_later_field_inference() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T
+            ---@return T?
+            function identity(value) end
+
+            result = identity({ name = "abc" })
+            "#,
+        );
+        ws.def(
+            r#"
+            function add_field()
+                result.age = 1
+            end
+            value = result.age
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "1");
+    }
+
+    #[test]
+    fn test_generic_nullable_param_identity_object_literal_still_allows_later_field_inference() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@generic T
+            ---@param value T?
+            ---@return T?
+            function identity(value) end
+
+            result = identity({ name = "abc" })
+            "#,
+        );
+        ws.def(
+            r#"
+            function add_field()
+                result.age = 1
+            end
+            value = result.age
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "1");
+    }
+
+    #[test]
+    fn test_alias_generic_does_not_replace_shadowed_mapped_key() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@alias Shadow<T> { [T in "name"]: T; }
+
+            ---@type Shadow<number>
+            local shadow
+
+            shadowName = shadow.name
+            "#,
+        );
+
+        let shadow_name_ty = ws.expr_ty("shadowName");
+        assert_eq!(ws.humanize_type(shadow_name_ty), "string");
+    }
+
+    #[test]
+    fn test_conditional_infer_requires_generic_base_match() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+            ---@field parse fun(self: Schema<T>, value: unknown): T
+            ---@class ObjectSchema<T>: Schema<T>
+            ---@class ArraySchema<T>: Schema<T[]>
+            ---@class OptionalSchema<T>: Schema<T>
+
+            ---@alias InferShape<T> { [K in keyof T]: T[K] extends ArraySchema<infer U> and U[] or T[K] extends ObjectSchema<infer U> and U or T[K] extends OptionalSchema<infer U> and U or T[K] extends Schema<infer U> and U or unknown; }
+
+            ---@return Schema<string>
+            function mk_string() end
+
+            ---@return Schema<number>
+            function mk_number() end
+
+            ---@return Schema<boolean>
+            function mk_boolean() end
+
+            ---@generic T
+            ---@param schema T
+            ---@return ObjectSchema<InferShape<T>>
+            function object(schema) end
+
+            ---@generic T
+            ---@param schema Schema<T>
+            ---@return ArraySchema<T>
+            function array(schema) end
+
+            ---@generic T
+            ---@param schema Schema<T>
+            ---@return OptionalSchema<T|nil>
+            function optional(schema) end
+
+            ---@generic T
+            ---@param schema T
+            ---@return InferShape<T>
+            function infer_shape(schema) end
+
+            schema = object({
+                name = mk_string(),
+                age = mk_number(),
+                admin = mk_boolean(),
+                tags = array(mk_string()),
+                profile = object({
+                    id = mk_string(),
+                    score = optional(mk_number()),
+                }),
+            })
+
+            parsed = schema:parse({})
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("parsed.name");
+        let age_ty = ws.expr_ty("parsed.age");
+        let admin_ty = ws.expr_ty("parsed.admin");
+        let profile_ty = ws.expr_ty("parsed.profile");
+        let id_ty = ws.expr_ty("parsed.profile.id");
+        let score_ty = ws.expr_ty("parsed.profile.score");
+        let tags_ty = ws.expr_ty("parsed.tags");
+        assert_eq!(ws.humanize_type(name_ty), "string");
+        assert_eq!(ws.humanize_type(age_ty), "number");
+        assert_eq!(ws.humanize_type(admin_ty), "boolean");
+        assert_eq!(
+            ws.humanize_type(profile_ty),
+            "{ id: string, score: number? }"
+        );
+        assert_eq!(ws.humanize_type(id_ty), "string");
+        assert_eq!(ws.humanize_type(score_ty), "number?");
+        assert_eq!(ws.humanize_type(tags_ty), "string[]");
+    }
+
+    #[test]
+    fn test_builder_namespace_method_chain_and_variable_shape_infer_parse_result() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Schema<T>
+            ---@field parse fun(self: Schema<T>, value: unknown): T
+            ---@field optional fun(self: Schema<T>): OptionalSchema<T|nil>
+            ---@class StringSchema: Schema<string>
+            ---@class NumberSchema: Schema<number>
+            ---@class BooleanSchema: Schema<boolean>
+            ---@class ObjectSchema<T>: Schema<T>
+            ---@class ArraySchema<T>: Schema<T[]>
+            ---@class OptionalSchema<T>: Schema<T>
+
+            ---@alias InferShape<T> { [K in keyof T]: T[K] extends ArraySchema<infer U> and U[] or T[K] extends ObjectSchema<infer U> and U or T[K] extends OptionalSchema<infer U> and U or T[K] extends Schema<infer U> and U or unknown; }
+
+            ---@class Z
+            ---@field string fun(): StringSchema
+            ---@field number fun(): NumberSchema
+            ---@field boolean fun(): BooleanSchema
+            ---@field array fun<T>(schema: Schema<T>): ArraySchema<T>
+            ---@field object fun<T>(shape: T): ObjectSchema<InferShape<T>>
+
+            ---@type Z
+            local z
+
+            local inline_schema = z.object({
+                name = z.string(),
+                age = z.number(),
+                admin = z.boolean(),
+                tags = z.array(z.string()),
+                profile = z.object({
+                    id = z.string(),
+                    score = z.number():optional(),
+                }),
+            })
+            parsed_inline = inline_schema:parse({})
+
+            local shape = {
+                profile = z.object({
+                    id = z.string(),
+                    score = z.number():optional(),
+                }),
+            }
+            local variable_schema = z.object(shape)
+            parsed_variable = variable_schema:parse({})
+            "#,
+        );
+
+        let inline_name_ty = ws.expr_ty("parsed_inline.name");
+        let inline_age_ty = ws.expr_ty("parsed_inline.age");
+        let inline_admin_ty = ws.expr_ty("parsed_inline.admin");
+        let inline_tags_ty = ws.expr_ty("parsed_inline.tags");
+        let inline_profile_ty = ws.expr_ty("parsed_inline.profile");
+        let inline_id_ty = ws.expr_ty("parsed_inline.profile.id");
+        let inline_score_ty = ws.expr_ty("parsed_inline.profile.score");
+        let variable_id_ty = ws.expr_ty("parsed_variable.profile.id");
+        let variable_score_ty = ws.expr_ty("parsed_variable.profile.score");
+        assert_eq!(ws.humanize_type(inline_name_ty), "string");
+        assert_eq!(ws.humanize_type(inline_age_ty), "number");
+        assert_eq!(ws.humanize_type(inline_admin_ty), "boolean");
+        assert_eq!(ws.humanize_type(inline_tags_ty), "string[]");
+        assert_eq!(
+            ws.humanize_type(inline_profile_ty),
+            "{ id: string, score: number? }"
+        );
+        assert_eq!(ws.humanize_type(inline_id_ty), "string");
+        assert_eq!(ws.humanize_type(inline_score_ty), "number?");
+        assert_eq!(ws.humanize_type(variable_id_ty), "string");
+        assert_eq!(ws.humanize_type(variable_score_ty), "number?");
+    }
+
+    #[test]
+    fn test_conditional_infer_handles_cyclic_concrete_supers() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Target<T>
+            ---@class A: B
+            ---@class B: A
+
+            ---@alias Extract<T> T extends Target<infer U> and U or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return Extract<T>
+            function extract(value) end
+
+            ---@type A
+            local source
+
+            value = extract(source)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "unknown");
+    }
+
+    #[test]
+    fn test_conditional_infer_handles_cyclic_generic_supers() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Target<T>
+            ---@class A<T>: B<T>
+            ---@class B<T>: A<T>
+
+            ---@alias Extract<T> T extends Target<infer U> and U or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return Extract<T>
+            function extract(value) end
+
+            ---@type A<string>
+            local source
+
+            value = extract(source)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "unknown");
+    }
+
+    #[test]
+    fn test_conditional_infer_function_return_uses_independent_guard() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Target<T>
+            ---@class Source<T>: Target<T>
+
+            ---@alias ExtractArg<F> F extends (fun(...: Target<infer A>): Target<infer B>) and A or unknown
+            ---@alias ExtractRet<F> F extends (fun(...: Target<infer A>): Target<infer B>) and B or unknown
+
+            ---@generic F
+            ---@param f F
+            ---@return ExtractArg<F>
+            function extract_arg(f) end
+
+            ---@generic F
+            ---@param f F
+            ---@return ExtractRet<F>
+            function extract_ret(f) end
+
+            ---@param ... Source<string>
+            ---@return Source<number>
+            function fn(...) end
+
+            arg = extract_arg(fn)
+            ret = extract_ret(fn)
+            "#,
+        );
+
+        let arg_ty = ws.expr_ty("arg");
+        let ret_ty = ws.expr_ty("ret");
+        assert_eq!(ws.humanize_type(arg_ty), "string");
+        assert_eq!(ws.humanize_type(ret_ty), "number");
+    }
+
+    #[test]
+    fn test_conditional_infer_instantiates_nested_generic_super_with_decl_tpl_id() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Pair<A, B>
+
+            ---@generic Outer
+            function setup()
+                ---@class Nested<Inner>: Pair<Outer, Inner>
+            end
+
+            ---@alias ExtractInner<T> T extends Pair<any, infer U> and U or unknown
+
+            ---@type ExtractInner<Nested<string>>
+            value = nil
+            "#,
+        );
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param value number
+            function take_number(value) end
+
+            take_number(value)
+            "#,
+        ));
+    }
+
+    #[test]
+    fn test_nested_generic_super_member_instantiates_decl_tpl_id() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Base<T>
+            ---@field value T
+
+            ---@generic Outer
+            function setup()
+                ---@class Nested<Inner>: Base<Inner>
+            end
+
+            ---@type Nested<string>
+            local nested
+
+            value = nested.value
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "string");
+    }
+
+    #[test]
     fn test_infer_new_constructor() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1032,6 +1032,61 @@ mod test {
     }
 
     #[test]
+    fn test_generic_tuple_callbacks_share_intra_expression_inference() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias Producer<T> fun(): T
+            ---@alias Consumer<T> fun(value: T)
+
+            ---@generic T
+            ---@param callbacks [Producer<T>, Consumer<T>]
+            function use_callbacks(callbacks) end
+
+            use_callbacks({
+                function()
+                    return 1
+                end,
+                function(value)
+                    tuple_callback_seen = value
+                end,
+            })
+            "#,
+        );
+
+        let seen_ty = ws.expr_ty("tuple_callback_seen");
+        assert_eq!(seen_ty, ws.ty("integer"));
+    }
+
+    #[test]
+    fn test_generic_object_callbacks_share_intra_expression_inference() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias Producer<T> fun(): T
+            ---@alias Consumer<T> fun(value: T)
+            ---@alias CallbackPair<T> { produce: Producer<T>, consume: Consumer<T> }
+
+            ---@generic T
+            ---@param callbacks CallbackPair<T>
+            function use_callbacks(callbacks) end
+
+            use_callbacks({
+                produce = function()
+                    return "value"
+                end,
+                consume = function(value)
+                    object_callback_seen = value
+                end,
+            })
+            "#,
+        );
+
+        let seen_ty = ws.expr_ty("object_callback_seen");
+        assert_eq!(seen_ty, ws.ty("string"));
+    }
+
+    #[test]
     fn test_generic_combinator_uses_first_arg_to_type_callback_params() {
         let mut ws = VirtualWorkspace::new();
         let file_id = ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -677,6 +677,32 @@ mod test {
     }
 
     #[test]
+    fn test_conditional_infer_collects_from_matching_pattern_union_members() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Left<T>
+            ---@class Right<T>
+            ---@alias Extract<T> T extends (Left<infer U>|Right<infer U>) and U or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return Extract<T>
+            function extract(value) end
+
+            ---@type Left<string>|Right<number>
+            local source
+
+            value = extract(source)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(ws.humanize_type(value_ty), "(string|number)");
+    }
+
+    #[test]
     fn test_generic_identity_table_literal_still_allows_later_field_inference() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1349,6 +1349,29 @@ mod test {
     }
 
     #[test]
+    fn test_reverse_mapped_infer_through_pick_key_constraint() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@alias Pick<T, K extends keyof T> { [P in K]: T[P]; }
+
+            ---@generic T, K extends keyof T
+            ---@param values Pick<T, K>
+            ---@return T
+            function restore_pick(values) end
+
+            result = restore_pick({
+                name = "Ada",
+            })
+            "#,
+        );
+
+        let name_ty = ws.expr_ty("result.name");
+        assert_eq!(ws.humanize_type(name_ty), "\"Ada\"");
+    }
+
+    #[test]
     fn test_reverse_mapped_infer_through_generic_wrapper() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -440,6 +440,40 @@ mod test {
     }
 
     #[test]
+    fn test_generic_mixed_candidates_use_contra_when_dependent_constraint_conflicts() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Animal
+            ---@class Dog: Animal
+            ---@class Cat: Animal
+
+            ---@generic T, U: T
+            ---@param value T
+            ---@param callback fun(value: T)
+            ---@param other U
+            ---@return T
+            function use_related(value, callback, other) end
+
+            ---@type Dog
+            local dog
+
+            ---@param value Animal
+            local function accepts_animal(value) end
+
+            ---@type Cat
+            local cat
+
+            result = use_related(dog, accepts_animal, cat)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        let expected = ws.ty("Animal");
+        assert_eq!(result_ty, expected);
+    }
+
+    #[test]
     fn test_generic_return_infers_from_local_doc_context() {
         let mut ws = VirtualWorkspace::new();
         let file_id = ws.def(
@@ -826,6 +860,33 @@ mod test {
 
             ---@type integer
             local value = make_string()
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("string");
+        assert_eq!(call_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_return_context_filters_union_by_type_constraint() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@generic T: string|number
+            ---@return T
+            function make_value() end
+
+            ---@type string|boolean
+            local value = make_value()
             "#,
         );
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1285,6 +1285,30 @@ mod test {
     }
 
     #[test]
+    fn test_mapped_inference_is_lower_priority_than_direct_inference() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@alias Mirror<T> { [K in keyof T]: T[K]; }
+
+            ---@generic T
+            ---@param secondary Mirror<T>
+            ---@param primary T
+            ---@return T
+            function mapped_then_direct(secondary, primary) end
+
+            result = mapped_then_direct({ x = 1 }, { x = "direct", y = "name" })
+            "#,
+        );
+
+        let x_ty = ws.expr_ty("result.x");
+        let y_ty = ws.expr_ty("result.y");
+        assert_eq!(ws.humanize_type(x_ty), "\"direct\"");
+        assert_eq!(ws.humanize_type(y_ty), "\"name\"");
+    }
+
+    #[test]
     fn test_conditional_infer_from_concrete_class_super_generic() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -753,6 +753,40 @@ mod test {
     }
 
     #[test]
+    fn test_conditional_infer_pattern_union_does_not_use_naked_fallback_after_structural_match() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@alias ExtractA<T> T extends (Box<infer A>|infer B) and A or unknown
+            ---@alias ExtractB<T> T extends (Box<infer A>|infer B) and B or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return ExtractA<T>
+            function extract_a(value) end
+
+            ---@generic T
+            ---@param value T
+            ---@return ExtractB<T>
+            function extract_b(value) end
+
+            ---@type Box<string>
+            local source
+
+            a = extract_a(source)
+            b = extract_b(source)
+            "#,
+        );
+
+        let a_ty = ws.expr_ty("a");
+        let b_ty = ws.expr_ty("b");
+        assert_eq!(ws.humanize_type(a_ty), "string");
+        assert_eq!(ws.humanize_type(b_ty), "unknown");
+    }
+
+    #[test]
     fn test_generic_identity_table_literal_still_allows_later_field_inference() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -109,12 +109,45 @@ mod test {
             function choose(first, second) end
 
             value = choose("name", 1)
+            other = choose("name", "other")
             "#,
         );
 
         let value_ty = ws.expr_ty("value");
         let expected = ws.ty("string|integer");
         assert_eq!(value_ty, expected);
+
+        let other_ty = ws.expr_ty("other");
+        let expected = ws.ty("string");
+        assert_eq!(other_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_literal_widening_keeps_raw_type_for_conditional() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias IsName<T> T extends "name" and true or false
+
+            ---@generic T
+            ---@param value T
+            ---@return T
+            function identity(value) end
+
+            ---@generic T
+            ---@param value T
+            ---@return IsName<T>
+            function is_name(value) end
+
+            widened = identity("name")
+            matched = is_name("name")
+            "#,
+        );
+
+        let widened_ty = ws.expr_ty("widened");
+        let matched_ty = ws.expr_ty("matched");
+        assert_eq!(ws.humanize_type(widened_ty), "string");
+        assert_eq!(ws.humanize_type(matched_ty), "true");
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -208,6 +208,65 @@ mod test {
     }
 
     #[test]
+    fn test_generic_function_parameter_candidates_use_common_subtype() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Animal
+            ---@class Dog: Animal
+
+            ---@generic T
+            ---@param first fun(value: T)
+            ---@param second fun(value: T)
+            ---@return T
+            function choose_callback_value(first, second) end
+
+            ---@param value Animal
+            local function accepts_animal(value) end
+
+            ---@param value Dog
+            local function accepts_dog(value) end
+
+            dog = choose_callback_value(accepts_animal, accepts_dog)
+            "#,
+        );
+
+        let dog_ty = ws.expr_ty("dog");
+        let expected = ws.ty("Dog");
+        assert_eq!(dog_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_function_return_candidates_use_common_supertype() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Animal
+            ---@class Dog: Animal
+            ---@class Cat: Animal
+
+            ---@generic T
+            ---@param first fun(): T
+            ---@param second fun(): T
+            ---@return T
+            function choose_producer_value(first, second) end
+
+            ---@return Dog
+            local function make_dog() end
+
+            ---@return Cat
+            local function make_cat() end
+
+            animal = choose_producer_value(make_dog, make_cat)
+            "#,
+        );
+
+        let animal_ty = ws.expr_ty("animal");
+        let expected = ws.ty("Animal");
+        assert_eq!(animal_ty, expected);
+    }
+
+    #[test]
     fn test_generic_return_infers_from_local_doc_context() {
         let mut ws = VirtualWorkspace::new();
         let file_id = ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -816,6 +816,33 @@ mod test {
     }
 
     #[test]
+    fn test_generic_return_context_respects_type_constraint() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+            ---@generic T: string
+            ---@return T
+            function make_string() end
+
+            ---@type integer
+            local value = make_string()
+            "#,
+        );
+
+        let call_expr = ws.get_node::<LuaCallExpr>(file_id);
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("Semantic model must exist");
+        let call_ty = semantic_model
+            .infer_expr(LuaExpr::CallExpr(call_expr))
+            .expect("Call type must resolve");
+        let expected = ws.ty("string");
+        assert_eq!(call_ty, expected);
+    }
+
+    #[test]
     fn test_generic_overload_return_context_flows_into_callback_param() {
         let mut ws = VirtualWorkspace::new();
         let file_id = ws.def(

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -1555,6 +1555,81 @@ mod test {
     }
 
     #[test]
+    fn test_reverse_mapped_collects_full_candidates_after_first_mapped_candidate() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@field value T
+
+            ---@alias Boxified<T> { [K in keyof T]: Box<T[K]>; }
+
+            ---@generic T
+            ---@param value T
+            ---@return Box<T>
+            function box(value) end
+
+            ---@generic T
+            ---@param first Boxified<T>
+            ---@param second Boxified<T>
+            ---@return T
+            function merge_boxified(first, second) end
+
+            local first = {
+                value = box("first"),
+            }
+
+            local second = {
+                value = box(42),
+            }
+
+            result = merge_boxified(first, second)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("result.value");
+        assert_eq!(ws.humanize_type(value_ty), "(string|integer)");
+    }
+
+    #[test]
+    fn test_inline_reverse_mapped_partial_does_not_block_later_full_candidate() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Box<T>
+            ---@field value T
+
+            ---@alias Boxified<T> { [K in keyof T]: Box<T[K]>; }
+
+            ---@generic T
+            ---@param value T
+            ---@return Box<T>
+            function box(value) end
+
+            ---@generic T
+            ---@param partial Boxified<T>
+            ---@param full Boxified<T>
+            ---@return T
+            function prefer_full(partial, full) end
+
+            result = prefer_full({
+                stale = box("partial"),
+                skipped = true,
+            }, {
+                fresh = box(42),
+            })
+            "#,
+        );
+
+        let stale_ty = ws.expr_ty("result.stale");
+        let fresh_ty = ws.expr_ty("result.fresh");
+        assert_eq!(ws.humanize_type(stale_ty), "nil");
+        assert_eq!(ws.humanize_type(fresh_ty), "integer");
+    }
+
+    #[test]
     fn test_mapped_inference_is_lower_priority_than_direct_inference() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/compilation/test/generic_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/generic_test.rs
@@ -503,6 +503,64 @@ mod test {
     }
 
     #[test]
+    fn test_generic_dependent_constraint_instantiates_later_type_param_through_alias() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Animal
+            ---@class Dog: Animal
+            ---@alias Upper<T> T
+
+            ---@generic T: Upper<U>, U
+            ---@param value T
+            ---@param upper U
+            ---@return T
+            function keep_specific(value, upper) end
+
+            ---@type Dog
+            local dog
+
+            ---@type Animal
+            local animal
+
+            result = keep_specific(dog, animal)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        let expected = ws.ty("Dog");
+        assert_eq!(result_ty, expected);
+    }
+
+    #[test]
+    fn test_generic_constraint_falls_back_to_instantiated_alias_constraint() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@alias Upper<T> T
+
+            ---@generic T: Upper<U>, U
+            ---@param value T
+            ---@param upper U
+            ---@return T
+            function constrained(value, upper) end
+
+            ---@type string
+            local text
+
+            ---@type integer
+            local count
+
+            result = constrained(text, count)
+            "#,
+        );
+
+        let result_ty = ws.expr_ty("result");
+        let expected = ws.ty("integer");
+        assert_eq!(result_ty, expected);
+    }
+
+    #[test]
     fn test_class_generic_constraint_can_reference_later_type_param() {
         let mut ws = VirtualWorkspace::new();
         ws.def(
@@ -2526,6 +2584,85 @@ mod test {
 
         let value_ty = ws.expr_ty("value");
         assert_eq!(ws.humanize_type(value_ty), "(string|number)");
+    }
+
+    #[test]
+    fn test_conditional_infer_uses_generic_type_parameter_constraint() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Pair<T, U: T>
+            ---@alias InferSecond<T> T extends Pair<integer, infer U> and U or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return InferSecond<T>
+            function infer_second(value) end
+
+            ---@type Pair<integer, string>
+            local pair
+
+            value = infer_second(pair)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(value_ty, ws.ty("integer"));
+    }
+
+    #[test]
+    fn test_conditional_infer_constraint_uses_outer_mapper() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Pair<T, U: T>
+            ---@alias InferSecond<Q, T> T extends Pair<Q, infer U> and U or unknown
+
+            ---@generic Q, T
+            ---@param value T
+            ---@param upper Q
+            ---@return InferSecond<Q, T>
+            function infer_second(value, upper) end
+
+            ---@type Pair<integer, string>
+            local pair
+
+            ---@type integer
+            local count
+
+            value = infer_second(pair, count)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(value_ty, ws.ty("integer"));
+    }
+
+    #[test]
+    fn test_conditional_infer_constraint_can_reference_other_infer_param() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Pair<T, U: T>
+            ---@alias InferSecond<T> T extends Pair<infer A, infer B> and B or unknown
+
+            ---@generic T
+            ---@param value T
+            ---@return InferSecond<T>
+            function infer_second(value) end
+
+            ---@type Pair<integer, string>
+            local pair
+
+            value = infer_second(pair)
+            "#,
+        );
+
+        let value_ty = ws.expr_ty("value");
+        assert_eq!(value_ty, ws.ty("integer"));
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/db_index/type/generic_param.rs
+++ b/crates/glua_code_analysis/src/db_index/type/generic_param.rs
@@ -1,12 +1,13 @@
 use smol_str::SmolStr;
 
-use crate::{LuaAttributeUse, LuaType};
+use crate::{GenericTplId, LuaAttributeUse, LuaType};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GenericParam {
     pub name: SmolStr,
     pub type_constraint: Option<LuaType>,
     pub attributes: Option<Vec<LuaAttributeUse>>,
+    pub tpl_id: Option<GenericTplId>,
 }
 
 impl GenericParam {
@@ -19,6 +20,12 @@ impl GenericParam {
             name,
             type_constraint,
             attributes,
+            tpl_id: None,
         }
+    }
+
+    pub fn with_tpl_id(mut self, tpl_id: GenericTplId) -> Self {
+        self.tpl_id = Some(tpl_id);
+        self
     }
 }

--- a/crates/glua_code_analysis/src/db_index/type/humanize_type.rs
+++ b/crates/glua_code_analysis/src/db_index/type/humanize_type.rs
@@ -552,7 +552,8 @@ fn humanize_generic_type(db: &DbIndex, generic: &LuaGenericType, level: RenderLe
         RenderLevel::Documentation | RenderLevel::CustomDetailed(_) | RenderLevel::Detailed
     ) && type_decl.is_alias()
     {
-        let substituor = TypeSubstitutor::from_type_array(generic.get_params().clone());
+        let substituor =
+            TypeSubstitutor::from_type_array_for_type(db, &base_id, generic.get_params().clone());
         if let Some(origin_type) = type_decl.get_alias_origin(db, Some(&substituor)) {
             // prevent infinite recursion
             let origin_type_str = humanize_type(db, &origin_type, level.next_level());

--- a/crates/glua_code_analysis/src/db_index/type/types.rs
+++ b/crates/glua_code_analysis/src/db_index/type/types.rs
@@ -535,9 +535,12 @@ impl TypeVisitTrait for LuaType {
                     param.visit_type(f);
                 }
             }
+            LuaType::Instance(inst) => inst.visit_type(f),
             LuaType::MultiLineUnion(inner) => inner.visit_type(f),
             LuaType::TypeGuard(inner) => inner.visit_type(f),
+            LuaType::DocAttribute(attribute) => attribute.visit_type(f),
             LuaType::Conditional(inner) => inner.visit_type(f),
+            LuaType::Mapped(mapped) => mapped.visit_type(f),
             LuaType::TableOf(inner) => inner.visit_type(f),
             _ => {}
         }
@@ -1627,6 +1630,18 @@ pub struct LuaMappedType {
     pub value: LuaType,
     pub is_readonly: bool,
     pub is_optional: bool,
+}
+
+impl TypeVisitTrait for LuaMappedType {
+    fn visit_type<F>(&self, f: &mut F)
+    where
+        F: FnMut(&LuaType),
+    {
+        if let Some(constraint) = &self.param.1.type_constraint {
+            constraint.visit_type(f);
+        }
+        self.value.visit_type(f);
+    }
 }
 
 impl LuaMappedType {

--- a/crates/glua_code_analysis/src/db_index/type/types.rs
+++ b/crates/glua_code_analysis/src/db_index/type/types.rs
@@ -1322,6 +1322,7 @@ impl LuaInstanceType {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum GenericTplId {
     Type(u32),
+    ScopedType { scope: u32, idx: u32 },
     Func(u32),
 }
 
@@ -1329,6 +1330,7 @@ impl GenericTplId {
     pub fn get_idx(&self) -> usize {
         match self {
             GenericTplId::Type(idx) => *idx as usize,
+            GenericTplId::ScopedType { idx, .. } => *idx as usize,
             GenericTplId::Func(idx) => *idx as usize,
         }
     }
@@ -1338,14 +1340,24 @@ impl GenericTplId {
     }
 
     pub fn is_type(&self) -> bool {
-        matches!(self, GenericTplId::Type(_))
+        matches!(
+            self,
+            GenericTplId::Type(_) | GenericTplId::ScopedType { .. }
+        )
     }
 
     pub fn with_idx(&self, idx: u32) -> Self {
         match self {
             GenericTplId::Type(_) => GenericTplId::Type(idx),
+            GenericTplId::ScopedType { scope, .. } => {
+                GenericTplId::ScopedType { scope: *scope, idx }
+            }
             GenericTplId::Func(_) => GenericTplId::Func(idx),
         }
+    }
+
+    pub fn scoped_type(scope: u32, idx: u32) -> Self {
+        GenericTplId::ScopedType { scope, idx }
     }
 }
 

--- a/crates/glua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
+++ b/crates/glua_code_analysis/src/diagnostic/checker/assign_type_mismatch.rs
@@ -125,6 +125,7 @@ fn check_name_expr(
         &value_type,
         false,
         source_is_inferred,
+        expr.as_ref().map(is_fresh_table_expr).unwrap_or(false),
     );
     let strict_inferred_mismatch = semantic_model.get_emmyrc().strict.inferred_type_mismatch;
     if let Some(expr) = expr {
@@ -175,6 +176,7 @@ fn check_index_expr(
         &value_type,
         true,
         source_is_inferred,
+        expr.as_ref().map(is_fresh_table_expr).unwrap_or(false),
     );
     let strict_inferred_mismatch = semantic_model.get_emmyrc().strict.inferred_type_mismatch;
     if let Some(expr) = expr {
@@ -464,6 +466,10 @@ fn check_local_stat(
             &value_type,
             false,
             false,
+            value_exprs
+                .get(idx)
+                .map(is_fresh_table_expr)
+                .unwrap_or(false),
         );
         if let Some(expr) = value_exprs.get(idx) {
             check_table_expr(
@@ -603,6 +609,7 @@ fn check_table_expr_content(
             &expr_type,
             allow_nil,
             source_is_inferred,
+            true,
         ) {
             has_diagnostic = has_diagnostic || result;
         }
@@ -631,6 +638,10 @@ fn should_check_nested_table_fields(source_type: &LuaType) -> bool {
             .any(should_check_nested_table_fields),
         _ => false,
     }
+}
+
+fn is_fresh_table_expr(expr: &LuaExpr) -> bool {
+    LuaTableExpr::cast(expr.syntax().clone()).is_some()
 }
 
 fn check_table_last_variadic_type(
@@ -662,6 +673,7 @@ fn check_table_last_variadic_type(
                     expr_type,
                     false,
                     false,
+                    true,
                 ) && result
                 {
                     return Some(true);
@@ -681,6 +693,7 @@ fn check_assign_type_mismatch(
     value_type: &LuaType,
     allow_nil: bool,
     source_is_inferred: bool,
+    is_fresh_table_expr: bool,
 ) -> Option<bool> {
     let source_type = source_type.unwrap_or(&LuaType::Any);
     // 如果一致, 则不进行类型检查
@@ -719,7 +732,11 @@ fn check_assign_type_mismatch(
         _ => {}
     }
 
-    let result = semantic_model.type_check_detail(source_type, value_type);
+    let result = if is_fresh_table_expr {
+        semantic_model.type_check_detail(source_type, value_type)
+    } else {
+        semantic_model.type_check_detail_no_excess(source_type, value_type)
+    };
     if result.is_err() {
         add_type_check_diagnostic(
             context,

--- a/crates/glua_code_analysis/src/diagnostic/checker/param_type_check.rs
+++ b/crates/glua_code_analysis/src/diagnostic/checker/param_type_check.rs
@@ -1,4 +1,6 @@
-use glua_parser::{LuaAst, LuaAstNode, LuaAstToken, LuaCallExpr, LuaExpr, LuaIndexExpr};
+use glua_parser::{
+    LuaAst, LuaAstNode, LuaAstToken, LuaCallExpr, LuaExpr, LuaIndexExpr, LuaTableExpr,
+};
 use rowan::TextRange;
 
 use crate::{
@@ -103,7 +105,17 @@ fn check_call_expr(
                     continue;
                 }
             }
-            let result = semantic_model.type_check_detail(&check_type, arg_type);
+            let arg_expr = match (colon_call, colon_define) {
+                (true, false) if idx == 0 => None,
+                (true, false) => arg_exprs.get(idx - 1),
+                _ => arg_exprs.get(idx),
+            };
+
+            let result = if arg_expr.map(is_fresh_table_expr).unwrap_or(false) {
+                semantic_model.type_check_detail(&check_type, arg_type)
+            } else {
+                semantic_model.type_check_detail_no_excess(&check_type, arg_type)
+            };
             if result.is_err() {
                 // `never` and `SelfInfer` indicate type inference limitations, skip the diagnostic.
                 // When the original param was SelfInfer and the arg is a class/ref/def type,
@@ -149,12 +161,6 @@ fn check_call_expr(
                     }
                 }
 
-                let arg_expr = match (colon_call, colon_define) {
-                    (true, false) if idx == 0 => None,
-                    (true, false) => arg_exprs.get(idx - 1),
-                    _ => arg_exprs.get(idx),
-                };
-
                 try_add_diagnostic(
                     context,
                     semantic_model,
@@ -169,6 +175,10 @@ fn check_call_expr(
     }
 
     Some(())
+}
+
+fn is_fresh_table_expr(expr: &LuaExpr) -> bool {
+    LuaTableExpr::cast(expr.syntax().clone()).is_some()
 }
 
 fn check_variadic_param_match_args(

--- a/crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
@@ -606,7 +606,7 @@ local b = a
             "#
         ));
 
-        assert!(ws.check_code_for_namespace(
+        assert!(!ws.check_code_for_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
 ---@class A
@@ -732,7 +732,7 @@ return t
         config.strict.array_index = true;
         ws.analysis.update_config(config.into());
 
-        assert!(ws.check_code_for_namespace(
+        assert!(!ws.check_code_for_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@class A

--- a/crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
@@ -2010,3 +2010,26 @@ fn test_doc_string_union_with_legacy_wrapped_literals_stays_strict() {
         "#
     ));
 }
+
+#[test]
+fn test_array_of_derived_class_keeps_declared_child_fields() {
+    let mut ws = crate::test_lib::VirtualWorkspace::new();
+    assert!(ws.check_code_for(
+        crate::DiagnosticCode::AssignTypeMismatch,
+        r#"
+        ---@class BaseItem
+        ---@field id string
+
+        ---@class DerivedItem : BaseItem
+        ---@field kind? string
+
+        ---@type DerivedItem[]
+        local items = {
+            {
+                id = "first",
+                kind = "visible",
+            },
+        }
+        "#
+    ));
+}

--- a/crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
@@ -743,9 +743,9 @@ return t
                 "#
         ));
 
-        // 允许接受父类.
-        // TODO: 接受父类时应该检查是否具有子类的所有非可空成员.
-        assert!(ws.check_code_for_namespace(
+        // Primitive-backed classes behave like branded primitive subtypes:
+        // the branded class is assignable to its primitive base, but not vice versa.
+        assert!(!ws.check_code_for_namespace(
             DiagnosticCode::AssignTypeMismatch,
             r#"
             ---@class Option: string

--- a/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -2383,6 +2383,49 @@ mod test {
     }
 
     #[test]
+    fn test_exact_class_dynamic_key_member_is_not_required_for_fresh_table_param() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@alias DisplayMode
+            ---| "compact"
+            ---| "expanded"
+
+            ---@class (exact) RenderOptions
+            ---@field size? integer
+            ---@field weight? number
+            ---@field mode? DisplayMode
+
+            ---@param baseOptions RenderOptions?
+            ---@return RenderOptions
+            local function copyOptions(baseOptions)
+                ---@type RenderOptions
+                local options = {}
+
+                if baseOptions ~= nil then
+                    for key, value in pairs(baseOptions) do
+                        options[key] = value
+                    end
+                end
+
+                return options
+            end
+
+            ---@param options? RenderOptions
+            local function render(options) end
+
+            render({
+                mode = "expanded",
+                size = 1,
+                weight = 0,
+            })
+        "#
+        ));
+    }
+
+    #[test]
     fn test_structural_object_param_rejects_extra_fresh_table_fields() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -677,7 +677,8 @@ mod test {
     #[test]
     fn test_super_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        // Integer literals are not implicitly branded as py.SlotType.
+        assert!(!ws.check_code_for(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@class py.SlotType: integer
@@ -788,7 +789,8 @@ mod test {
     #[test]
     fn test_super_and_enum_1() {
         let mut ws = VirtualWorkspace::new();
-        assert!(ws.check_code_for(
+        // Integer enums are not implicitly branded as py.AbilityType.
+        assert!(!ws.check_code_for(
             DiagnosticCode::ParamTypeMismatch,
             r#"
                 ---@enum AbilityType

--- a/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -2316,4 +2316,132 @@ mod test {
         "#
         ));
     }
+
+    #[test]
+    fn test_open_class_param_allows_extra_fresh_table_fields() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@class OpenOptions
+            ---@field mode string
+
+            ---@param options OpenOptions
+            local function useOptions(options) end
+
+            useOptions({
+                mode = "fast",
+                extra = 1,
+            })
+        "#
+        ));
+    }
+
+    #[test]
+    fn test_open_class_param_allows_extra_nonfresh_table_fields() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@class OpenOptionsFromVariable
+            ---@field mode string
+
+            ---@param options OpenOptionsFromVariable
+            local function useOptions(options) end
+
+            local options = {
+                mode = "fast",
+                extra = 1,
+            }
+
+            useOptions(options)
+        "#
+        ));
+    }
+
+    #[test]
+    fn test_exact_class_param_rejects_extra_fresh_table_fields() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@class (exact) ExactOptions
+            ---@field mode string
+
+            ---@param options ExactOptions
+            local function useOptions(options) end
+
+            useOptions({
+                mode = "fast",
+                extra = 1,
+            })
+        "#
+        ));
+    }
+
+    #[test]
+    fn test_structural_object_param_rejects_extra_fresh_table_fields() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param options { mode: string }
+            local function useOptions(options) end
+
+            useOptions({
+                mode = "fast",
+                extra = 1,
+            })
+        "#
+        ));
+    }
+
+    #[test]
+    fn test_structural_object_param_allows_extra_nonfresh_table_fields() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param options { mode: string }
+            local function useOptions(options) end
+
+            local options = {
+                mode = "fast",
+                extra = 1,
+            }
+
+            useOptions(options)
+        "#
+        ));
+    }
+
+    #[test]
+    fn test_broad_table_union_member_accepts_returned_object() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param options { camera?: "2D"|table }
+            local function render(options) end
+
+            local function makeCamera()
+                return {
+                    x = 0,
+                    y = 0,
+                    mode = "3D",
+                }
+            end
+
+            render({
+                camera = makeCamera(),
+            })
+        "#
+        ));
+    }
 }

--- a/crates/glua_code_analysis/src/diagnostic/test/return_type_mismatch_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/return_type_mismatch_test.rs
@@ -346,7 +346,8 @@ mod tests {
     fn test_supper() {
         let mut ws = VirtualWorkspace::new_with_init_std_lib();
 
-        assert!(ws.check_code_for(
+        // Integer literals are not implicitly branded as key.
+        assert!(!ws.check_code_for(
             DiagnosticCode::ReturnTypeMismatch,
             r#"
                 ---@class key: integer

--- a/crates/glua_code_analysis/src/diagnostic/test/undefined_field_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/undefined_field_test.rs
@@ -30,6 +30,43 @@ mod test {
     }
 
     #[test]
+    fn test_local_table_field_assigned_in_function_body_not_undefined_field() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+                local a = {}
+                function f()
+                    a.customValue = 1
+                end
+                print(a.customValue)
+                fieldTypeProbe = a.customValue
+            "#,
+        );
+
+        ws.enable_check(DiagnosticCode::UndefinedField);
+        let diagnostics = ws
+            .analysis
+            .diagnose_file(file_id, CancellationToken::new())
+            .unwrap_or_default();
+        let undefined_field_code = Some(NumberOrString::String(
+            DiagnosticCode::UndefinedField.get_name().to_string(),
+        ));
+        let undefined_fields: Vec<_> = diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == undefined_field_code)
+            .collect();
+        assert!(
+            undefined_fields.is_empty(),
+            "unexpected undefined-field diagnostics: {undefined_fields:#?}"
+        );
+
+        let field_ty = ws.expr_ty("fieldTypeProbe");
+        let integer_ty = ws.ty("integer");
+        assert!(ws.check_type(&field_ty, &integer_ty));
+        assert_eq!(ws.humanize_type(field_ty), "1");
+    }
+
+    #[test]
     fn test_numeric_for_index_expr_on_inferred_setmetatable_table() {
         let mut ws = VirtualWorkspace::new();
         assert!(ws.check_code_for(

--- a/crates/glua_code_analysis/src/semantic/generic/call_constraint.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/call_constraint.rs
@@ -1,10 +1,11 @@
-use std::{ops::Deref, sync::Arc};
+use std::{collections::HashSet, ops::Deref, sync::Arc};
 
 use glua_parser::{LuaAstNode, LuaCallExpr, LuaExpr, LuaIndexExpr};
 
 use crate::{
-    DbIndex, DocTypeInferContext, GenericTplId, LuaFunctionType, LuaSemanticDeclId, LuaType,
-    SemanticDeclLevel, SemanticModel, TypeOps, TypeSubstitutor, VariadicType, infer_doc_type,
+    DbIndex, DocTypeInferContext, GenericTplId, InferenceContext, InferencePriority,
+    InferenceVariance, LuaFunctionType, LuaSemanticDeclId, LuaType, SemanticDeclLevel,
+    SemanticModel, TypeOps, TypeSubstitutor, VariadicType, infer_doc_type,
 };
 
 // 泛型约束上下文
@@ -21,7 +22,8 @@ pub fn build_call_constraint_context(
     let doc_func = infer_call_doc_function(semantic_model, call_expr)?;
     let mut params = doc_func.get_params().to_vec();
     let mut arg_infos = get_arg_infos(semantic_model, call_expr)?;
-    let mut substitutor = TypeSubstitutor::new();
+    let mut inference = InferenceContext::new();
+    let mut explicit_tpl_ids = HashSet::new();
 
     // 读取显式传入的泛型实参
     if let Some(type_list) = call_expr.get_call_generic_type_list() {
@@ -29,7 +31,9 @@ pub fn build_call_constraint_context(
             DocTypeInferContext::new(semantic_model.get_db(), semantic_model.get_file_id());
         for (idx, doc_type) in type_list.get_types().enumerate() {
             let ty = infer_doc_type(doc_ctx, &doc_type);
-            substitutor.insert_type(GenericTplId::Func(idx as u32), ty, true);
+            let tpl_id = GenericTplId::Func(idx as u32);
+            explicit_tpl_ids.insert(tpl_id);
+            inference.set_explicit_type(tpl_id, ty, true);
         }
     }
 
@@ -44,13 +48,19 @@ pub fn build_call_constraint_context(
         }
     }
 
-    collect_generic_assignments(&mut substitutor, &params, &arg_infos);
+    collect_generic_assignments(
+        semantic_model.get_db(),
+        &mut inference,
+        &params,
+        &arg_infos,
+        &explicit_tpl_ids,
+    );
 
     Some((
         CallConstraintContext {
             params,
             arg_infos,
-            substitutor,
+            substitutor: inference.substitutor().clone(),
         },
         doc_func,
     ))
@@ -66,10 +76,17 @@ pub fn normalize_constraint_type(db: &DbIndex, ty: LuaType) -> LuaType {
 
 // 收集各个参数对应的泛型推导
 fn collect_generic_assignments(
-    substitutor: &mut TypeSubstitutor,
+    db: &DbIndex,
+    inference: &mut InferenceContext,
     params: &[(String, Option<LuaType>)],
     arg_infos: &[LuaType],
+    explicit_tpl_ids: &HashSet<GenericTplId>,
 ) {
+    let state = inference.begin_candidate_collection(
+        true,
+        InferencePriority::Direct,
+        InferenceVariance::Covariant,
+    );
     for (idx, (_, param_type)) in params.iter().enumerate() {
         let Some(param_type) = param_type else {
             continue;
@@ -77,29 +94,40 @@ fn collect_generic_assignments(
         let Some(arg_type) = arg_infos.get(idx) else {
             continue;
         };
-        record_generic_assignment(param_type, arg_type, substitutor);
+        record_generic_assignment(param_type, arg_type, inference, explicit_tpl_ids);
     }
+    inference.finish_candidate_collection(db, state);
 }
 
 // 实际写入泛型替换表
 fn record_generic_assignment(
     param_type: &LuaType,
     arg_type: &LuaType,
-    substitutor: &mut TypeSubstitutor,
+    inference: &mut InferenceContext,
+    explicit_tpl_ids: &HashSet<GenericTplId>,
 ) {
     match param_type {
         LuaType::TplRef(tpl_ref) => {
-            substitutor.insert_type(tpl_ref.get_tpl_id(), arg_type.clone(), true);
+            let tpl_id = tpl_ref.get_tpl_id();
+            if !explicit_tpl_ids.contains(&tpl_id) {
+                inference.infer_type(tpl_id, arg_type.clone(), true);
+            }
         }
         LuaType::ConstTplRef(tpl_ref) => {
-            substitutor.insert_type(tpl_ref.get_tpl_id(), arg_type.clone(), false);
+            let tpl_id = tpl_ref.get_tpl_id();
+            if !explicit_tpl_ids.contains(&tpl_id) {
+                inference.infer_type(tpl_id, arg_type.clone(), false);
+            }
         }
         LuaType::StrTplRef(str_tpl_ref) => {
-            substitutor.insert_type(str_tpl_ref.get_tpl_id(), arg_type.clone(), true);
+            let tpl_id = str_tpl_ref.get_tpl_id();
+            if !explicit_tpl_ids.contains(&tpl_id) {
+                inference.infer_type(tpl_id, arg_type.clone(), true);
+            }
         }
         LuaType::Variadic(variadic) => {
             if let Some(inner) = variadic.get_type(0) {
-                record_generic_assignment(inner, arg_type, substitutor);
+                record_generic_assignment(inner, arg_type, inference, explicit_tpl_ids);
             }
         }
         _ => {}

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -26,6 +26,15 @@ impl InferencePriority {
         )
     }
 
+    pub fn implies_covariant_candidate_combination(self) -> bool {
+        matches!(
+            self,
+            InferencePriority::Direct
+                | InferencePriority::ContextualReturn
+                | InferencePriority::MappedTypeConstraint
+        )
+    }
+
     fn rank(self) -> u16 {
         match self {
             InferencePriority::None | InferencePriority::Direct => 0,

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -1,8 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
 use super::{
-    type_substitutor::{candidate_assignable_to, SubstitutorTypeValue, SubstitutorValue},
     TypeSubstitutor,
+    instantiate_type::instantiate_type_generic,
+    type_substitutor::{SubstitutorTypeValue, SubstitutorValue, candidate_assignable_to},
 };
 use crate::{DbIndex, GenericTplId, LuaType};
 
@@ -51,6 +52,7 @@ pub enum InferenceVariance {
 pub struct InferenceContext {
     substitutor: TypeSubstitutor,
     type_inferences: HashMap<GenericTplId, TypeInferenceInfo>,
+    type_constraints: HashMap<GenericTplId, LuaType>,
     collect_type_candidates: bool,
     priority: InferencePriority,
     variance: InferenceVariance,
@@ -75,6 +77,7 @@ impl InferenceContext {
         Self {
             substitutor: TypeSubstitutor::new(),
             type_inferences: HashMap::new(),
+            type_constraints: HashMap::new(),
             collect_type_candidates: false,
             priority: InferencePriority::None,
             variance: InferenceVariance::Covariant,
@@ -85,6 +88,7 @@ impl InferenceContext {
         Self {
             substitutor,
             type_inferences: HashMap::new(),
+            type_constraints: HashMap::new(),
             collect_type_candidates: false,
             priority: InferencePriority::None,
             variance: InferenceVariance::Covariant,
@@ -135,6 +139,10 @@ impl InferenceContext {
 
     pub fn add_pending_type_parameters(&mut self, tpl_ids: HashSet<GenericTplId>) {
         self.substitutor.add_need_infer_tpls(tpl_ids);
+    }
+
+    pub fn add_type_constraint(&mut self, tpl_id: GenericTplId, constraint: LuaType) {
+        self.type_constraints.entry(tpl_id).or_insert(constraint);
     }
 
     pub fn is_fully_inferred(&self) -> bool {
@@ -237,11 +245,27 @@ impl InferenceContext {
     }
 
     fn normalize_type_inferences(&mut self, db: &DbIndex) {
-        for (tpl_id, inference) in self.type_inferences.iter_mut() {
-            inference.normalize_with_common_supertype(db);
+        let mut tpl_ids = self.type_inferences.keys().copied().collect::<Vec<_>>();
+        tpl_ids.sort_by_key(|tpl_id| {
+            let kind = match tpl_id {
+                GenericTplId::Type(_) => 0,
+                GenericTplId::ScopedType { .. } => 1,
+                GenericTplId::Func(_) => 2,
+            };
+            (kind, tpl_id.get_idx())
+        });
+        for tpl_id in tpl_ids {
+            let constraint = self
+                .type_constraints
+                .get(&tpl_id)
+                .map(|constraint| instantiate_type_generic(db, constraint, &self.substitutor));
+            let Some(inference) = self.type_inferences.get_mut(&tpl_id) else {
+                continue;
+            };
+            inference.normalize_with_common_supertype(db, constraint.as_ref());
             if let Some(inferred) = inference.inferred() {
                 self.substitutor
-                    .set_inferred_type_value(*tpl_id, inferred.clone());
+                    .set_inferred_type_value(tpl_id, inferred.clone());
             }
         }
     }
@@ -304,26 +328,32 @@ impl TypeInferenceInfo {
         candidates.push(candidate);
     }
 
-    fn normalize_with_common_supertype(&mut self, db: &DbIndex) {
-        self.inferred = self.infer_candidate(db);
+    fn normalize_with_common_supertype(&mut self, db: &DbIndex, constraint: Option<&LuaType>) {
+        self.inferred = self.infer_candidate(db, constraint);
     }
 
-    fn infer_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
+    fn infer_candidate(
+        &self,
+        db: &DbIndex,
+        constraint: Option<&LuaType>,
+    ) -> Option<SubstitutorTypeValue> {
         let covariant = self.infer_covariant_candidate(db);
         let contravariant = self.infer_contravariant_candidate(db);
 
-        match (covariant, contravariant) {
+        let (preferred, fallback) = match (covariant, contravariant) {
             (Some(covariant), Some(contravariant)) => {
                 if self.prefer_covariant_candidate(db, &covariant) {
-                    Some(covariant)
+                    (Some(covariant), Some(contravariant))
                 } else {
-                    Some(contravariant)
+                    (Some(contravariant), Some(covariant))
                 }
             }
-            (Some(covariant), None) => Some(covariant),
-            (None, Some(contravariant)) => Some(contravariant),
-            (None, None) => None,
-        }
+            (Some(covariant), None) => (Some(covariant), None),
+            (None, Some(contravariant)) => (Some(contravariant), None),
+            (None, None) => (None, None),
+        };
+
+        self.apply_constraint(db, preferred, fallback, constraint)
     }
 
     fn infer_covariant_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
@@ -376,6 +406,32 @@ impl TypeInferenceInfo {
             .any(|candidate| candidate_assignable_to(db, covariant.default(), candidate.default()))
     }
 
+    fn apply_constraint(
+        &self,
+        db: &DbIndex,
+        preferred: Option<SubstitutorTypeValue>,
+        fallback: Option<SubstitutorTypeValue>,
+        constraint: Option<&LuaType>,
+    ) -> Option<SubstitutorTypeValue> {
+        let Some(constraint) = constraint else {
+            return preferred;
+        };
+
+        if let Some(candidate) = preferred
+            && candidate_satisfies_constraint(db, &candidate, constraint)
+        {
+            return Some(candidate);
+        }
+
+        if let Some(candidate) = fallback
+            && candidate_satisfies_constraint(db, &candidate, constraint)
+        {
+            return Some(candidate);
+        }
+
+        Some(SubstitutorTypeValue::new(constraint.clone(), false))
+    }
+
     fn inferred(&self) -> Option<&SubstitutorTypeValue> {
         self.inferred.as_ref()
     }
@@ -383,4 +439,56 @@ impl TypeInferenceInfo {
     fn priority(&self) -> InferencePriority {
         self.priority.unwrap_or(InferencePriority::Direct)
     }
+}
+
+fn candidate_satisfies_constraint(
+    db: &DbIndex,
+    candidate: &SubstitutorTypeValue,
+    constraint: &LuaType,
+) -> bool {
+    candidate_type_satisfies_constraint(db, candidate.raw(), constraint)
+        || candidate_type_satisfies_constraint(db, candidate.default(), constraint)
+}
+
+fn candidate_type_satisfies_constraint(
+    db: &DbIndex,
+    candidate: &LuaType,
+    constraint: &LuaType,
+) -> bool {
+    if candidate_is_pending_str_tpl_ref(db, candidate, constraint) {
+        return true;
+    }
+
+    if candidate_assignable_to(db, candidate, constraint) {
+        return true;
+    }
+
+    if let LuaType::Tuple(tuple) = constraint {
+        return tuple
+            .get_types()
+            .iter()
+            .any(|member| candidate_assignable_to(db, candidate, member));
+    }
+
+    false
+}
+
+fn candidate_is_pending_str_tpl_ref(
+    db: &DbIndex,
+    candidate: &LuaType,
+    constraint: &LuaType,
+) -> bool {
+    let LuaType::Ref(candidate_id) = candidate else {
+        return false;
+    };
+    if db.get_type_index().get_type_decl(candidate_id).is_some() {
+        return false;
+    }
+
+    let (LuaType::Ref(constraint_id) | LuaType::Def(constraint_id)) = constraint else {
+        return false;
+    };
+    db.get_type_index()
+        .get_type_decl(constraint_id)
+        .is_some_and(|decl| decl.is_class())
 }

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -389,9 +389,7 @@ impl TypeInferenceInfo {
     }
 
     fn infer_covariant_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
-        let Some((first, rest)) = self.candidates.split_first() else {
-            return None;
-        };
+        let (first, rest) = self.candidates.split_first()?;
 
         let mut inferred = first.clone();
         let combine_candidates = self
@@ -409,9 +407,7 @@ impl TypeInferenceInfo {
     }
 
     fn infer_contravariant_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
-        let Some((first, rest)) = self.contra_candidates.split_first() else {
-            return None;
-        };
+        let (first, rest) = self.contra_candidates.split_first()?;
 
         let mut inferred = first.clone();
         let combine_candidates = self

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -38,10 +38,17 @@ impl InferencePriority {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InferenceVariance {
+    Covariant,
+    Contravariant,
+}
+
 #[derive(Debug, Clone)]
 pub struct InferenceContext {
     substitutor: TypeSubstitutor,
     priority: InferencePriority,
+    variance: InferenceVariance,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -49,6 +56,7 @@ pub(super) struct CandidateCollectionState {
     enabled: bool,
     previous_enabled: bool,
     previous_priority: InferencePriority,
+    previous_variance: InferenceVariance,
 }
 
 impl Default for InferenceContext {
@@ -62,6 +70,7 @@ impl InferenceContext {
         Self {
             substitutor: TypeSubstitutor::new(),
             priority: InferencePriority::None,
+            variance: InferenceVariance::Covariant,
         }
     }
 
@@ -69,6 +78,7 @@ impl InferenceContext {
         Self {
             substitutor,
             priority: InferencePriority::None,
+            variance: InferenceVariance::Covariant,
         }
     }
 
@@ -88,17 +98,28 @@ impl InferenceContext {
         self.priority
     }
 
+    pub fn variance(&self) -> InferenceVariance {
+        self.variance
+    }
+
     pub fn insert_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
-        self.substitutor
-            .insert_type_with_priority(tpl_id, replace_type, decay, self.priority);
+        self.substitutor.insert_type_with_priority(
+            tpl_id,
+            replace_type,
+            decay,
+            self.priority,
+            self.variance,
+        );
     }
 
     pub(super) fn begin_candidate_collection(
         &mut self,
         enabled: bool,
         priority: InferencePriority,
+        variance: InferenceVariance,
     ) -> CandidateCollectionState {
         let previous_priority = self.priority;
+        let previous_variance = self.variance;
         let previous_enabled = self
             .substitutor
             .set_type_candidate_collection_enabled(enabled);
@@ -107,11 +128,17 @@ impl InferenceContext {
         } else {
             InferencePriority::None
         };
+        self.variance = if enabled {
+            variance
+        } else {
+            InferenceVariance::Covariant
+        };
 
         CandidateCollectionState {
             enabled,
             previous_enabled,
             previous_priority,
+            previous_variance,
         }
     }
 
@@ -127,6 +154,7 @@ impl InferenceContext {
         self.substitutor
             .set_type_candidate_collection_enabled(state.previous_enabled);
         self.priority = state.previous_priority;
+        self.variance = state.previous_variance;
     }
 }
 

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use super::TypeSubstitutor;
-use crate::DbIndex;
+use crate::{DbIndex, GenericTplId, LuaType};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InferencePriority {
@@ -12,6 +12,30 @@ pub enum InferencePriority {
     PartialHomomorphicMappedType,
     MappedTypeConstraint,
     NakedUnionFallback,
+}
+
+impl InferencePriority {
+    pub fn is_higher_than(self, other: Self) -> bool {
+        self.rank() < other.rank()
+    }
+
+    pub fn implies_candidate_combination(self) -> bool {
+        matches!(
+            self,
+            InferencePriority::ContextualReturn | InferencePriority::MappedTypeConstraint
+        )
+    }
+
+    fn rank(self) -> u16 {
+        match self {
+            InferencePriority::None | InferencePriority::Direct => 0,
+            InferencePriority::NakedUnionFallback => 1,
+            InferencePriority::HomomorphicMappedType => 8,
+            InferencePriority::PartialHomomorphicMappedType => 16,
+            InferencePriority::MappedTypeConstraint => 32,
+            InferencePriority::ContextualReturn => 128,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -62,6 +86,11 @@ impl InferenceContext {
 
     pub fn priority(&self) -> InferencePriority {
         self.priority
+    }
+
+    pub fn insert_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
+        self.substitutor
+            .insert_type_with_priority(tpl_id, replace_type, decay, self.priority);
     }
 
     pub(super) fn begin_candidate_collection(

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -1,6 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use super::TypeSubstitutor;
+use crate::DbIndex;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InferencePriority {
@@ -16,6 +17,14 @@ pub enum InferencePriority {
 #[derive(Debug, Clone)]
 pub struct InferenceContext {
     substitutor: TypeSubstitutor,
+    priority: InferencePriority,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CandidateCollectionState {
+    enabled: bool,
+    previous_enabled: bool,
+    previous_priority: InferencePriority,
 }
 
 impl Default for InferenceContext {
@@ -28,11 +37,15 @@ impl InferenceContext {
     pub fn new() -> Self {
         Self {
             substitutor: TypeSubstitutor::new(),
+            priority: InferencePriority::None,
         }
     }
 
     pub fn from_substitutor(substitutor: TypeSubstitutor) -> Self {
-        Self { substitutor }
+        Self {
+            substitutor,
+            priority: InferencePriority::None,
+        }
     }
 
     pub fn into_substitutor(self) -> TypeSubstitutor {
@@ -45,6 +58,46 @@ impl InferenceContext {
 
     pub fn substitutor_mut(&mut self) -> &mut TypeSubstitutor {
         &mut self.substitutor
+    }
+
+    pub fn priority(&self) -> InferencePriority {
+        self.priority
+    }
+
+    pub(super) fn begin_candidate_collection(
+        &mut self,
+        enabled: bool,
+        priority: InferencePriority,
+    ) -> CandidateCollectionState {
+        let previous_priority = self.priority;
+        let previous_enabled = self
+            .substitutor
+            .set_type_candidate_collection_enabled(enabled);
+        self.priority = if enabled {
+            priority
+        } else {
+            InferencePriority::None
+        };
+
+        CandidateCollectionState {
+            enabled,
+            previous_enabled,
+            previous_priority,
+        }
+    }
+
+    pub(super) fn finish_candidate_collection(
+        &mut self,
+        db: &DbIndex,
+        state: CandidateCollectionState,
+    ) {
+        if state.enabled {
+            self.substitutor.normalize_type_inferences(db);
+        }
+
+        self.substitutor
+            .set_type_candidate_collection_enabled(state.previous_enabled);
+        self.priority = state.previous_priority;
     }
 }
 

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -31,6 +31,8 @@ impl InferencePriority {
     }
 
     fn rank(self) -> u16 {
+        // Mirrors TS inference priorities: direct candidates win, reverse
+        // mapped candidates are weaker, and contextual return is speculative.
         match self {
             InferencePriority::None | InferencePriority::Direct => 0,
             InferencePriority::NakedUnionFallback => 1,
@@ -257,6 +259,8 @@ impl InferenceContext {
         let inference_snapshot = self.type_inferences.clone();
         let constraint_snapshot = self.type_constraints.clone();
         for tpl_id in tpl_ids {
+            // TS-Go getInferredType instantiates type-parameter constraints
+            // with the current non-fixing mapper before checking candidates.
             let constraint = self
                 .type_constraints
                 .get(&tpl_id)
@@ -359,6 +363,9 @@ impl TypeInferenceInfo {
         let covariant = self.infer_covariant_candidate(db);
         let contravariant = self.infer_contravariant_candidate(db);
 
+        // TS-Go preferCovariantType: prefer covariant only when it is useful,
+        // assignable to a contra candidate, and doesn't break dependent
+        // constraints from other type parameters.
         let (preferred, fallback) = match (covariant, contravariant) {
             (Some(covariant), Some(contravariant)) => {
                 if self.prefer_covariant_candidate(
@@ -462,6 +469,8 @@ impl TypeInferenceInfo {
             if candidate_satisfies_constraint(db, &candidate, constraint) {
                 return Some(candidate);
             }
+            // TS-Go lets pure return-type inference filter a speculative union
+            // by the constraint before falling back to the constraint itself.
             if self.priority() == InferencePriority::ContextualReturn
                 && let Some(filtered) = filter_candidate_by_constraint(db, &candidate, constraint)
             {
@@ -540,6 +549,8 @@ fn dependent_constraint_candidates_accept_covariant(
     all_inferences: &HashMap<GenericTplId, TypeInferenceInfo>,
     all_constraints: &HashMap<GenericTplId, LuaType>,
 ) -> bool {
+    // TS-Go blocks a covariant choice when another type parameter constrained
+    // to this one has candidates that would stop satisfying that constraint.
     all_inferences.iter().all(|(other_tpl_id, inference)| {
         if *other_tpl_id == tpl_id {
             return true;

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -1,9 +1,9 @@
-use std::{
-    collections::HashSet,
-    ops::{Deref, DerefMut},
-};
+use std::collections::{HashMap, HashSet};
 
-use super::{type_substitutor::SubstitutorValue, TypeSubstitutor};
+use super::{
+    type_substitutor::{candidate_assignable_to, SubstitutorTypeValue, SubstitutorValue},
+    TypeSubstitutor,
+};
 use crate::{DbIndex, GenericTplId, LuaType};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,6 +50,8 @@ pub enum InferenceVariance {
 #[derive(Debug, Clone)]
 pub struct InferenceContext {
     substitutor: TypeSubstitutor,
+    type_inferences: HashMap<GenericTplId, TypeInferenceInfo>,
+    collect_type_candidates: bool,
     priority: InferencePriority,
     variance: InferenceVariance,
 }
@@ -72,6 +74,8 @@ impl InferenceContext {
     pub fn new() -> Self {
         Self {
             substitutor: TypeSubstitutor::new(),
+            type_inferences: HashMap::new(),
+            collect_type_candidates: false,
             priority: InferencePriority::None,
             variance: InferenceVariance::Covariant,
         }
@@ -80,21 +84,15 @@ impl InferenceContext {
     pub fn from_substitutor(substitutor: TypeSubstitutor) -> Self {
         Self {
             substitutor,
+            type_inferences: HashMap::new(),
+            collect_type_candidates: false,
             priority: InferencePriority::None,
             variance: InferenceVariance::Covariant,
         }
     }
 
-    pub fn into_substitutor(self) -> TypeSubstitutor {
-        self.substitutor
-    }
-
     pub fn substitutor(&self) -> &TypeSubstitutor {
         &self.substitutor
-    }
-
-    pub fn substitutor_mut(&mut self) -> &mut TypeSubstitutor {
-        &mut self.substitutor
     }
 
     pub fn priority(&self) -> InferencePriority {
@@ -106,13 +104,12 @@ impl InferenceContext {
     }
 
     pub fn insert_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
-        self.substitutor.insert_type_with_priority(
-            tpl_id,
-            replace_type,
-            decay,
-            self.priority,
-            self.variance,
-        );
+        let value = SubstitutorTypeValue::new(replace_type, decay);
+        if self.collect_type_candidates {
+            self.insert_type_candidate(tpl_id, value, self.priority, self.variance);
+        } else {
+            self.substitutor.insert_type_value(tpl_id, value);
+        }
     }
 
     pub fn infer_type(&mut self, tpl_id: GenericTplId, candidate: LuaType, decay: bool) {
@@ -144,7 +141,12 @@ impl InferenceContext {
     }
 
     pub fn has_non_direct_type_inferences(&self) -> bool {
-        self.substitutor.has_non_direct_type_inferences()
+        self.type_inferences.values().any(|inference| {
+            !matches!(
+                inference.priority(),
+                InferencePriority::None | InferencePriority::Direct
+            )
+        })
     }
 
     pub fn add_self_type(&mut self, self_type: LuaType) {
@@ -167,9 +169,8 @@ impl InferenceContext {
     ) -> CandidateCollectionState {
         let previous_priority = self.priority;
         let previous_variance = self.variance;
-        let previous_enabled = self
-            .substitutor
-            .set_type_candidate_collection_enabled(enabled);
+        let previous_enabled = self.collect_type_candidates;
+        self.collect_type_candidates = enabled;
         self.priority = if enabled {
             priority
         } else {
@@ -195,26 +196,190 @@ impl InferenceContext {
         state: CandidateCollectionState,
     ) {
         if state.enabled {
-            self.substitutor.normalize_type_inferences(db);
+            self.normalize_type_inferences(db);
         }
 
-        self.substitutor
-            .set_type_candidate_collection_enabled(state.previous_enabled);
+        self.collect_type_candidates = state.previous_enabled;
         self.priority = state.previous_priority;
         self.variance = state.previous_variance;
     }
-}
 
-impl Deref for InferenceContext {
-    type Target = TypeSubstitutor;
+    fn insert_type_candidate(
+        &mut self,
+        tpl_id: GenericTplId,
+        value: SubstitutorTypeValue,
+        priority: InferencePriority,
+        variance: InferenceVariance,
+    ) {
+        let existing_type = match self.substitutor.get(tpl_id) {
+            Some(SubstitutorValue::Type(existing)) => Some(existing.clone()),
+            Some(SubstitutorValue::None) | None => None,
+            Some(_) => return,
+        };
+        let include_existing_type =
+            !self.type_inferences.contains_key(&tpl_id) && existing_type.is_some();
 
-    fn deref(&self) -> &Self::Target {
-        &self.substitutor
+        let inference = self
+            .type_inferences
+            .entry(tpl_id)
+            .or_insert_with(TypeInferenceInfo::new);
+
+        if include_existing_type && let Some(existing) = existing_type {
+            inference.add_candidate(existing, priority, InferenceVariance::Covariant);
+        }
+
+        inference.add_candidate(value, priority, variance);
+        if let Some(inferred) = inference.inferred() {
+            self.substitutor
+                .set_inferred_type_value(tpl_id, inferred.clone());
+        }
+    }
+
+    fn normalize_type_inferences(&mut self, db: &DbIndex) {
+        for (tpl_id, inference) in self.type_inferences.iter_mut() {
+            inference.normalize_with_common_supertype(db);
+            if let Some(inferred) = inference.inferred() {
+                self.substitutor
+                    .set_inferred_type_value(*tpl_id, inferred.clone());
+            }
+        }
     }
 }
 
-impl DerefMut for InferenceContext {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.substitutor
+#[derive(Debug, Clone)]
+struct TypeInferenceInfo {
+    candidates: Vec<SubstitutorTypeValue>,
+    contra_candidates: Vec<SubstitutorTypeValue>,
+    inferred: Option<SubstitutorTypeValue>,
+    priority: Option<InferencePriority>,
+}
+
+impl TypeInferenceInfo {
+    fn new() -> Self {
+        Self {
+            candidates: Vec::new(),
+            contra_candidates: Vec::new(),
+            inferred: None,
+            priority: None,
+        }
+    }
+
+    fn add_candidate(
+        &mut self,
+        candidate: SubstitutorTypeValue,
+        priority: InferencePriority,
+        variance: InferenceVariance,
+    ) {
+        match self.priority {
+            Some(existing) if priority.is_higher_than(existing) => {
+                self.candidates.clear();
+                self.contra_candidates.clear();
+                self.inferred = None;
+                self.priority = Some(priority);
+            }
+            Some(existing) if existing.is_higher_than(priority) => {
+                return;
+            }
+            Some(_) => {}
+            None => {
+                self.priority = Some(priority);
+            }
+        }
+
+        let candidates = match variance {
+            InferenceVariance::Covariant => &mut self.candidates,
+            InferenceVariance::Contravariant => &mut self.contra_candidates,
+        };
+
+        if candidates.contains(&candidate) {
+            return;
+        }
+
+        if let Some(inferred) = &mut self.inferred {
+            inferred.union_with(candidate.clone());
+        } else {
+            self.inferred = Some(candidate.clone());
+        }
+        candidates.push(candidate);
+    }
+
+    fn normalize_with_common_supertype(&mut self, db: &DbIndex) {
+        self.inferred = self.infer_candidate(db);
+    }
+
+    fn infer_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
+        let covariant = self.infer_covariant_candidate(db);
+        let contravariant = self.infer_contravariant_candidate(db);
+
+        match (covariant, contravariant) {
+            (Some(covariant), Some(contravariant)) => {
+                if self.prefer_covariant_candidate(db, &covariant) {
+                    Some(covariant)
+                } else {
+                    Some(contravariant)
+                }
+            }
+            (Some(covariant), None) => Some(covariant),
+            (None, Some(contravariant)) => Some(contravariant),
+            (None, None) => None,
+        }
+    }
+
+    fn infer_covariant_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
+        let Some((first, rest)) = self.candidates.split_first() else {
+            return None;
+        };
+
+        let mut inferred = first.clone();
+        let combine_candidates = self
+            .priority
+            .is_some_and(InferencePriority::implies_candidate_combination);
+        for candidate in rest {
+            if combine_candidates {
+                inferred.union_with(candidate.clone());
+            } else {
+                inferred.combine_with_common_supertype(db, candidate.clone());
+            }
+        }
+
+        Some(inferred)
+    }
+
+    fn infer_contravariant_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
+        let Some((first, rest)) = self.contra_candidates.split_first() else {
+            return None;
+        };
+
+        let mut inferred = first.clone();
+        let combine_candidates = self
+            .priority
+            .is_some_and(InferencePriority::implies_candidate_combination);
+        for candidate in rest {
+            if combine_candidates {
+                inferred.union_with(candidate.clone());
+            } else {
+                inferred.combine_with_common_subtype(db, candidate.clone());
+            }
+        }
+
+        Some(inferred)
+    }
+
+    fn prefer_covariant_candidate(&self, db: &DbIndex, covariant: &SubstitutorTypeValue) -> bool {
+        if matches!(covariant.default(), LuaType::Any | LuaType::Never) {
+            return false;
+        }
+
+        self.contra_candidates
+            .iter()
+            .any(|candidate| candidate_assignable_to(db, covariant.default(), candidate.default()))
+    }
+
+    fn inferred(&self) -> Option<&SubstitutorTypeValue> {
+        self.inferred.as_ref()
+    }
+
+    fn priority(&self) -> InferencePriority {
+        self.priority.unwrap_or(InferencePriority::Direct)
     }
 }

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -254,6 +254,8 @@ impl InferenceContext {
             };
             (kind, tpl_id.get_idx())
         });
+        let inference_snapshot = self.type_inferences.clone();
+        let constraint_snapshot = self.type_constraints.clone();
         for tpl_id in tpl_ids {
             let constraint = self
                 .type_constraints
@@ -262,7 +264,13 @@ impl InferenceContext {
             let Some(inference) = self.type_inferences.get_mut(&tpl_id) else {
                 continue;
             };
-            inference.normalize_with_common_supertype(db, constraint.as_ref());
+            inference.normalize_with_common_supertype(
+                db,
+                tpl_id,
+                constraint.as_ref(),
+                &inference_snapshot,
+                &constraint_snapshot,
+            );
             if let Some(inferred) = inference.inferred() {
                 self.substitutor
                     .set_inferred_type_value(tpl_id, inferred.clone());
@@ -328,21 +336,38 @@ impl TypeInferenceInfo {
         candidates.push(candidate);
     }
 
-    fn normalize_with_common_supertype(&mut self, db: &DbIndex, constraint: Option<&LuaType>) {
-        self.inferred = self.infer_candidate(db, constraint);
+    fn normalize_with_common_supertype(
+        &mut self,
+        db: &DbIndex,
+        tpl_id: GenericTplId,
+        constraint: Option<&LuaType>,
+        all_inferences: &HashMap<GenericTplId, TypeInferenceInfo>,
+        all_constraints: &HashMap<GenericTplId, LuaType>,
+    ) {
+        self.inferred =
+            self.infer_candidate(db, tpl_id, constraint, all_inferences, all_constraints);
     }
 
     fn infer_candidate(
         &self,
         db: &DbIndex,
+        tpl_id: GenericTplId,
         constraint: Option<&LuaType>,
+        all_inferences: &HashMap<GenericTplId, TypeInferenceInfo>,
+        all_constraints: &HashMap<GenericTplId, LuaType>,
     ) -> Option<SubstitutorTypeValue> {
         let covariant = self.infer_covariant_candidate(db);
         let contravariant = self.infer_contravariant_candidate(db);
 
         let (preferred, fallback) = match (covariant, contravariant) {
             (Some(covariant), Some(contravariant)) => {
-                if self.prefer_covariant_candidate(db, &covariant) {
+                if self.prefer_covariant_candidate(
+                    db,
+                    tpl_id,
+                    &covariant,
+                    all_inferences,
+                    all_constraints,
+                ) {
                     (Some(covariant), Some(contravariant))
                 } else {
                     (Some(contravariant), Some(covariant))
@@ -396,14 +421,30 @@ impl TypeInferenceInfo {
         Some(inferred)
     }
 
-    fn prefer_covariant_candidate(&self, db: &DbIndex, covariant: &SubstitutorTypeValue) -> bool {
+    fn prefer_covariant_candidate(
+        &self,
+        db: &DbIndex,
+        tpl_id: GenericTplId,
+        covariant: &SubstitutorTypeValue,
+        all_inferences: &HashMap<GenericTplId, TypeInferenceInfo>,
+        all_constraints: &HashMap<GenericTplId, LuaType>,
+    ) -> bool {
         if matches!(covariant.default(), LuaType::Any | LuaType::Never) {
             return false;
         }
 
-        self.contra_candidates
+        let assignable_to_contra = self
+            .contra_candidates
             .iter()
-            .any(|candidate| candidate_assignable_to(db, covariant.default(), candidate.default()))
+            .any(|candidate| candidate_assignable_to(db, covariant.default(), candidate.default()));
+        assignable_to_contra
+            && dependent_constraint_candidates_accept_covariant(
+                db,
+                tpl_id,
+                covariant,
+                all_inferences,
+                all_constraints,
+            )
     }
 
     fn apply_constraint(
@@ -417,10 +458,15 @@ impl TypeInferenceInfo {
             return preferred;
         };
 
-        if let Some(candidate) = preferred
-            && candidate_satisfies_constraint(db, &candidate, constraint)
-        {
-            return Some(candidate);
+        if let Some(candidate) = preferred {
+            if candidate_satisfies_constraint(db, &candidate, constraint) {
+                return Some(candidate);
+            }
+            if self.priority() == InferencePriority::ContextualReturn
+                && let Some(filtered) = filter_candidate_by_constraint(db, &candidate, constraint)
+            {
+                return Some(filtered);
+            }
         }
 
         if let Some(candidate) = fallback
@@ -448,6 +494,76 @@ fn candidate_satisfies_constraint(
 ) -> bool {
     candidate_type_satisfies_constraint(db, candidate.raw(), constraint)
         || candidate_type_satisfies_constraint(db, candidate.default(), constraint)
+}
+
+fn filter_candidate_by_constraint(
+    db: &DbIndex,
+    candidate: &SubstitutorTypeValue,
+    constraint: &LuaType,
+) -> Option<SubstitutorTypeValue> {
+    let raw = filter_type_by_constraint(db, candidate.raw(), constraint)?;
+    let default = filter_type_by_constraint(db, candidate.default(), constraint)
+        .unwrap_or_else(|| raw.clone());
+    Some(SubstitutorTypeValue::with_raw_default(raw, default))
+}
+
+fn filter_type_by_constraint(
+    db: &DbIndex,
+    candidate: &LuaType,
+    constraint: &LuaType,
+) -> Option<LuaType> {
+    if candidate_type_satisfies_constraint(db, candidate, constraint) {
+        return Some(candidate.clone());
+    }
+
+    match candidate {
+        LuaType::Union(union) => {
+            let filtered = union
+                .into_vec()
+                .into_iter()
+                .filter(|member| candidate_type_satisfies_constraint(db, member, constraint))
+                .collect::<Vec<_>>();
+            if filtered.is_empty() {
+                None
+            } else {
+                Some(LuaType::from_vec(filtered))
+            }
+        }
+        _ => None,
+    }
+}
+
+fn dependent_constraint_candidates_accept_covariant(
+    db: &DbIndex,
+    tpl_id: GenericTplId,
+    covariant: &SubstitutorTypeValue,
+    all_inferences: &HashMap<GenericTplId, TypeInferenceInfo>,
+    all_constraints: &HashMap<GenericTplId, LuaType>,
+) -> bool {
+    all_inferences.iter().all(|(other_tpl_id, inference)| {
+        if *other_tpl_id == tpl_id {
+            return true;
+        }
+
+        let Some(constraint) = all_constraints.get(other_tpl_id) else {
+            return true;
+        };
+        if !constraint_is_direct_tpl_ref(constraint, tpl_id) {
+            return true;
+        }
+
+        inference
+            .candidates
+            .iter()
+            .all(|candidate| candidate_satisfies_constraint(db, candidate, covariant.default()))
+    })
+}
+
+fn constraint_is_direct_tpl_ref(constraint: &LuaType, tpl_id: GenericTplId) -> bool {
+    match constraint {
+        LuaType::TplRef(tpl) | LuaType::ConstTplRef(tpl) => tpl.get_tpl_id() == tpl_id,
+        _ => false,
+    }
 }
 
 fn candidate_type_satisfies_constraint(

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -1,6 +1,9 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    collections::HashSet,
+    ops::{Deref, DerefMut},
+};
 
-use super::TypeSubstitutor;
+use super::{type_substitutor::SubstitutorValue, TypeSubstitutor};
 use crate::{DbIndex, GenericTplId, LuaType};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -110,6 +113,50 @@ impl InferenceContext {
             self.priority,
             self.variance,
         );
+    }
+
+    pub fn infer_type(&mut self, tpl_id: GenericTplId, candidate: LuaType, decay: bool) {
+        self.insert_type(tpl_id, candidate, decay);
+    }
+
+    pub fn set_explicit_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
+        self.insert_type(tpl_id, replace_type, decay);
+    }
+
+    pub fn infer_params(&mut self, tpl_id: GenericTplId, params: Vec<(String, Option<LuaType>)>) {
+        self.substitutor.insert_params(tpl_id, params);
+    }
+
+    pub fn infer_multi_types(&mut self, tpl_id: GenericTplId, types: Vec<LuaType>) {
+        self.substitutor.insert_multi_types(tpl_id, types);
+    }
+
+    pub fn infer_multi_base(&mut self, tpl_id: GenericTplId, type_base: LuaType) {
+        self.substitutor.insert_multi_base(tpl_id, type_base);
+    }
+
+    pub fn add_pending_type_parameters(&mut self, tpl_ids: HashSet<GenericTplId>) {
+        self.substitutor.add_need_infer_tpls(tpl_ids);
+    }
+
+    pub fn is_fully_inferred(&self) -> bool {
+        self.substitutor.is_infer_all_tpl()
+    }
+
+    pub fn has_non_direct_type_inferences(&self) -> bool {
+        self.substitutor.has_non_direct_type_inferences()
+    }
+
+    pub fn add_self_type(&mut self, self_type: LuaType) {
+        self.substitutor.add_self_type(self_type);
+    }
+
+    pub fn get_self_type(&self) -> Option<&LuaType> {
+        self.substitutor.get_self_type()
+    }
+
+    pub fn get(&self, tpl_id: GenericTplId) -> Option<&SubstitutorValue> {
+        self.substitutor.get(tpl_id)
     }
 
     pub(super) fn begin_candidate_collection(

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -103,21 +103,22 @@ impl InferenceContext {
         self.variance
     }
 
-    pub fn insert_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
+    fn record_inferred_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
         let value = SubstitutorTypeValue::new(replace_type, decay);
         if self.collect_type_candidates {
             self.insert_type_candidate(tpl_id, value, self.priority, self.variance);
         } else {
-            self.substitutor.insert_type_value(tpl_id, value);
+            self.substitutor.set_fixed_type_value(tpl_id, value);
         }
     }
 
     pub fn infer_type(&mut self, tpl_id: GenericTplId, candidate: LuaType, decay: bool) {
-        self.insert_type(tpl_id, candidate, decay);
+        self.record_inferred_type(tpl_id, candidate, decay);
     }
 
     pub fn set_explicit_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
-        self.insert_type(tpl_id, replace_type, decay);
+        self.substitutor
+            .set_fixed_type_value(tpl_id, SubstitutorTypeValue::new(replace_type, decay));
     }
 
     pub fn infer_params(&mut self, tpl_id: GenericTplId, params: Vec<(String, Option<LuaType>)>) {

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -1,0 +1,63 @@
+use std::ops::{Deref, DerefMut};
+
+use super::TypeSubstitutor;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InferencePriority {
+    None,
+    Direct,
+    ContextualReturn,
+    HomomorphicMappedType,
+    PartialHomomorphicMappedType,
+    MappedTypeConstraint,
+    NakedUnionFallback,
+}
+
+#[derive(Debug, Clone)]
+pub struct InferenceContext {
+    substitutor: TypeSubstitutor,
+}
+
+impl Default for InferenceContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InferenceContext {
+    pub fn new() -> Self {
+        Self {
+            substitutor: TypeSubstitutor::new(),
+        }
+    }
+
+    pub fn from_substitutor(substitutor: TypeSubstitutor) -> Self {
+        Self { substitutor }
+    }
+
+    pub fn into_substitutor(self) -> TypeSubstitutor {
+        self.substitutor
+    }
+
+    pub fn substitutor(&self) -> &TypeSubstitutor {
+        &self.substitutor
+    }
+
+    pub fn substitutor_mut(&mut self) -> &mut TypeSubstitutor {
+        &mut self.substitutor
+    }
+}
+
+impl Deref for InferenceContext {
+    type Target = TypeSubstitutor;
+
+    fn deref(&self) -> &Self::Target {
+        &self.substitutor
+    }
+}
+
+impl DerefMut for InferenceContext {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.substitutor
+    }
+}

--- a/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/inference_context.rs
@@ -26,15 +26,6 @@ impl InferencePriority {
         )
     }
 
-    pub fn implies_covariant_candidate_combination(self) -> bool {
-        matches!(
-            self,
-            InferencePriority::Direct
-                | InferencePriority::ContextualReturn
-                | InferencePriority::MappedTypeConstraint
-        )
-    }
-
     fn rank(self) -> u16 {
         match self {
             InferencePriority::None | InferencePriority::Direct => 0,

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -198,6 +198,9 @@ fn infer_generic_types_from_call(
                     .substitutor
                     .set_type_candidate_collection_enabled(collect_more_candidates);
                 tpl_pattern_match(context, func_param_type, &arg_type)?;
+                if collect_more_candidates {
+                    context.substitutor.normalize_type_inferences(db);
+                }
                 context
                     .substitutor
                     .set_type_candidate_collection_enabled(previous);

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -16,7 +16,7 @@ use crate::{
     semantic::{
         LuaInferCache,
         generic::{
-            instantiate_type::instantiate_doc_function,
+            instantiate_type::{instantiate_doc_function, instantiate_type_generic},
             tpl_context::TplContext,
             tpl_pattern::{
                 multi_param_tpl_pattern_match_multi_return, tpl_pattern_match,
@@ -229,6 +229,11 @@ fn infer_generic_types_from_call(
 
     if !context.substitutor.is_infer_all_tpl() {
         for (func_param_type, call_arg_expr) in unresolve_tpls {
+            let func_param_type = if matches!(call_arg_expr, LuaExpr::ClosureExpr(_)) {
+                instantiate_type_generic(db, &func_param_type, context.substitutor)
+            } else {
+                func_param_type
+            };
             let closure_type =
                 infer_generic_arg_type(db, context, &call_arg_expr, use_inline_table_object)?;
 

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use crate::{LuaMemberOwner, LuaSemanticDeclId, SemanticDeclLevel, infer_node_semantic_decl};
 
-use crate::InferenceContext;
+use crate::{InferenceContext, InferencePriority};
 
 pub fn instantiate_func_generic(
     db: &DbIndex,
@@ -208,16 +208,11 @@ fn infer_generic_types_from_call(
                 break;
             }
             _ => {
-                let previous = context
-                    .substitutor
-                    .set_type_candidate_collection_enabled(collect_more_candidates);
-                tpl_pattern_match(context, func_param_type, &arg_type)?;
-                if collect_more_candidates {
-                    context.substitutor.normalize_type_inferences(db);
-                }
-                context
-                    .substitutor
-                    .set_type_candidate_collection_enabled(previous);
+                context.with_inference_priority(
+                    InferencePriority::Direct,
+                    collect_more_candidates,
+                    |context| tpl_pattern_match(context, func_param_type, &arg_type),
+                )?;
             }
         }
     }

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -16,7 +16,9 @@ use crate::{
     semantic::{
         LuaInferCache,
         generic::{
-            instantiate_type::{instantiate_doc_function, instantiate_type_generic},
+            instantiate_type::{
+                instantiate_doc_function, instantiate_type_generic_preserve_unresolved,
+            },
             tpl_context::TplContext,
             tpl_pattern::{
                 multi_param_tpl_pattern_match_multi_return, tpl_pattern_match,
@@ -256,7 +258,11 @@ fn infer_generic_types_from_call(
     if !context.substitutor.is_infer_all_tpl() {
         for (func_param_type, call_arg_expr) in unresolve_tpls {
             let func_param_type = if matches!(call_arg_expr, LuaExpr::ClosureExpr(_)) {
-                instantiate_type_generic(db, &func_param_type, context.substitutor)
+                instantiate_type_generic_preserve_unresolved(
+                    db,
+                    &func_param_type,
+                    context.substitutor,
+                )
             } else {
                 func_param_type
             };

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -262,6 +262,8 @@ fn infer_generic_types_from_call(
         && func.get_ret().contain_tpl()
         && !context.inference.is_fully_inferred()
     {
+        // TS-Go infers from a call's contextual type into the generic return
+        // type at a lower priority than ordinary argument inference.
         context.with_inference_priority(InferencePriority::ContextualReturn, true, |context| {
             tpl_pattern_match(context, func.get_ret(), return_hint)
         })?;
@@ -273,6 +275,8 @@ fn infer_generic_types_from_call(
         for (func_param_type, call_arg_expr) in unresolve_tpls {
             let is_closure_arg = matches!(call_arg_expr, LuaExpr::ClosureExpr(_));
             let original_func_param_type = func_param_type.clone();
+            // Context-sensitive closure arguments are delayed until earlier
+            // arguments and contextual return hints have produced candidates.
             let func_param_type = if is_closure_arg {
                 instantiate_type_generic_preserve_unresolved(
                     db,

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -4,13 +4,14 @@ use std::{
     sync::Arc,
 };
 
-use glua_parser::{LuaAstNode, LuaDocTypeList};
+use glua_parser::{LuaAstNode, LuaClosureExpr, LuaDocTypeList};
 use glua_parser::{LuaCallExpr, LuaExpr};
 use internment::ArcIntern;
 
 use crate::{
     DocTypeInferContext, FileId, GenericTpl, GenericTplId, LuaFunctionType, LuaGenericType,
-    LuaMemberKey, LuaObjectType, TypeVisitTrait,
+    LuaMemberKey, LuaObjectType, TypeOps, TypeVisitTrait, VariadicType,
+    compilation::analyzer::{LuaReturnPoint, analyze_func_body_returns},
     db_index::{DbIndex, LuaType},
     infer_doc_type,
     semantic::{
@@ -255,9 +256,13 @@ fn infer_generic_types_from_call(
         })?;
     }
 
-    if !context.substitutor.is_infer_all_tpl() {
+    if !unresolve_tpls.is_empty()
+        && (!context.substitutor.is_infer_all_tpl() || contextual_return_hint.is_some())
+    {
         for (func_param_type, call_arg_expr) in unresolve_tpls {
-            let func_param_type = if matches!(call_arg_expr, LuaExpr::ClosureExpr(_)) {
+            let is_closure_arg = matches!(call_arg_expr, LuaExpr::ClosureExpr(_));
+            let original_func_param_type = func_param_type.clone();
+            let func_param_type = if is_closure_arg {
                 instantiate_type_generic_preserve_unresolved(
                     db,
                     &func_param_type,
@@ -269,11 +274,210 @@ fn infer_generic_types_from_call(
             let closure_type =
                 infer_generic_arg_type(db, context, &call_arg_expr, use_inline_table_object)?;
 
-            tpl_pattern_match(context, &func_param_type, &closure_type)?;
+            context.with_inference_priority(InferencePriority::Direct, true, |context| {
+                tpl_pattern_match(context, &func_param_type, &closure_type)
+            })?;
+
+            if is_closure_arg && original_func_param_type.contain_tpl() {
+                let direct_closure_type = infer_closure_body_function_type(
+                    db,
+                    context,
+                    &func_param_type,
+                    &call_arg_expr,
+                    true,
+                )
+                .unwrap_or_else(|| closure_type.clone());
+                context.with_inference_priority(InferencePriority::Direct, true, |context| {
+                    tpl_pattern_match(context, &original_func_param_type, &direct_closure_type)
+                })?;
+            }
         }
     }
 
     Ok(())
+}
+
+fn infer_closure_body_function_type(
+    db: &DbIndex,
+    context: &mut TplContext,
+    expected_type: &LuaType,
+    call_arg_expr: &LuaExpr,
+    use_inline_table_object: bool,
+) -> Option<LuaType> {
+    let LuaExpr::ClosureExpr(closure) = call_arg_expr else {
+        return None;
+    };
+    let expected_func = match expected_type {
+        LuaType::DocFunction(func) => func.clone(),
+        LuaType::Signature(sig_id) => context
+            .db
+            .get_signature_index()
+            .get(sig_id)?
+            .to_doc_func_type(),
+        _ => return None,
+    };
+    let closure_param_types = closure_param_type_map(closure, expected_func.as_ref());
+    let return_type = infer_closure_body_return_type(
+        db,
+        context,
+        closure.clone(),
+        use_inline_table_object,
+        &closure_param_types,
+    )?;
+    if return_type.is_unknown() {
+        return None;
+    }
+
+    Some(LuaType::DocFunction(
+        LuaFunctionType::new(
+            expected_func.get_async_state(),
+            expected_func.is_colon_define(),
+            expected_func.is_variadic(),
+            expected_func.get_params().to_vec(),
+            return_type,
+        )
+        .into(),
+    ))
+}
+
+fn infer_closure_body_return_type(
+    db: &DbIndex,
+    context: &mut TplContext,
+    closure: LuaClosureExpr,
+    use_inline_table_object: bool,
+    closure_param_types: &HashMap<String, LuaType>,
+) -> Option<LuaType> {
+    let block = closure.get_block()?;
+    let return_points = analyze_func_body_returns(block);
+    let mut return_type = LuaType::Unknown;
+    for point in return_points {
+        let point_type = infer_closure_return_point_type(
+            db,
+            context,
+            point,
+            use_inline_table_object,
+            closure_param_types,
+        )
+        .ok()?;
+        return_type = if return_type.is_unknown() {
+            point_type
+        } else {
+            TypeOps::Union.apply(db, &return_type, &point_type)
+        };
+    }
+
+    Some(return_type)
+}
+
+fn infer_closure_return_point_type(
+    db: &DbIndex,
+    context: &mut TplContext,
+    point: LuaReturnPoint,
+    use_inline_table_object: bool,
+    closure_param_types: &HashMap<String, LuaType>,
+) -> Result<LuaType, InferFailReason> {
+    match point {
+        LuaReturnPoint::Expr(expr) => infer_generic_arg_type_with_closure_params(
+            db,
+            context,
+            &expr,
+            use_inline_table_object,
+            Some(closure_param_types),
+        ),
+        LuaReturnPoint::MuliExpr(exprs) => {
+            let mut types = Vec::new();
+            for expr in exprs {
+                types.push(infer_generic_arg_type_with_closure_params(
+                    db,
+                    context,
+                    &expr,
+                    use_inline_table_object,
+                    Some(closure_param_types),
+                )?);
+            }
+            Ok(LuaType::Variadic(VariadicType::Multi(types).into()))
+        }
+        LuaReturnPoint::Nil => Ok(LuaType::Nil),
+        LuaReturnPoint::Error => Ok(LuaType::Unknown),
+    }
+}
+
+fn closure_param_type_map(
+    closure: &LuaClosureExpr,
+    expected_func: &LuaFunctionType,
+) -> HashMap<String, LuaType> {
+    let mut param_types = HashMap::new();
+    let Some(params_list) = closure.get_params_list() else {
+        return param_types;
+    };
+
+    for (index, param) in params_list.get_params().enumerate() {
+        let Some(name_token) = param.get_name_token() else {
+            continue;
+        };
+        let Some((_, Some(expected_type))) = expected_func.get_params().get(index) else {
+            continue;
+        };
+        param_types.insert(
+            name_token.get_name_text().to_string(),
+            expected_type.clone(),
+        );
+    }
+
+    param_types
+}
+
+fn infer_generic_arg_type_with_closure_params(
+    db: &DbIndex,
+    context: &mut TplContext,
+    arg_expr: &LuaExpr,
+    use_inline_table_object: bool,
+    closure_param_types: Option<&HashMap<String, LuaType>>,
+) -> Result<LuaType, InferFailReason> {
+    if let LuaExpr::NameExpr(name_expr) = arg_expr
+        && let Some(name) = name_expr.get_name_text()
+        && let Some(param_type) = closure_param_types.and_then(|param_types| param_types.get(&name))
+    {
+        return Ok(param_type.clone());
+    }
+
+    if use_inline_table_object
+        && let LuaExpr::TableExpr(table_expr) = arg_expr
+        && !table_expr.is_array()
+        && !table_expr.is_empty()
+    {
+        let mut fields = HashMap::new();
+        for field in table_expr.get_fields() {
+            let field_key = field.get_field_key().ok_or(InferFailReason::None)?;
+            let member_key = LuaMemberKey::from_index_key(db, context.cache, &field_key)?;
+            if matches!(member_key, LuaMemberKey::ExprType(ref typ) if typ.is_unknown()) {
+                continue;
+            }
+
+            let value_expr = field.get_value_expr().ok_or(InferFailReason::None)?;
+            let value_type = infer_generic_arg_type_with_closure_params(
+                db,
+                context,
+                &value_expr,
+                use_inline_table_object,
+                closure_param_types,
+            )?;
+            let value_type = match value_type {
+                LuaType::Variadic(multi) => multi.get_type(0).cloned().unwrap_or(LuaType::Nil),
+                LuaType::Def(ref_id) => LuaType::Ref(ref_id),
+                other => other,
+            };
+            fields.insert(member_key, value_type);
+        }
+
+        if !fields.is_empty() {
+            return Ok(LuaType::Object(
+                LuaObjectType::new_with_fields(fields, Vec::new()).into(),
+            ));
+        }
+    }
+
+    infer_expr(db, context.cache, arg_expr.clone())
 }
 
 fn is_direct_type_candidate(typ: &LuaType) -> bool {
@@ -303,37 +507,7 @@ fn infer_generic_arg_type(
     arg_expr: &LuaExpr,
     use_inline_table_object: bool,
 ) -> Result<LuaType, InferFailReason> {
-    if use_inline_table_object
-        && let LuaExpr::TableExpr(table_expr) = arg_expr
-        && !table_expr.is_array()
-        && !table_expr.is_empty()
-    {
-        let mut fields = HashMap::new();
-        for field in table_expr.get_fields() {
-            let field_key = field.get_field_key().ok_or(InferFailReason::None)?;
-            let member_key = LuaMemberKey::from_index_key(db, context.cache, &field_key)?;
-            if matches!(member_key, LuaMemberKey::ExprType(ref typ) if typ.is_unknown()) {
-                continue;
-            }
-
-            let value_expr = field.get_value_expr().ok_or(InferFailReason::None)?;
-            let value_type = infer_expr(db, context.cache, value_expr)?;
-            let value_type = match value_type {
-                LuaType::Variadic(multi) => multi.get_type(0).cloned().unwrap_or(LuaType::Nil),
-                LuaType::Def(ref_id) => LuaType::Ref(ref_id),
-                other => other,
-            };
-            fields.insert(member_key, value_type);
-        }
-
-        if !fields.is_empty() {
-            return Ok(LuaType::Object(
-                LuaObjectType::new_with_fields(fields, Vec::new()).into(),
-            ));
-        }
-    }
-
-    infer_expr(db, context.cache, arg_expr.clone())
+    infer_generic_arg_type_with_closure_params(db, context, arg_expr, use_inline_table_object, None)
 }
 
 fn type_needs_structural_table_arg(db: &DbIndex, typ: &LuaType, depth: usize) -> bool {

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -248,10 +248,24 @@ fn infer_generic_types_from_call(
 }
 
 fn is_direct_type_candidate(typ: &LuaType) -> bool {
-    matches!(
-        typ,
-        LuaType::TplRef(_) | LuaType::ConstTplRef(_) | LuaType::StrTplRef(_)
-    )
+    match typ {
+        LuaType::TplRef(_) | LuaType::ConstTplRef(_) | LuaType::StrTplRef(_) => true,
+        LuaType::DocFunction(func) => {
+            func.get_params()
+                .iter()
+                .filter_map(|(_, ty)| ty.as_ref())
+                .any(is_direct_type_candidate)
+                || is_direct_type_candidate(func.get_ret())
+        }
+        LuaType::Variadic(variadic) => match variadic.deref() {
+            crate::VariadicType::Base(base) => is_direct_type_candidate(base),
+            crate::VariadicType::Multi(types) => types.iter().any(is_direct_type_candidate),
+        },
+        LuaType::Array(array) => is_direct_type_candidate(array.get_base()),
+        LuaType::Tuple(tuple) => tuple.get_types().iter().any(is_direct_type_candidate),
+        LuaType::Generic(generic) => generic.get_params().iter().any(is_direct_type_candidate),
+        _ => false,
+    }
 }
 
 fn infer_generic_arg_type(

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -85,11 +85,11 @@ pub fn instantiate_func_generic_with_context(
         let mut context = TplContext {
             db,
             cache,
-            substitutor: &mut inference,
+            inference: &mut inference,
             call_expr: Some(call_expr.clone()),
         };
         if !generic_tpls.is_empty() {
-            context.substitutor.add_need_infer_tpls(generic_tpls);
+            context.inference.add_pending_type_parameters(generic_tpls);
 
             if let Some(type_list) = call_expr.get_call_generic_type_list() {
                 // 如果使用了`obj:abc--[[@<string>]]("abc")`强制指定了泛型, 那么我们只需要直接应用
@@ -130,8 +130,8 @@ fn apply_call_generic_type_list(
     for (i, doc_type) in type_list.get_types().enumerate() {
         let typ = infer_doc_type(doc_ctx, &doc_type);
         context
-            .substitutor
-            .insert_type(GenericTplId::Func(i as u32), typ, true);
+            .inference
+            .set_explicit_type(GenericTplId::Func(i as u32), typ, true);
     }
 }
 
@@ -176,9 +176,9 @@ fn infer_generic_types_from_call(
 
         let (_, func_param_type) = &func_params[i];
         let collect_more_candidates = is_direct_type_candidate(func_param_type);
-        if context.substitutor.is_infer_all_tpl()
+        if context.inference.is_fully_inferred()
             && !collect_more_candidates
-            && !context.substitutor.has_non_direct_type_inferences()
+            && !context.inference.has_non_direct_type_inferences()
         {
             break;
         }
@@ -249,7 +249,7 @@ fn infer_generic_types_from_call(
 
     if let Some(return_hint) = contextual_return_hint
         && func.get_ret().contain_tpl()
-        && !context.substitutor.is_infer_all_tpl()
+        && !context.inference.is_fully_inferred()
     {
         context.with_inference_priority(InferencePriority::ContextualReturn, true, |context| {
             tpl_pattern_match(context, func.get_ret(), return_hint)
@@ -257,7 +257,7 @@ fn infer_generic_types_from_call(
     }
 
     if !unresolve_tpls.is_empty()
-        && (!context.substitutor.is_infer_all_tpl() || contextual_return_hint.is_some())
+        && (!context.inference.is_fully_inferred() || contextual_return_hint.is_some())
     {
         for (func_param_type, call_arg_expr) in unresolve_tpls {
             let is_closure_arg = matches!(call_arg_expr, LuaExpr::ClosureExpr(_));
@@ -266,7 +266,7 @@ fn infer_generic_types_from_call(
                 instantiate_type_generic_preserve_unresolved(
                     db,
                     &func_param_type,
-                    context.substitutor,
+                    context.inference.substitutor(),
                 )
             } else {
                 func_param_type

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -196,11 +196,11 @@ fn infer_generic_types_from_call(
             _ => {
                 let previous = context
                     .substitutor
-                    .set_union_type_candidates_enabled(collect_more_candidates);
+                    .set_type_candidate_collection_enabled(collect_more_candidates);
                 tpl_pattern_match(context, func_param_type, &arg_type)?;
                 context
                     .substitutor
-                    .set_union_type_candidates_enabled(previous);
+                    .set_type_candidate_collection_enabled(previous);
             }
         }
     }

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -248,7 +248,9 @@ fn infer_generic_types_from_call(
         && func.get_ret().contain_tpl()
         && !context.substitutor.is_infer_all_tpl()
     {
-        tpl_pattern_match(context, func.get_ret(), return_hint)?;
+        context.with_inference_priority(InferencePriority::ContextualReturn, true, |context| {
+            tpl_pattern_match(context, func.get_ret(), return_hint)
+        })?;
     }
 
     if !context.substitutor.is_infer_all_tpl() {

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -198,31 +198,28 @@ fn infer_generic_types_from_call(
             continue;
         }
 
-        match func_param_type {
-            LuaType::Variadic(variadic) => {
-                let mut rest_arg_exprs = &arg_exprs[arg_index..];
-                let is_last_param = i + 1 == func_params.len();
-                if !is_last_param {
-                    let suffix_len = func_params.len() - i - 1;
-                    let rest_len = rest_arg_exprs.len().saturating_sub(suffix_len);
-                    rest_arg_exprs = &rest_arg_exprs[..rest_len];
-                    arg_offset += rest_len as isize - 1;
-                }
-
-                let mut arg_types = vec![];
-                for arg_expr in rest_arg_exprs {
-                    let arg_type =
-                        infer_generic_arg_type(db, context, arg_expr, use_inline_table_object)?;
-                    arg_types.push(arg_type);
-                }
-                variadic_tpl_pattern_match(context, variadic, &arg_types)?;
-                if is_last_param {
-                    break;
-                }
-
-                continue;
+        if let LuaType::Variadic(variadic) = func_param_type {
+            let mut rest_arg_exprs = &arg_exprs[arg_index..];
+            let is_last_param = i + 1 == func_params.len();
+            if !is_last_param {
+                let suffix_len = func_params.len() - i - 1;
+                let rest_len = rest_arg_exprs.len().saturating_sub(suffix_len);
+                rest_arg_exprs = &rest_arg_exprs[..rest_len];
+                arg_offset += rest_len as isize - 1;
             }
-            _ => {}
+
+            let mut arg_types = vec![];
+            for arg_expr in rest_arg_exprs {
+                let arg_type =
+                    infer_generic_arg_type(db, context, arg_expr, use_inline_table_object)?;
+                arg_types.push(arg_type);
+            }
+            variadic_tpl_pattern_match(context, variadic, &arg_types)?;
+            if is_last_param {
+                break;
+            }
+
+            continue;
         }
 
         let call_arg_expr = &arg_exprs[arg_index];

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -52,16 +52,24 @@ pub fn instantiate_func_generic_with_context(
 ) -> Result<LuaFunctionType, InferFailReason> {
     let file_id = cache.get_file_id().clone();
     let mut generic_tpls = HashSet::new();
+    let mut generic_tpl_constraints = HashMap::new();
     let mut contain_self = false;
     func.visit_type(&mut |t| match t {
         LuaType::TplRef(generic_tpl) | LuaType::ConstTplRef(generic_tpl) => {
             let tpl_id = generic_tpl.get_tpl_id();
             if tpl_id.is_func() {
                 generic_tpls.insert(tpl_id);
+                if let Some(constraint) = generic_tpl.get_constraint() {
+                    generic_tpl_constraints.insert(tpl_id, constraint.clone());
+                }
             }
         }
         LuaType::StrTplRef(str_tpl) => {
-            generic_tpls.insert(str_tpl.get_tpl_id());
+            let tpl_id = str_tpl.get_tpl_id();
+            generic_tpls.insert(tpl_id);
+            if let Some(constraint) = str_tpl.get_constraint() {
+                generic_tpl_constraints.insert(tpl_id, constraint.clone());
+            }
         }
         LuaType::SelfInfer => {
             contain_self = true;
@@ -90,6 +98,9 @@ pub fn instantiate_func_generic_with_context(
         };
         if !generic_tpls.is_empty() {
             context.inference.add_pending_type_parameters(generic_tpls);
+            for (tpl_id, constraint) in generic_tpl_constraints {
+                context.inference.add_type_constraint(tpl_id, constraint);
+            }
 
             if let Some(type_list) = call_expr.get_call_generic_type_list() {
                 // 如果使用了`obj:abc--[[@<string>]]("abc")`强制指定了泛型, 那么我们只需要直接应用

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, ops::Deref, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Deref,
+    sync::Arc,
+};
 
 use glua_parser::{LuaAstNode, LuaDocTypeList};
 use glua_parser::{LuaCallExpr, LuaExpr};
@@ -6,7 +10,7 @@ use internment::ArcIntern;
 
 use crate::{
     DocTypeInferContext, FileId, GenericTpl, GenericTplId, LuaFunctionType, LuaGenericType,
-    TypeVisitTrait,
+    LuaMemberKey, LuaObjectType, TypeVisitTrait,
     db_index::{DbIndex, LuaType},
     infer_doc_type,
     semantic::{
@@ -138,6 +142,7 @@ fn infer_generic_types_from_call(
     }
 
     let mut unresolve_tpls = vec![];
+    let use_inline_table_object = type_needs_structural_table_arg(db, func.get_ret(), 0);
     for i in 0..func_params.len() {
         if i >= arg_exprs.len() {
             break;
@@ -161,16 +166,18 @@ fn infer_generic_types_from_call(
             continue;
         }
 
-        let arg_type = match infer_expr(db, context.cache, call_arg_expr.clone()) {
-            Ok(t) => t,
-            Err(InferFailReason::FieldNotFound) => LuaType::Nil, // 对于未找到的字段, 我们认为是 nil 以执行后续推断
-            Err(e) => return Err(e),
-        };
+        let arg_type =
+            match infer_generic_arg_type(db, context, call_arg_expr, use_inline_table_object) {
+                Ok(t) => t,
+                Err(InferFailReason::FieldNotFound) => LuaType::Nil, // 对于未找到的字段, 我们认为是 nil 以执行后续推断
+                Err(e) => return Err(e),
+            };
         match (func_param_type, &arg_type) {
             (LuaType::Variadic(variadic), _) => {
                 let mut arg_types = vec![];
                 for arg_expr in &arg_exprs[i..] {
-                    let arg_type = infer_expr(db, context.cache, arg_expr.clone())?;
+                    let arg_type =
+                        infer_generic_arg_type(db, context, arg_expr, use_inline_table_object)?;
                     arg_types.push(arg_type);
                 }
                 variadic_tpl_pattern_match(context, variadic, &arg_types)?;
@@ -193,13 +200,102 @@ fn infer_generic_types_from_call(
 
     if !context.substitutor.is_infer_all_tpl() {
         for (func_param_type, call_arg_expr) in unresolve_tpls {
-            let closure_type = infer_expr(db, context.cache, call_arg_expr)?;
+            let closure_type =
+                infer_generic_arg_type(db, context, &call_arg_expr, use_inline_table_object)?;
 
             tpl_pattern_match(context, &func_param_type, &closure_type)?;
         }
     }
 
     Ok(())
+}
+
+fn infer_generic_arg_type(
+    db: &DbIndex,
+    context: &mut TplContext,
+    arg_expr: &LuaExpr,
+    use_inline_table_object: bool,
+) -> Result<LuaType, InferFailReason> {
+    if use_inline_table_object
+        && let LuaExpr::TableExpr(table_expr) = arg_expr
+        && !table_expr.is_array()
+        && !table_expr.is_empty()
+    {
+        let mut fields = HashMap::new();
+        for field in table_expr.get_fields() {
+            let field_key = field.get_field_key().ok_or(InferFailReason::None)?;
+            let member_key = LuaMemberKey::from_index_key(db, context.cache, &field_key)?;
+            if matches!(member_key, LuaMemberKey::ExprType(ref typ) if typ.is_unknown()) {
+                continue;
+            }
+
+            let value_expr = field.get_value_expr().ok_or(InferFailReason::None)?;
+            let value_type = infer_expr(db, context.cache, value_expr)?;
+            let value_type = match value_type {
+                LuaType::Variadic(multi) => multi.get_type(0).cloned().unwrap_or(LuaType::Nil),
+                LuaType::Def(ref_id) => LuaType::Ref(ref_id),
+                other => other,
+            };
+            fields.insert(member_key, value_type);
+        }
+
+        if !fields.is_empty() {
+            return Ok(LuaType::Object(
+                LuaObjectType::new_with_fields(fields, Vec::new()).into(),
+            ));
+        }
+    }
+
+    infer_expr(db, context.cache, arg_expr.clone())
+}
+
+fn type_needs_structural_table_arg(db: &DbIndex, typ: &LuaType, depth: usize) -> bool {
+    if depth > 8 {
+        return false;
+    }
+
+    let mut needs_structural_table_arg = false;
+    typ.visit_type(&mut |visited| {
+        if needs_structural_table_arg {
+            return;
+        }
+
+        match visited {
+            LuaType::Mapped(_) | LuaType::Conditional(_) | LuaType::Call(_) => {
+                needs_structural_table_arg = true;
+            }
+            LuaType::Generic(generic) => {
+                let type_id = generic.get_base_type_id();
+                let Some(type_decl) = db.get_type_index().get_type_decl(&type_id) else {
+                    return;
+                };
+                if !type_decl.is_alias() {
+                    return;
+                }
+
+                if let Some(origin) = type_decl.get_alias_ref() {
+                    needs_structural_table_arg =
+                        type_needs_structural_table_arg(db, origin, depth + 1);
+                }
+            }
+            LuaType::Ref(type_id) | LuaType::Def(type_id) => {
+                let Some(type_decl) = db.get_type_index().get_type_decl(type_id) else {
+                    return;
+                };
+                if !type_decl.is_alias() {
+                    return;
+                }
+
+                if let Some(origin) = type_decl.get_alias_ref() {
+                    needs_structural_table_arg =
+                        type_needs_structural_table_arg(db, origin, depth + 1);
+                }
+            }
+            _ => {}
+        }
+    });
+
+    needs_structural_table_arg
 }
 
 pub fn build_self_type(db: &DbIndex, self_type: &LuaType) -> LuaType {

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -148,11 +148,12 @@ fn infer_generic_types_from_call(
             break;
         }
 
-        if context.substitutor.is_infer_all_tpl() {
+        let (_, func_param_type) = &func_params[i];
+        let collect_more_candidates = is_direct_type_candidate(func_param_type);
+        if context.substitutor.is_infer_all_tpl() && !collect_more_candidates {
             break;
         }
 
-        let (_, func_param_type) = &func_params[i];
         let call_arg_expr = &arg_exprs[i];
         if !func_param_type.contain_tpl() {
             continue;
@@ -193,7 +194,13 @@ fn infer_generic_types_from_call(
                 break;
             }
             _ => {
+                let previous = context
+                    .substitutor
+                    .set_union_type_candidates_enabled(collect_more_candidates);
                 tpl_pattern_match(context, func_param_type, &arg_type)?;
+                context
+                    .substitutor
+                    .set_union_type_candidates_enabled(previous);
             }
         }
     }
@@ -208,6 +215,13 @@ fn infer_generic_types_from_call(
     }
 
     Ok(())
+}
+
+fn is_direct_type_candidate(typ: &LuaType) -> bool {
+    matches!(
+        typ,
+        LuaType::TplRef(_) | LuaType::ConstTplRef(_) | LuaType::StrTplRef(_)
+    )
 }
 
 fn infer_generic_arg_type(

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use crate::{LuaMemberOwner, LuaSemanticDeclId, SemanticDeclLevel, infer_node_semantic_decl};
 
-use super::TypeSubstitutor;
+use crate::InferenceContext;
 
 pub fn instantiate_func_generic(
     db: &DbIndex,
@@ -77,38 +77,40 @@ pub fn instantiate_func_generic_with_context(
         .ok_or(InferFailReason::None)?
         .get_args()
         .collect::<Vec<_>>();
-    let mut substitutor = TypeSubstitutor::new();
-    let mut context = TplContext {
-        db,
-        cache,
-        substitutor: &mut substitutor,
-        call_expr: Some(call_expr.clone()),
-    };
-    if !generic_tpls.is_empty() {
-        context.substitutor.add_need_infer_tpls(generic_tpls);
+    let mut inference = InferenceContext::new();
+    {
+        let mut context = TplContext {
+            db,
+            cache,
+            substitutor: &mut inference,
+            call_expr: Some(call_expr.clone()),
+        };
+        if !generic_tpls.is_empty() {
+            context.substitutor.add_need_infer_tpls(generic_tpls);
 
-        if let Some(type_list) = call_expr.get_call_generic_type_list() {
-            // 如果使用了`obj:abc--[[@<string>]]("abc")`强制指定了泛型, 那么我们只需要直接应用
-            apply_call_generic_type_list(db, file_id, &mut context, &type_list);
-        } else {
-            // 如果没有指定泛型, 则需要从调用参数中推断
-            infer_generic_types_from_call(
-                db,
-                &mut context,
-                func,
-                &call_expr,
-                &mut func_params,
-                &arg_exprs,
-                contextual_return_hint.as_ref(),
-            )?;
+            if let Some(type_list) = call_expr.get_call_generic_type_list() {
+                // 如果使用了`obj:abc--[[@<string>]]("abc")`强制指定了泛型, 那么我们只需要直接应用
+                apply_call_generic_type_list(db, file_id, &mut context, &type_list);
+            } else {
+                // 如果没有指定泛型, 则需要从调用参数中推断
+                infer_generic_types_from_call(
+                    db,
+                    &mut context,
+                    func,
+                    &call_expr,
+                    &mut func_params,
+                    &arg_exprs,
+                    contextual_return_hint.as_ref(),
+                )?;
+            }
         }
     }
 
     if contain_self && let Some(self_type) = infer_self_type(db, cache, &call_expr) {
-        substitutor.add_self_type(self_type);
+        inference.add_self_type(self_type);
     }
 
-    if let LuaType::DocFunction(f) = instantiate_doc_function(db, func, &substitutor) {
+    if let LuaType::DocFunction(f) = instantiate_doc_function(db, func, inference.substitutor()) {
         Ok(f.deref().clone())
     } else {
         Ok(func.clone())

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -160,8 +160,14 @@ fn infer_generic_types_from_call(
         || func_params
             .iter()
             .any(|(_, ty)| type_needs_structural_table_arg(db, ty, 0));
+    let mut arg_offset = 0isize;
     for i in 0..func_params.len() {
-        if i >= arg_exprs.len() {
+        let arg_index = i as isize + arg_offset;
+        if arg_index < 0 {
+            continue;
+        }
+        let arg_index = arg_index as usize;
+        if arg_index >= arg_exprs.len() {
             break;
         }
 
@@ -174,14 +180,39 @@ fn infer_generic_types_from_call(
             break;
         }
 
-        let call_arg_expr = &arg_exprs[i];
         if !func_param_type.contain_tpl() {
             continue;
         }
 
-        if !func_param_type.is_variadic()
-            && check_expr_can_later_infer(context, func_param_type, call_arg_expr)?
-        {
+        match func_param_type {
+            LuaType::Variadic(variadic) => {
+                let mut rest_arg_exprs = &arg_exprs[arg_index..];
+                let is_last_param = i + 1 == func_params.len();
+                if !is_last_param {
+                    let suffix_len = func_params.len() - i - 1;
+                    let rest_len = rest_arg_exprs.len().saturating_sub(suffix_len);
+                    rest_arg_exprs = &rest_arg_exprs[..rest_len];
+                    arg_offset += rest_len as isize - 1;
+                }
+
+                let mut arg_types = vec![];
+                for arg_expr in rest_arg_exprs {
+                    let arg_type =
+                        infer_generic_arg_type(db, context, arg_expr, use_inline_table_object)?;
+                    arg_types.push(arg_type);
+                }
+                variadic_tpl_pattern_match(context, variadic, &arg_types)?;
+                if is_last_param {
+                    break;
+                }
+
+                continue;
+            }
+            _ => {}
+        }
+
+        let call_arg_expr = &arg_exprs[arg_index];
+        if check_expr_can_later_infer(context, func_param_type, call_arg_expr)? {
             // 如果参数不能被后续推断, 那么我们先不处理
             unresolve_tpls.push((func_param_type.clone(), call_arg_expr.clone()));
             continue;
@@ -193,18 +224,8 @@ fn infer_generic_types_from_call(
                 Err(InferFailReason::FieldNotFound) => LuaType::Nil, // 对于未找到的字段, 我们认为是 nil 以执行后续推断
                 Err(e) => return Err(e),
             };
-        match (func_param_type, &arg_type) {
-            (LuaType::Variadic(variadic), _) => {
-                let mut arg_types = vec![];
-                for arg_expr in &arg_exprs[i..] {
-                    let arg_type =
-                        infer_generic_arg_type(db, context, arg_expr, use_inline_table_object)?;
-                    arg_types.push(arg_type);
-                }
-                variadic_tpl_pattern_match(context, variadic, &arg_types)?;
-                break;
-            }
-            (_, LuaType::Variadic(variadic)) => {
+        match &arg_type {
+            LuaType::Variadic(variadic) => {
                 let func_param_types = func_params[i..]
                     .iter()
                     .map(|(_, t)| t)

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -156,7 +156,10 @@ fn infer_generic_types_from_call(
     }
 
     let mut unresolve_tpls = vec![];
-    let use_inline_table_object = type_needs_structural_table_arg(db, func.get_ret(), 0);
+    let use_inline_table_object = type_needs_structural_table_arg(db, func.get_ret(), 0)
+        || func_params
+            .iter()
+            .any(|(_, ty)| type_needs_structural_table_arg(db, ty, 0));
     for i in 0..func_params.len() {
         if i >= arg_exprs.len() {
             break;
@@ -302,7 +305,10 @@ fn type_needs_structural_table_arg(db: &DbIndex, typ: &LuaType, depth: usize) ->
         }
 
         match visited {
-            LuaType::Mapped(_) | LuaType::Conditional(_) | LuaType::Call(_) => {
+            LuaType::Mapped(_)
+            | LuaType::TableGeneric(_)
+            | LuaType::Conditional(_)
+            | LuaType::Call(_) => {
                 needs_structural_table_arg = true;
             }
             LuaType::Generic(generic) => {

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -164,7 +164,10 @@ fn infer_generic_types_from_call(
 
         let (_, func_param_type) = &func_params[i];
         let collect_more_candidates = is_direct_type_candidate(func_param_type);
-        if context.substitutor.is_infer_all_tpl() && !collect_more_candidates {
+        if context.substitutor.is_infer_all_tpl()
+            && !collect_more_candidates
+            && !context.substitutor.has_non_direct_type_inferences()
+        {
             break;
         }
 

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -37,6 +37,16 @@ pub fn instantiate_func_generic(
     func: &LuaFunctionType,
     call_expr: LuaCallExpr,
 ) -> Result<LuaFunctionType, InferFailReason> {
+    instantiate_func_generic_with_context(db, cache, func, call_expr, None)
+}
+
+pub fn instantiate_func_generic_with_context(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    func: &LuaFunctionType,
+    call_expr: LuaCallExpr,
+    contextual_return_hint: Option<LuaType>,
+) -> Result<LuaFunctionType, InferFailReason> {
     let file_id = cache.get_file_id().clone();
     let mut generic_tpls = HashSet::new();
     let mut contain_self = false;
@@ -89,6 +99,7 @@ pub fn instantiate_func_generic(
                 &call_expr,
                 &mut func_params,
                 &arg_exprs,
+                contextual_return_hint.as_ref(),
             )?;
         }
     }
@@ -126,6 +137,7 @@ fn infer_generic_types_from_call(
     call_expr: &LuaCallExpr,
     func_params: &mut Vec<(String, LuaType)>,
     arg_exprs: &[LuaExpr],
+    contextual_return_hint: Option<&LuaType>,
 ) -> Result<(), InferFailReason> {
     let colon_call = call_expr.is_colon_call();
     let colon_define = func.is_colon_define();
@@ -206,6 +218,13 @@ fn infer_generic_types_from_call(
                     .set_type_candidate_collection_enabled(previous);
             }
         }
+    }
+
+    if let Some(return_hint) = contextual_return_hint
+        && func.get_ret().contain_tpl()
+        && !context.substitutor.is_infer_all_tpl()
+    {
+        tpl_pattern_match(context, func.get_ret(), return_hint)?;
     }
 
     if !context.substitutor.is_infer_all_tpl() {

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_special_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_special_generic.rs
@@ -319,7 +319,22 @@ fn instantiate_index_call(db: &DbIndex, owner: &LuaType, key: &LuaType) -> LuaTy
     }
 
     if let Some(member_key) = key_type_to_member_key(key) {
-        infer_raw_member_type(db, owner, &member_key).unwrap_or(LuaType::Never)
+        infer_raw_member_type(db, owner, &member_key).unwrap_or_else(|_| {
+            find_members(db, owner)
+                .and_then(|members| {
+                    let mut result = LuaType::Unknown;
+                    let mut found = false;
+                    for member in members {
+                        if member.key == member_key {
+                            result = TypeOps::Union.apply(db, &result, &member.typ);
+                            found = true;
+                        }
+                    }
+
+                    found.then_some(result)
+                })
+                .unwrap_or(LuaType::Never)
+        })
     } else {
         LuaType::Never
     }

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -20,7 +20,10 @@ use crate::{
 use super::type_substitutor::{SubstitutorValue, TypeSubstitutor, union_candidate_type};
 use crate::TypeVisitTrait;
 use crate::semantic::member::find_members_with_key;
-pub use instantiate_func_generic::{build_self_type, infer_self_type, instantiate_func_generic};
+pub use instantiate_func_generic::{
+    build_self_type, infer_self_type, instantiate_func_generic,
+    instantiate_func_generic_with_context,
+};
 pub use instantiate_special_generic::get_keyof_members;
 pub use instantiate_special_generic::instantiate_alias_call;
 

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -808,17 +808,65 @@ fn collect_infer_to_union(
     assignments: &mut HashMap<String, LuaType>,
     infer_guard: &InferGuardRef,
 ) -> bool {
+    if let LuaType::Union(source_union) = source {
+        let mut matched = false;
+        let mut union_assignments = assignments.clone();
+        for source_member in source_union.into_vec() {
+            let mut branch_assignments = union_assignments.clone();
+            if collect_infer_to_union(
+                db,
+                &source_member,
+                pattern_union,
+                &mut branch_assignments,
+                &infer_guard.fork(),
+            ) {
+                union_assignments = branch_assignments;
+                matched = true;
+            }
+        }
+
+        if matched {
+            *assignments = union_assignments;
+        }
+        return matched;
+    }
+
     let mut matched = false;
     let mut union_assignments = assignments.clone();
-    for member in pattern_union.into_vec() {
+    let mut structural_infer_names = HashSet::new();
+    let pattern_members = pattern_union.into_vec();
+
+    for member in pattern_members
+        .iter()
+        .filter(|member| !is_naked_conditional_infer(member))
+    {
         let mut branch_assignments = union_assignments.clone();
         if collect_infer_assignments_inner(
             db,
             source,
-            &member,
+            member,
             &mut branch_assignments,
             &infer_guard.fork(),
         ) {
+            collect_conditional_infer_names(member, &mut structural_infer_names);
+            union_assignments = branch_assignments;
+            matched = true;
+        }
+    }
+
+    for member in pattern_members
+        .iter()
+        .filter(|member| is_naked_conditional_infer(member))
+    {
+        let LuaType::ConditionalInfer(name) = member else {
+            continue;
+        };
+        if structural_infer_names.contains(name.as_str()) {
+            continue;
+        }
+
+        let mut branch_assignments = union_assignments.clone();
+        if insert_infer_assignment(&mut branch_assignments, name.as_str(), source) {
             union_assignments = branch_assignments;
             matched = true;
         }
@@ -828,6 +876,18 @@ fn collect_infer_to_union(
         *assignments = union_assignments;
     }
     matched
+}
+
+fn is_naked_conditional_infer(ty: &LuaType) -> bool {
+    matches!(ty, LuaType::ConditionalInfer(_))
+}
+
+fn collect_conditional_infer_names(ty: &LuaType, names: &mut HashSet<String>) {
+    ty.visit_type(&mut |inner| {
+        if let LuaType::ConditionalInfer(name) = inner {
+            names.insert(name.as_str().to_string());
+        }
+    });
 }
 
 fn collect_infer_from_generic_source(

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -983,7 +983,7 @@ fn collect_infer_from_matching_generic_params(
             source_param,
             pattern_param,
             &mut branch_assignments,
-            infer_guard,
+            &infer_guard.fork(),
         ) {
             return false;
         }

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -74,6 +74,22 @@ pub fn instantiate_type_generic(
     }
 }
 
+pub fn instantiate_type_generic_preserve_unresolved(
+    db: &DbIndex,
+    ty: &LuaType,
+    substitutor: &TypeSubstitutor,
+) -> LuaType {
+    match ty {
+        LuaType::DocFunction(doc_func) => {
+            instantiate_doc_function_with_unresolved(db, doc_func, substitutor)
+        }
+        LuaType::Variadic(variadic) => {
+            instantiate_variadic_type_preserve_unresolved(db, variadic, substitutor)
+        }
+        _ => instantiate_type_generic(db, ty, substitutor),
+    }
+}
+
 fn instantiate_array(db: &DbIndex, base: &LuaType, substitutor: &TypeSubstitutor) -> LuaType {
     let base = instantiate_type_generic(db, base, substitutor);
     LuaType::Array(LuaArrayType::from_base_type(base).into())
@@ -123,6 +139,23 @@ pub fn instantiate_doc_function(
     doc_func: &LuaFunctionType,
     substitutor: &TypeSubstitutor,
 ) -> LuaType {
+    instantiate_doc_function_inner(db, doc_func, substitutor, false)
+}
+
+fn instantiate_doc_function_with_unresolved(
+    db: &DbIndex,
+    doc_func: &LuaFunctionType,
+    substitutor: &TypeSubstitutor,
+) -> LuaType {
+    instantiate_doc_function_inner(db, doc_func, substitutor, true)
+}
+
+fn instantiate_doc_function_inner(
+    db: &DbIndex,
+    doc_func: &LuaFunctionType,
+    substitutor: &TypeSubstitutor,
+    preserve_unresolved: bool,
+) -> LuaType {
     let tpl_func_params = doc_func.get_params();
     let tpl_ret = doc_func.get_ret();
     let async_state = doc_func.get_async_state();
@@ -159,7 +192,7 @@ pub fn instantiate_doc_function(
                                     new_params.push((
                                         "...".to_string(),
                                         Some(LuaType::Variadic(
-                                            VariadicType::Base(LuaType::Any).into(),
+                                            VariadicType::Base(resolved_type.clone()).into(),
                                         )),
                                     ));
                                 }
@@ -176,15 +209,25 @@ pub fn instantiate_doc_function(
                                     }
                                 }
                                 _ => {
-                                    is_variadic = true;
-                                    new_params.push((
-                                        "...".to_string(),
-                                        Some(LuaType::Variadic(
-                                            VariadicType::Base(LuaType::Any).into(),
-                                        )),
-                                    ));
+                                    if preserve_unresolved {
+                                        new_params.push((
+                                            origin_param.0.clone(),
+                                            Some(origin_param_type.clone()),
+                                        ));
+                                    } else {
+                                        is_variadic = true;
+                                        new_params.push((
+                                            "...".to_string(),
+                                            Some(LuaType::Variadic(
+                                                VariadicType::Base(LuaType::Any).into(),
+                                            )),
+                                        ));
+                                    }
                                 }
                             }
+                        } else if preserve_unresolved {
+                            new_params
+                                .push((origin_param.0.clone(), Some(origin_param_type.clone())));
                         }
                     }
                     LuaType::Generic(generic) => {
@@ -206,13 +249,21 @@ pub fn instantiate_doc_function(
                 VariadicType::Multi(_) => (),
             },
             _ => {
-                let new_type = instantiate_type_generic(db, origin_param_type, substitutor);
+                let new_type = if preserve_unresolved {
+                    instantiate_type_generic_preserve_unresolved(db, origin_param_type, substitutor)
+                } else {
+                    instantiate_type_generic(db, origin_param_type, substitutor)
+                };
                 new_params.push((origin_param.0.clone(), Some(new_type)));
             }
         }
     }
 
-    let mut inst_ret_type = instantiate_type_generic(db, tpl_ret, substitutor);
+    let mut inst_ret_type = if preserve_unresolved {
+        instantiate_type_generic_preserve_unresolved(db, tpl_ret, substitutor)
+    } else {
+        instantiate_type_generic(db, tpl_ret, substitutor)
+    };
     // 对于可变返回值, 如果实例化是 tuple, 那么我们将展开 tuple
     if let LuaType::Variadic(_) = &&tpl_ret
         && let LuaType::Tuple(tuple) = &inst_ret_type
@@ -465,6 +516,50 @@ fn instantiate_variadic_type(
     }
 
     LuaType::Variadic(variadic.clone().into())
+}
+
+fn instantiate_variadic_type_preserve_unresolved(
+    db: &DbIndex,
+    variadic: &VariadicType,
+    substitutor: &TypeSubstitutor,
+) -> LuaType {
+    match variadic {
+        VariadicType::Base(base) => match base {
+            LuaType::TplRef(tpl) => match substitutor.get(tpl.get_tpl_id()) {
+                Some(SubstitutorValue::None) | None => {
+                    return LuaType::Variadic(variadic.clone().into());
+                }
+                _ => {}
+            },
+            LuaType::Generic(generic) => {
+                return instantiate_generic(db, generic, substitutor);
+            }
+            _ => {}
+        },
+        VariadicType::Multi(types) => {
+            if types.iter().any(|it| it.contain_tpl()) {
+                let mut new_types = Vec::new();
+                for t in types {
+                    let t = instantiate_type_generic_preserve_unresolved(db, t, substitutor);
+                    match t {
+                        LuaType::Never => {}
+                        LuaType::Variadic(variadic) => match variadic.deref() {
+                            VariadicType::Base(base) => new_types.push(base.clone()),
+                            VariadicType::Multi(multi) => {
+                                for mt in multi {
+                                    new_types.push(mt.clone());
+                                }
+                            }
+                        },
+                        _ => new_types.push(t),
+                    }
+                }
+                return LuaType::Variadic(VariadicType::Multi(new_types).into());
+            }
+        }
+    }
+
+    instantiate_variadic_type(db, variadic, substitutor)
 }
 
 fn instantiate_conditional(

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -633,7 +633,7 @@ fn instantiate_conditional(
                     let tpl_id_map = resolve_infer_tpl_ids(conditional, substitutor, &infer_names);
                     for (name, ty) in infer_assignments.iter() {
                         if let Some(tpl_id) = tpl_id_map.get(name.as_str()) {
-                            true_substitutor.insert_type(*tpl_id, ty.clone(), true);
+                            true_substitutor.set_fixed_type(*tpl_id, ty.clone(), true);
                         }
                     }
                 }
@@ -1445,7 +1445,7 @@ fn instantiate_mapped_value(
     replacement: &LuaType,
 ) -> LuaType {
     let mut local_substitutor = substitutor.clone();
-    local_substitutor.insert_type(tpl_id, replacement.clone(), true);
+    local_substitutor.set_fixed_type(tpl_id, replacement.clone(), true);
     let mut result = instantiate_type_generic(db, &mapped.value, &local_substitutor);
     // 根据 readonly 和 optional 属性进行处理
     if mapped.is_optional {

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -586,6 +586,9 @@ fn instantiate_conditional(
         }
         let right_origin = &alias_call.get_operands()[1];
         let right = instantiate_type_generic(db, right_origin, substitutor);
+        // TS-Go getInferredTypeParameterConstraint: in Foo<T, U extends T>,
+        // Foo<number, infer B> constrains B to number, and Foo<Q, infer B>
+        // constrains B through the outer mapper for Q.
         let infer_constraints = collect_conditional_infer_constraints(db, &right);
         // 如果存在 new 标记与左侧为类定义, 那么我们需要的是他的构造函数签名
         if conditional.has_new
@@ -700,6 +703,8 @@ fn collect_conditional_infer_constraints_inner(
                     generic.get_params().clone(),
                 );
                 for (i, pattern_param) in generic.get_params().iter().enumerate() {
+                    // If infer sits directly in a generic argument, inherit the
+                    // declared constraint from that generic parameter.
                     if let LuaType::ConditionalInfer(name) = pattern_param
                         && let Some(declared_constraint) = generic_params
                             .get(i)
@@ -837,6 +842,8 @@ fn insert_conditional_infer_constraint(
 }
 
 fn is_self_conditional_infer(ty: &LuaType, name: &str) -> bool {
+    // TS-Go discards constraints that instantiate back to the same infer
+    // parameter, e.g. Foo<infer X, infer X> where U extends T.
     matches!(ty, LuaType::ConditionalInfer(infer_name) if infer_name.as_str() == name)
 }
 
@@ -851,6 +858,9 @@ fn apply_conditional_infer_constraints(
 
     let assignments_snapshot = assignments.clone();
     for (name, constraint) in constraints {
+        // This is a narrow nonFixingMapper-shaped substitution: constraints
+        // may reference another infer parameter, so resolve through the
+        // assignments collected from the same conditional pattern.
         let constraint = substitute_conditional_infer_names(constraint, &assignments_snapshot);
         if contains_conditional_infer(&constraint) {
             continue;

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -821,8 +821,10 @@ fn collect_infer_from_generic_source(
             infer_guard,
         ),
         LuaType::Union(union) => {
+            let mut matched = false;
+            let mut union_assignments = assignments.clone();
             for member in union.into_vec() {
-                let mut branch_assignments = assignments.clone();
+                let mut branch_assignments = union_assignments.clone();
                 if collect_infer_from_generic_source(
                     db,
                     &member,
@@ -830,11 +832,15 @@ fn collect_infer_from_generic_source(
                     &mut branch_assignments,
                     &infer_guard.fork(),
                 ) {
-                    *assignments = branch_assignments;
-                    return true;
+                    union_assignments = branch_assignments;
+                    matched = true;
                 }
             }
-            false
+
+            if matched {
+                *assignments = union_assignments;
+            }
+            matched
         }
         _ => false,
     }

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -595,6 +595,9 @@ fn collect_infer_assignments_inner(
         LuaType::ConditionalInfer(name) => {
             insert_infer_assignment(assignments, name.as_str(), source)
         }
+        LuaType::Union(pattern_union) => {
+            collect_infer_to_union(db, source, pattern_union, assignments, infer_guard)
+        }
         LuaType::Generic(pattern_generic) => {
             collect_infer_from_generic_source(db, source, pattern_generic, assignments, infer_guard)
         }
@@ -796,6 +799,35 @@ fn collect_infer_assignments_inner(
             }
         }
     }
+}
+
+fn collect_infer_to_union(
+    db: &DbIndex,
+    source: &LuaType,
+    pattern_union: &LuaUnionType,
+    assignments: &mut HashMap<String, LuaType>,
+    infer_guard: &InferGuardRef,
+) -> bool {
+    let mut matched = false;
+    let mut union_assignments = assignments.clone();
+    for member in pattern_union.into_vec() {
+        let mut branch_assignments = union_assignments.clone();
+        if collect_infer_assignments_inner(
+            db,
+            source,
+            &member,
+            &mut branch_assignments,
+            &infer_guard.fork(),
+        ) {
+            union_assignments = branch_assignments;
+            matched = true;
+        }
+    }
+
+    if matched {
+        *assignments = union_assignments;
+    }
+    matched
 }
 
 fn collect_infer_from_generic_source(

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -11,8 +11,8 @@ use crate::{
     LuaConditionalType, LuaInstanceType, LuaMappedType, LuaMemberKey, LuaOperatorMetaMethod,
     LuaSignatureId, LuaTupleStatus, LuaTypeDeclId, TypeOps, check_type_compact,
     db_index::{
-        LuaFunctionType, LuaGenericType, LuaIntersectionType, LuaObjectType, LuaTupleType, LuaType,
-        LuaUnionType, VariadicType,
+        LuaAliasCallType, LuaAttributeType, LuaFunctionType, LuaGenericType, LuaIntersectionType,
+        LuaMultiLineUnion, LuaObjectType, LuaTupleType, LuaType, LuaUnionType, VariadicType,
     },
     semantic::type_check::{TypeCheckCheckLevel, check_type_compact_with_level},
 };
@@ -586,6 +586,7 @@ fn instantiate_conditional(
         }
         let right_origin = &alias_call.get_operands()[1];
         let right = instantiate_type_generic(db, right_origin, substitutor);
+        let infer_constraints = collect_conditional_infer_constraints(db, &right);
         // 如果存在 new 标记与左侧为类定义, 那么我们需要的是他的构造函数签名
         if conditional.has_new
             && let LuaType::Ref(id) | LuaType::Def(id) = &left
@@ -604,6 +605,7 @@ fn instantiate_conditional(
         if contains_conditional_infer(&right)
             && collect_infer_assignments(db, &left, &right, &mut infer_assignments)
         {
+            apply_conditional_infer_constraints(db, &mut infer_assignments, &infer_constraints);
             condition_result = Some(true);
         } else {
             condition_result = Some(
@@ -670,6 +672,408 @@ fn contains_conditional_infer(ty: &LuaType) -> bool {
         }
     });
     found
+}
+
+fn collect_conditional_infer_constraints(
+    db: &DbIndex,
+    pattern: &LuaType,
+) -> HashMap<String, LuaType> {
+    let mut constraints = HashMap::new();
+    collect_conditional_infer_constraints_inner(db, pattern, &mut constraints);
+    constraints
+}
+
+fn collect_conditional_infer_constraints_inner(
+    db: &DbIndex,
+    pattern: &LuaType,
+    constraints: &mut HashMap<String, LuaType>,
+) {
+    match pattern {
+        LuaType::Generic(generic) => {
+            if let Some(generic_params) = db
+                .get_type_index()
+                .get_generic_params(generic.get_base_type_id_ref())
+            {
+                let substitutor = TypeSubstitutor::from_type_array_for_type(
+                    db,
+                    generic.get_base_type_id_ref(),
+                    generic.get_params().clone(),
+                );
+                for (i, pattern_param) in generic.get_params().iter().enumerate() {
+                    if let LuaType::ConditionalInfer(name) = pattern_param
+                        && let Some(declared_constraint) = generic_params
+                            .get(i)
+                            .and_then(|param| param.type_constraint.as_ref())
+                    {
+                        let constraint =
+                            instantiate_type_generic(db, declared_constraint, &substitutor);
+                        if !is_self_conditional_infer(&constraint, name.as_str()) {
+                            insert_conditional_infer_constraint(
+                                constraints,
+                                name.as_str(),
+                                constraint,
+                            );
+                        }
+                    }
+                }
+            }
+
+            for param in generic.get_params() {
+                collect_conditional_infer_constraints_inner(db, param, constraints);
+            }
+        }
+        LuaType::Array(array) => {
+            collect_conditional_infer_constraints_inner(db, array.get_base(), constraints);
+        }
+        LuaType::Tuple(tuple) => {
+            for ty in tuple.get_types() {
+                collect_conditional_infer_constraints_inner(db, ty, constraints);
+            }
+        }
+        LuaType::DocFunction(func) => {
+            for (_, param) in func.get_params() {
+                if let Some(param) = param {
+                    collect_conditional_infer_constraints_inner(db, param, constraints);
+                }
+            }
+            collect_conditional_infer_constraints_inner(db, func.get_ret(), constraints);
+        }
+        LuaType::Object(object) => {
+            for ty in object.get_fields().values() {
+                collect_conditional_infer_constraints_inner(db, ty, constraints);
+            }
+            for (key, value) in object.get_index_access() {
+                collect_conditional_infer_constraints_inner(db, key, constraints);
+                collect_conditional_infer_constraints_inner(db, value, constraints);
+            }
+        }
+        LuaType::Union(union) => {
+            for ty in union.into_vec() {
+                collect_conditional_infer_constraints_inner(db, &ty, constraints);
+            }
+        }
+        LuaType::Intersection(intersection) => {
+            for ty in intersection.get_types() {
+                collect_conditional_infer_constraints_inner(db, ty, constraints);
+            }
+        }
+        LuaType::TableGeneric(params) => {
+            for param in params.iter() {
+                collect_conditional_infer_constraints_inner(db, param, constraints);
+            }
+        }
+        LuaType::Variadic(variadic) => match variadic.deref() {
+            VariadicType::Base(base) => {
+                collect_conditional_infer_constraints_inner(db, base, constraints);
+            }
+            VariadicType::Multi(types) => {
+                for ty in types {
+                    collect_conditional_infer_constraints_inner(db, ty, constraints);
+                }
+            }
+        },
+        LuaType::Call(call) => {
+            for operand in call.get_operands() {
+                collect_conditional_infer_constraints_inner(db, operand, constraints);
+            }
+        }
+        LuaType::MultiLineUnion(union) => {
+            for (ty, _) in union.get_unions() {
+                collect_conditional_infer_constraints_inner(db, ty, constraints);
+            }
+        }
+        LuaType::TypeGuard(inner) => {
+            collect_conditional_infer_constraints_inner(db, inner, constraints);
+        }
+        LuaType::TableOf(inner) => {
+            collect_conditional_infer_constraints_inner(db, inner, constraints);
+        }
+        LuaType::Conditional(conditional) => {
+            collect_conditional_infer_constraints_inner(
+                db,
+                conditional.get_condition(),
+                constraints,
+            );
+            collect_conditional_infer_constraints_inner(
+                db,
+                conditional.get_true_type(),
+                constraints,
+            );
+            collect_conditional_infer_constraints_inner(
+                db,
+                conditional.get_false_type(),
+                constraints,
+            );
+        }
+        LuaType::Mapped(mapped) => {
+            if let Some(constraint) = &mapped.param.1.type_constraint {
+                collect_conditional_infer_constraints_inner(db, constraint, constraints);
+            }
+            collect_conditional_infer_constraints_inner(db, &mapped.value, constraints);
+        }
+        _ => {}
+    }
+}
+
+fn insert_conditional_infer_constraint(
+    constraints: &mut HashMap<String, LuaType>,
+    name: &str,
+    constraint: LuaType,
+) {
+    if let Some(existing) = constraints.get_mut(name) {
+        if *existing == constraint {
+            return;
+        }
+
+        let mut types = match existing {
+            LuaType::Intersection(intersection) => intersection.into_types(),
+            _ => vec![existing.clone()],
+        };
+        types.push(constraint);
+        *existing = LuaType::Intersection(LuaIntersectionType::new(types).into());
+    } else {
+        constraints.insert(name.to_string(), constraint);
+    }
+}
+
+fn is_self_conditional_infer(ty: &LuaType, name: &str) -> bool {
+    matches!(ty, LuaType::ConditionalInfer(infer_name) if infer_name.as_str() == name)
+}
+
+fn apply_conditional_infer_constraints(
+    db: &DbIndex,
+    assignments: &mut HashMap<String, LuaType>,
+    constraints: &HashMap<String, LuaType>,
+) {
+    if constraints.is_empty() {
+        return;
+    }
+
+    let assignments_snapshot = assignments.clone();
+    for (name, constraint) in constraints {
+        let constraint = substitute_conditional_infer_names(constraint, &assignments_snapshot);
+        if contains_conditional_infer(&constraint) {
+            continue;
+        }
+
+        let Some(candidate) = assignments.get(name).cloned() else {
+            assignments.insert(name.clone(), constraint);
+            continue;
+        };
+
+        if check_type_compact_with_level(
+            db,
+            &constraint,
+            &candidate,
+            TypeCheckCheckLevel::GenericConditional,
+        )
+        .is_err()
+        {
+            assignments.insert(name.clone(), constraint);
+        }
+    }
+}
+
+fn substitute_conditional_infer_names(
+    ty: &LuaType,
+    assignments: &HashMap<String, LuaType>,
+) -> LuaType {
+    match ty {
+        LuaType::ConditionalInfer(name) => assignments
+            .get(name.as_str())
+            .cloned()
+            .unwrap_or_else(|| ty.clone()),
+        LuaType::Array(array) => LuaType::Array(
+            LuaArrayType::new(
+                substitute_conditional_infer_names(array.get_base(), assignments),
+                array.get_len().clone(),
+            )
+            .into(),
+        ),
+        LuaType::Tuple(tuple) => LuaType::Tuple(
+            LuaTupleType::new(
+                tuple
+                    .get_types()
+                    .iter()
+                    .map(|ty| substitute_conditional_infer_names(ty, assignments))
+                    .collect(),
+                tuple.status,
+            )
+            .into(),
+        ),
+        LuaType::DocFunction(func) => LuaType::DocFunction(
+            LuaFunctionType::new(
+                func.get_async_state(),
+                func.is_colon_define(),
+                func.is_variadic(),
+                func.get_params()
+                    .iter()
+                    .map(|(name, ty)| {
+                        (
+                            name.clone(),
+                            ty.as_ref()
+                                .map(|ty| substitute_conditional_infer_names(ty, assignments)),
+                        )
+                    })
+                    .collect(),
+                substitute_conditional_infer_names(func.get_ret(), assignments),
+            )
+            .into(),
+        ),
+        LuaType::Object(object) => {
+            let fields = object
+                .get_fields()
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        substitute_conditional_infer_names(value, assignments),
+                    )
+                })
+                .collect();
+            let index_access = object
+                .get_index_access()
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        substitute_conditional_infer_names(key, assignments),
+                        substitute_conditional_infer_names(value, assignments),
+                    )
+                })
+                .collect();
+            LuaType::Object(LuaObjectType::new_with_fields(fields, index_access).into())
+        }
+        LuaType::Union(union) => LuaType::from_vec(
+            union
+                .into_vec()
+                .into_iter()
+                .map(|ty| substitute_conditional_infer_names(&ty, assignments))
+                .collect(),
+        ),
+        LuaType::Intersection(intersection) => LuaType::Intersection(
+            LuaIntersectionType::new(
+                intersection
+                    .get_types()
+                    .iter()
+                    .map(|ty| substitute_conditional_infer_names(ty, assignments))
+                    .collect(),
+            )
+            .into(),
+        ),
+        LuaType::Generic(generic) => LuaType::Generic(
+            LuaGenericType::new(
+                generic.get_base_type_id(),
+                generic
+                    .get_params()
+                    .iter()
+                    .map(|ty| substitute_conditional_infer_names(ty, assignments))
+                    .collect(),
+            )
+            .into(),
+        ),
+        LuaType::TableGeneric(params) => LuaType::TableGeneric(
+            params
+                .iter()
+                .map(|ty| substitute_conditional_infer_names(ty, assignments))
+                .collect::<Vec<_>>()
+                .into(),
+        ),
+        LuaType::Variadic(variadic) => LuaType::Variadic(
+            match variadic.deref() {
+                VariadicType::Base(base) => {
+                    VariadicType::Base(substitute_conditional_infer_names(base, assignments))
+                }
+                VariadicType::Multi(types) => VariadicType::Multi(
+                    types
+                        .iter()
+                        .map(|ty| substitute_conditional_infer_names(ty, assignments))
+                        .collect(),
+                ),
+            }
+            .into(),
+        ),
+        LuaType::Instance(inst) => LuaType::Instance(
+            LuaInstanceType::new(
+                substitute_conditional_infer_names(inst.get_base(), assignments),
+                inst.get_range().clone(),
+            )
+            .into(),
+        ),
+        LuaType::Call(call) => LuaType::Call(
+            LuaAliasCallType::new(
+                call.get_call_kind(),
+                call.get_operands()
+                    .iter()
+                    .map(|ty| substitute_conditional_infer_names(ty, assignments))
+                    .collect(),
+            )
+            .into(),
+        ),
+        LuaType::MultiLineUnion(union) => LuaType::MultiLineUnion(
+            LuaMultiLineUnion::new(
+                union
+                    .get_unions()
+                    .iter()
+                    .map(|(ty, description)| {
+                        (
+                            substitute_conditional_infer_names(ty, assignments),
+                            description.clone(),
+                        )
+                    })
+                    .collect(),
+            )
+            .into(),
+        ),
+        LuaType::TypeGuard(inner) => {
+            LuaType::TypeGuard(substitute_conditional_infer_names(inner, assignments).into())
+        }
+        LuaType::DocAttribute(attribute) => LuaType::DocAttribute(
+            LuaAttributeType::new(
+                attribute
+                    .get_params()
+                    .iter()
+                    .map(|(name, ty)| {
+                        (
+                            name.clone(),
+                            ty.as_ref()
+                                .map(|ty| substitute_conditional_infer_names(ty, assignments)),
+                        )
+                    })
+                    .collect(),
+            )
+            .into(),
+        ),
+        LuaType::Conditional(conditional) => LuaType::Conditional(
+            LuaConditionalType::new(
+                substitute_conditional_infer_names(conditional.get_condition(), assignments),
+                substitute_conditional_infer_names(conditional.get_true_type(), assignments),
+                substitute_conditional_infer_names(conditional.get_false_type(), assignments),
+                conditional.get_infer_params().to_vec(),
+                conditional.has_new,
+            )
+            .into(),
+        ),
+        LuaType::Mapped(mapped) => {
+            let mut param = mapped.param.1.clone();
+            param.type_constraint = param
+                .type_constraint
+                .as_ref()
+                .map(|ty| substitute_conditional_infer_names(ty, assignments));
+            LuaType::Mapped(
+                LuaMappedType::new(
+                    (mapped.param.0, param),
+                    substitute_conditional_infer_names(&mapped.value, assignments),
+                    mapped.is_readonly,
+                    mapped.is_optional,
+                )
+                .into(),
+            )
+        }
+        LuaType::TableOf(inner) => {
+            LuaType::TableOf(substitute_conditional_infer_names(inner, assignments).into())
+        }
+        _ => ty.clone(),
+    }
 }
 
 // 尝试将`pattern`中的每个`infer`名称映射到`source`内部对应的类型, 当结构不兼容或发现冲突的赋值时, 返回`false`

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     semantic::type_check::{TypeCheckCheckLevel, check_type_compact_with_level},
 };
 
-use super::type_substitutor::{SubstitutorValue, TypeSubstitutor};
+use super::type_substitutor::{SubstitutorValue, TypeSubstitutor, union_candidate_type};
 use crate::TypeVisitTrait;
 use crate::semantic::member::find_members_with_key;
 pub use instantiate_func_generic::{build_self_type, infer_self_type, instantiate_func_generic};
@@ -1144,7 +1144,9 @@ fn insert_infer_assignment(
     ty: &LuaType,
 ) -> bool {
     if let Some(existing) = assignments.get(name) {
-        existing == ty
+        let inferred = union_candidate_type(existing.clone(), ty.clone());
+        assignments.insert(name.to_string(), inferred);
+        true
     } else {
         assignments.insert(name.to_string(), ty.clone());
         true

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -833,7 +833,7 @@ fn collect_infer_to_union(
 
     let mut matched = false;
     let mut union_assignments = assignments.clone();
-    let mut structural_infer_names = HashSet::new();
+    let mut structural_matched = false;
     let pattern_members = pattern_union.into_vec();
 
     for member in pattern_members
@@ -848,27 +848,26 @@ fn collect_infer_to_union(
             &mut branch_assignments,
             &infer_guard.fork(),
         ) {
-            collect_conditional_infer_names(member, &mut structural_infer_names);
             union_assignments = branch_assignments;
+            structural_matched = true;
             matched = true;
         }
     }
 
-    for member in pattern_members
-        .iter()
-        .filter(|member| is_naked_conditional_infer(member))
-    {
-        let LuaType::ConditionalInfer(name) = member else {
-            continue;
-        };
-        if structural_infer_names.contains(name.as_str()) {
-            continue;
-        }
+    if !structural_matched {
+        for member in pattern_members
+            .iter()
+            .filter(|member| is_naked_conditional_infer(member))
+        {
+            let LuaType::ConditionalInfer(name) = member else {
+                continue;
+            };
 
-        let mut branch_assignments = union_assignments.clone();
-        if insert_infer_assignment(&mut branch_assignments, name.as_str(), source) {
-            union_assignments = branch_assignments;
-            matched = true;
+            let mut branch_assignments = union_assignments.clone();
+            if insert_infer_assignment(&mut branch_assignments, name.as_str(), source) {
+                union_assignments = branch_assignments;
+                matched = true;
+            }
         }
     }
 
@@ -880,14 +879,6 @@ fn collect_infer_to_union(
 
 fn is_naked_conditional_infer(ty: &LuaType) -> bool {
     matches!(ty, LuaType::ConditionalInfer(_))
-}
-
-fn collect_conditional_infer_names(ty: &LuaType, names: &mut HashSet<String>) {
-    ty.visit_type(&mut |inner| {
-        if let LuaType::ConditionalInfer(name) = inner {
-            names.insert(name.as_str().to_string());
-        }
-    });
 }
 
 fn collect_infer_from_generic_source(

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/mod.rs
@@ -7,9 +7,9 @@ use std::{
 };
 
 use crate::{
-    DbIndex, GenericTpl, GenericTplId, LuaAliasCallKind, LuaArrayType, LuaConditionalType,
-    LuaInstanceType, LuaMappedType, LuaMemberKey, LuaOperatorMetaMethod, LuaSignatureId,
-    LuaTupleStatus, LuaTypeDeclId, TypeOps, check_type_compact,
+    DbIndex, GenericTpl, GenericTplId, InferGuard, InferGuardRef, LuaAliasCallKind, LuaArrayType,
+    LuaConditionalType, LuaInstanceType, LuaMappedType, LuaMemberKey, LuaOperatorMetaMethod,
+    LuaSignatureId, LuaTupleStatus, LuaTypeDeclId, TypeOps, check_type_compact,
     db_index::{
         LuaFunctionType, LuaGenericType, LuaIntersectionType, LuaObjectType, LuaTupleType, LuaType,
         LuaUnionType, VariadicType,
@@ -309,7 +309,8 @@ pub fn instantiate_generic(
         && let Some(type_decl) = db.get_type_index().get_type_decl(&type_decl_id)
         && type_decl.is_alias()
     {
-        let new_substitutor = TypeSubstitutor::from_alias(new_params.clone(), type_decl_id.clone());
+        let new_substitutor =
+            TypeSubstitutor::from_alias_for_type(db, new_params.clone(), type_decl_id.clone());
         if let Some(origin) = type_decl.get_alias_origin(db, Some(&new_substitutor)) {
             return origin;
         }
@@ -580,26 +581,22 @@ fn collect_infer_assignments(
     pattern: &LuaType,
     assignments: &mut HashMap<String, LuaType>,
 ) -> bool {
+    collect_infer_assignments_inner(db, source, pattern, assignments, &InferGuard::new())
+}
+
+fn collect_infer_assignments_inner(
+    db: &DbIndex,
+    source: &LuaType,
+    pattern: &LuaType,
+    assignments: &mut HashMap<String, LuaType>,
+    infer_guard: &InferGuardRef,
+) -> bool {
     match pattern {
         LuaType::ConditionalInfer(name) => {
             insert_infer_assignment(assignments, name.as_str(), source)
         }
         LuaType::Generic(pattern_generic) => {
-            if let LuaType::Generic(source_generic) = source {
-                let pattern_params = pattern_generic.get_params();
-                let source_params = source_generic.get_params();
-                if pattern_params.len() != source_params.len() {
-                    return false;
-                }
-                for (pattern_param, source_param) in pattern_params.iter().zip(source_params) {
-                    if !collect_infer_assignments(db, source_param, pattern_param, assignments) {
-                        return false;
-                    }
-                }
-                true
-            } else {
-                false
-            }
+            collect_infer_from_generic_source(db, source, pattern_generic, assignments, infer_guard)
         }
         LuaType::DocFunction(pattern_func) => {
             match source {
@@ -626,11 +623,12 @@ fn collect_infer_assignments(
                         if let Some((_, source_param)) = source_params.get(i) {
                             match (source_param, pattern_param) {
                                 (Some(source_ty), Some(pattern_ty)) => {
-                                    if !collect_infer_assignments(
+                                    if !collect_infer_assignments_inner(
                                         db,
                                         source_ty,
                                         pattern_ty,
                                         assignments,
+                                        &infer_guard.fork(),
                                     ) {
                                         return false;
                                     }
@@ -692,7 +690,13 @@ fn collect_infer_assignments(
                                     ),
                                 };
 
-                                if !collect_infer_assignments(db, &ty, pattern_ty, assignments) {
+                                if !collect_infer_assignments_inner(
+                                    db,
+                                    &ty,
+                                    pattern_ty,
+                                    assignments,
+                                    &infer_guard.fork(),
+                                ) {
                                     return false;
                                 }
                             }
@@ -703,11 +707,12 @@ fn collect_infer_assignments(
                     let pattern_ret = pattern_func.get_ret();
                     if contains_conditional_infer(pattern_ret) {
                         // 如果返回值也包含 infer, 继续与来源返回值进行匹配
-                        collect_infer_assignments(
+                        collect_infer_assignments_inner(
                             db,
                             source_func.get_ret(),
                             pattern_ret,
                             assignments,
+                            &infer_guard.fork(),
                         )
                     } else {
                         true
@@ -716,11 +721,12 @@ fn collect_infer_assignments(
                 LuaType::Signature(id) => {
                     if let Some(signature) = db.get_signature_index().get(id) {
                         let source_func = signature.to_doc_func_type();
-                        collect_infer_assignments(
+                        collect_infer_assignments_inner(
                             db,
                             &LuaType::DocFunction(source_func),
                             pattern,
                             assignments,
+                            infer_guard,
                         )
                     } else {
                         false
@@ -731,7 +737,13 @@ fn collect_infer_assignments(
                         if type_decl.is_alias()
                             && let Some(origin) = type_decl.get_alias_origin(db, None)
                         {
-                            return collect_infer_assignments(db, &origin, &pattern, assignments);
+                            return collect_infer_assignments_inner(
+                                db,
+                                &origin,
+                                &pattern,
+                                assignments,
+                                infer_guard,
+                            );
                         }
                     }
                     false
@@ -741,26 +753,39 @@ fn collect_infer_assignments(
         }
         LuaType::Array(array) => {
             if let LuaType::Array(source_array) = source {
-                collect_infer_assignments(
+                collect_infer_assignments_inner(
                     db,
                     source_array.get_base(),
                     array.get_base(),
                     assignments,
+                    infer_guard,
                 )
             } else {
                 false
             }
         }
         LuaType::Object(pattern_object) => match source {
-            LuaType::Object(source_object) => {
-                collect_infer_from_object_to_object(db, source_object, pattern_object, assignments)
-            }
-            LuaType::Ref(type_id) | LuaType::Def(type_id) => {
-                collect_infer_from_class_to_object(db, type_id, pattern_object, assignments)
-            }
-            LuaType::TableConst(table_id) => {
-                collect_infer_from_table_to_object(db, table_id, pattern_object, assignments)
-            }
+            LuaType::Object(source_object) => collect_infer_from_object_to_object(
+                db,
+                source_object,
+                pattern_object,
+                assignments,
+                infer_guard,
+            ),
+            LuaType::Ref(type_id) | LuaType::Def(type_id) => collect_infer_from_class_to_object(
+                db,
+                type_id,
+                pattern_object,
+                assignments,
+                infer_guard,
+            ),
+            LuaType::TableConst(table_id) => collect_infer_from_table_to_object(
+                db,
+                table_id,
+                pattern_object,
+                assignments,
+                infer_guard,
+            ),
             _ => false,
         },
         _ => {
@@ -773,19 +798,221 @@ fn collect_infer_assignments(
     }
 }
 
+fn collect_infer_from_generic_source(
+    db: &DbIndex,
+    source: &LuaType,
+    pattern_generic: &LuaGenericType,
+    assignments: &mut HashMap<String, LuaType>,
+    infer_guard: &InferGuardRef,
+) -> bool {
+    match source {
+        LuaType::Generic(source_generic) => collect_infer_from_source_generic_to_pattern_generic(
+            db,
+            source_generic,
+            pattern_generic,
+            assignments,
+            infer_guard,
+        ),
+        LuaType::Ref(type_id) | LuaType::Def(type_id) => collect_infer_from_type_decl_to_generic(
+            db,
+            type_id,
+            pattern_generic,
+            assignments,
+            infer_guard,
+        ),
+        LuaType::Union(union) => {
+            for member in union.into_vec() {
+                let mut branch_assignments = assignments.clone();
+                if collect_infer_from_generic_source(
+                    db,
+                    &member,
+                    pattern_generic,
+                    &mut branch_assignments,
+                    &infer_guard.fork(),
+                ) {
+                    *assignments = branch_assignments;
+                    return true;
+                }
+            }
+            false
+        }
+        _ => false,
+    }
+}
+
+fn collect_infer_from_source_generic_to_pattern_generic(
+    db: &DbIndex,
+    source_generic: &LuaGenericType,
+    pattern_generic: &LuaGenericType,
+    assignments: &mut HashMap<String, LuaType>,
+    infer_guard: &InferGuardRef,
+) -> bool {
+    let source_base = source_generic.get_base_type_id_ref();
+    let pattern_base = pattern_generic.get_base_type_id_ref();
+    if source_base == pattern_base {
+        return collect_infer_from_matching_generic_params(
+            db,
+            source_generic.get_params(),
+            pattern_generic.get_params(),
+            assignments,
+            infer_guard,
+        );
+    }
+
+    if infer_guard.check(source_base).is_err() {
+        return false;
+    }
+
+    let Some(source_decl) = db.get_type_index().get_type_decl(source_base) else {
+        return false;
+    };
+
+    if source_decl.is_alias() {
+        let substitutor = TypeSubstitutor::from_alias_for_type(
+            db,
+            source_generic.get_params().clone(),
+            source_base.clone(),
+        );
+        if let Some(origin) = source_decl.get_alias_origin(db, Some(&substitutor)) {
+            let mut branch_assignments = assignments.clone();
+            if collect_infer_assignments_inner(
+                db,
+                &origin,
+                &LuaType::Generic(pattern_generic.clone().into()),
+                &mut branch_assignments,
+                &infer_guard.fork(),
+            ) {
+                *assignments = branch_assignments;
+                return true;
+            }
+        }
+    }
+
+    let Some(super_types) = db.get_type_index().get_super_types(source_base) else {
+        return false;
+    };
+
+    let substitutor = TypeSubstitutor::from_type_array_for_type(
+        db,
+        source_base,
+        source_generic.get_params().clone(),
+    );
+    for super_type in super_types {
+        let instantiated_super = instantiate_type_generic(db, &super_type, &substitutor);
+        let mut branch_assignments = assignments.clone();
+        if collect_infer_assignments_inner(
+            db,
+            &instantiated_super,
+            &LuaType::Generic(pattern_generic.clone().into()),
+            &mut branch_assignments,
+            &infer_guard.fork(),
+        ) {
+            *assignments = branch_assignments;
+            return true;
+        }
+    }
+
+    false
+}
+
+fn collect_infer_from_type_decl_to_generic(
+    db: &DbIndex,
+    type_id: &LuaTypeDeclId,
+    pattern_generic: &LuaGenericType,
+    assignments: &mut HashMap<String, LuaType>,
+    infer_guard: &InferGuardRef,
+) -> bool {
+    if infer_guard.check(type_id).is_err() {
+        return false;
+    }
+
+    let Some(type_decl) = db.get_type_index().get_type_decl(type_id) else {
+        return false;
+    };
+
+    if let Some(origin) = type_decl.get_alias_origin(db, None) {
+        let mut branch_assignments = assignments.clone();
+        if collect_infer_assignments_inner(
+            db,
+            &origin,
+            &LuaType::Generic(pattern_generic.clone().into()),
+            &mut branch_assignments,
+            &infer_guard.fork(),
+        ) {
+            *assignments = branch_assignments;
+            return true;
+        }
+    }
+
+    let Some(super_types) = db.get_type_index().get_super_types(type_id) else {
+        return false;
+    };
+
+    for super_type in super_types {
+        let mut branch_assignments = assignments.clone();
+        if collect_infer_assignments_inner(
+            db,
+            &super_type,
+            &LuaType::Generic(pattern_generic.clone().into()),
+            &mut branch_assignments,
+            &infer_guard.fork(),
+        ) {
+            *assignments = branch_assignments;
+            return true;
+        }
+    }
+
+    false
+}
+
+fn collect_infer_from_matching_generic_params(
+    db: &DbIndex,
+    source_params: &[LuaType],
+    pattern_params: &[LuaType],
+    assignments: &mut HashMap<String, LuaType>,
+    infer_guard: &InferGuardRef,
+) -> bool {
+    if source_params.len() != pattern_params.len() {
+        return false;
+    }
+
+    let mut branch_assignments = assignments.clone();
+    for (source_param, pattern_param) in source_params.iter().zip(pattern_params) {
+        if !collect_infer_assignments_inner(
+            db,
+            source_param,
+            pattern_param,
+            &mut branch_assignments,
+            infer_guard,
+        ) {
+            return false;
+        }
+    }
+
+    *assignments = branch_assignments;
+    true
+}
+
 /// Match object literal to object pattern, extracting infer types from fields
 fn collect_infer_from_object_to_object(
     db: &DbIndex,
     source_object: &LuaObjectType,
     pattern_object: &LuaObjectType,
     assignments: &mut HashMap<String, LuaType>,
+    infer_guard: &InferGuardRef,
 ) -> bool {
     let source_fields = source_object.get_fields();
     let pattern_fields = pattern_object.get_fields();
 
     for (key, pattern_field_ty) in pattern_fields {
         if let Some(source_field_ty) = source_fields.get(key) {
-            if !collect_infer_assignments(db, source_field_ty, pattern_field_ty, assignments) {
+            if !collect_infer_assignments_inner(
+                db,
+                source_field_ty,
+                pattern_field_ty,
+                assignments,
+                infer_guard,
+            ) {
                 return false;
             }
         } else if contains_conditional_infer(pattern_field_ty) {
@@ -803,6 +1030,7 @@ fn collect_infer_from_class_to_object(
     type_id: &LuaTypeDeclId,
     pattern_object: &LuaObjectType,
     assignments: &mut HashMap<String, LuaType>,
+    infer_guard: &InferGuardRef,
 ) -> bool {
     let pattern_fields = pattern_object.get_fields();
     let source_type = LuaType::Ref(type_id.clone());
@@ -810,7 +1038,13 @@ fn collect_infer_from_class_to_object(
     for (key, pattern_field_ty) in pattern_fields {
         if let Some(member_infos) = find_members_with_key(db, &source_type, key.clone(), false) {
             if let Some(member_info) = member_infos.first() {
-                if !collect_infer_assignments(db, &member_info.typ, pattern_field_ty, assignments) {
+                if !collect_infer_assignments_inner(
+                    db,
+                    &member_info.typ,
+                    pattern_field_ty,
+                    assignments,
+                    infer_guard,
+                ) {
                     return false;
                 }
             } else if contains_conditional_infer(pattern_field_ty) {
@@ -830,6 +1064,7 @@ fn collect_infer_from_table_to_object(
     table_id: &crate::InFiled<rowan::TextRange>,
     pattern_object: &LuaObjectType,
     assignments: &mut HashMap<String, LuaType>,
+    infer_guard: &InferGuardRef,
 ) -> bool {
     let pattern_fields = pattern_object.get_fields();
     let source_type = LuaType::TableConst(table_id.clone());
@@ -837,7 +1072,13 @@ fn collect_infer_from_table_to_object(
     for (key, pattern_field_ty) in pattern_fields {
         if let Some(member_infos) = find_members_with_key(db, &source_type, key.clone(), false) {
             if let Some(member_info) = member_infos.first() {
-                if !collect_infer_assignments(db, &member_info.typ, pattern_field_ty, assignments) {
+                if !collect_infer_assignments_inner(
+                    db,
+                    &member_info.typ,
+                    pattern_field_ty,
+                    assignments,
+                    infer_guard,
+                ) {
                     return false;
                 }
             } else if contains_conditional_infer(pattern_field_ty) {

--- a/crates/glua_code_analysis/src/semantic/generic/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/mod.rs
@@ -1,4 +1,5 @@
 mod call_constraint;
+mod inference_context;
 mod instantiate_type;
 mod test;
 mod tpl_context;
@@ -10,6 +11,7 @@ pub use call_constraint::{
 };
 use glua_parser::LuaAstNode;
 use glua_parser::LuaExpr;
+pub use inference_context::{InferenceContext, InferencePriority};
 pub use instantiate_type::*;
 use rowan::NodeOrToken;
 pub use tpl_context::TplContext;

--- a/crates/glua_code_analysis/src/semantic/generic/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/mod.rs
@@ -11,7 +11,7 @@ pub use call_constraint::{
 };
 use glua_parser::LuaAstNode;
 use glua_parser::LuaExpr;
-pub use inference_context::{InferenceContext, InferencePriority};
+pub use inference_context::{InferenceContext, InferencePriority, InferenceVariance};
 pub use instantiate_type::*;
 use rowan::NodeOrToken;
 pub use tpl_context::TplContext;

--- a/crates/glua_code_analysis/src/semantic/generic/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/mod.rs
@@ -69,7 +69,7 @@ pub fn get_tpl_ref_extend_type(
                     }
                     None
                 }
-                GenericTplId::Type(tpl_id) => {
+                GenericTplId::Type(tpl_id) | GenericTplId::ScopedType { idx: tpl_id, .. } => {
                     if let LuaSemanticDeclId::LuaDecl(decl_id) = semantic_decl {
                         let decl = db.get_decl_index().get_decl(&decl_id)?;
                         match decl.extra {

--- a/crates/glua_code_analysis/src/semantic/generic/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/mod.rs
@@ -13,6 +13,7 @@ use glua_parser::LuaExpr;
 pub use instantiate_type::*;
 use rowan::NodeOrToken;
 pub use tpl_context::TplContext;
+pub(crate) use tpl_pattern::tpl_pattern_match;
 pub use tpl_pattern::tpl_pattern_match_args;
 pub use type_substitutor::TypeSubstitutor;
 

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_context.rs
@@ -1,6 +1,6 @@
 use glua_parser::LuaCallExpr;
 
-use crate::{DbIndex, InferenceContext, LuaInferCache};
+use crate::{DbIndex, InferenceContext, InferencePriority, LuaInferCache};
 
 #[derive(Debug)]
 pub struct TplContext<'a> {
@@ -8,4 +8,20 @@ pub struct TplContext<'a> {
     pub cache: &'a mut LuaInferCache,
     pub substitutor: &'a mut InferenceContext,
     pub call_expr: Option<LuaCallExpr>,
+}
+
+impl TplContext<'_> {
+    pub fn with_inference_priority<R>(
+        &mut self,
+        priority: InferencePriority,
+        collect_candidates: bool,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let state = self
+            .substitutor
+            .begin_candidate_collection(collect_candidates, priority);
+        let result = f(self);
+        self.substitutor.finish_candidate_collection(self.db, state);
+        result
+    }
 }

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_context.rs
@@ -1,6 +1,6 @@
 use glua_parser::LuaCallExpr;
 
-use crate::{DbIndex, InferenceContext, InferencePriority, LuaInferCache};
+use crate::{DbIndex, InferenceContext, InferencePriority, InferenceVariance, LuaInferCache};
 
 #[derive(Debug)]
 pub struct TplContext<'a> {
@@ -17,9 +17,24 @@ impl TplContext<'_> {
         collect_candidates: bool,
         f: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        let state = self
-            .substitutor
-            .begin_candidate_collection(collect_candidates, priority);
+        self.with_inference_priority_and_variance(
+            priority,
+            collect_candidates,
+            InferenceVariance::Covariant,
+            f,
+        )
+    }
+
+    pub fn with_inference_priority_and_variance<R>(
+        &mut self,
+        priority: InferencePriority,
+        collect_candidates: bool,
+        variance: InferenceVariance,
+        f: impl FnOnce(&mut Self) -> R,
+    ) -> R {
+        let state =
+            self.substitutor
+                .begin_candidate_collection(collect_candidates, priority, variance);
         let result = f(self);
         self.substitutor.finish_candidate_collection(self.db, state);
         result

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_context.rs
@@ -1,11 +1,11 @@
 use glua_parser::LuaCallExpr;
 
-use crate::{DbIndex, LuaInferCache, TypeSubstitutor};
+use crate::{DbIndex, InferenceContext, LuaInferCache};
 
 #[derive(Debug)]
 pub struct TplContext<'a> {
     pub db: &'a DbIndex,
     pub cache: &'a mut LuaInferCache,
-    pub substitutor: &'a mut TypeSubstitutor,
+    pub substitutor: &'a mut InferenceContext,
     pub call_expr: Option<LuaCallExpr>,
 }

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_context.rs
@@ -6,7 +6,7 @@ use crate::{DbIndex, InferenceContext, InferencePriority, InferenceVariance, Lua
 pub struct TplContext<'a> {
     pub db: &'a DbIndex,
     pub cache: &'a mut LuaInferCache,
-    pub substitutor: &'a mut InferenceContext,
+    pub inference: &'a mut InferenceContext,
     pub call_expr: Option<LuaCallExpr>,
 }
 
@@ -32,11 +32,11 @@ impl TplContext<'_> {
         variance: InferenceVariance,
         f: impl FnOnce(&mut Self) -> R,
     ) -> R {
-        let state =
-            self.substitutor
-                .begin_candidate_collection(collect_candidates, priority, variance);
+        let state = self
+            .inference
+            .begin_candidate_collection(collect_candidates, priority, variance);
         let result = f(self);
-        self.substitutor.finish_candidate_collection(self.db, state);
+        self.inference.finish_candidate_collection(self.db, state);
         result
     }
 }

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/generic_tpl_pattern.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/generic_tpl_pattern.rs
@@ -48,7 +48,8 @@ fn generic_tpl_pattern_match_inner(
                 .get_type_decl(target_base)
                 .ok_or(InferFailReason::None)?;
             if target_decl.is_alias() {
-                let substitutor = TypeSubstitutor::from_alias(
+                let substitutor = TypeSubstitutor::from_alias_for_type(
+                    context.db,
                     target_generic.get_params().clone(),
                     target_base.clone(),
                 );
@@ -67,8 +68,11 @@ fn generic_tpl_pattern_match_inner(
             {
                 for mut super_type in super_types {
                     if super_type.contain_tpl() {
-                        let substitutor =
-                            TypeSubstitutor::from_type_array(target_generic.get_params().clone());
+                        let substitutor = TypeSubstitutor::from_type_array_for_type(
+                            context.db,
+                            target_base,
+                            target_generic.get_params().clone(),
+                        );
                         super_type =
                             instantiate_type_generic(context.db, &super_type, &substitutor);
                     }

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/generic_tpl_pattern.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/generic_tpl_pattern.rs
@@ -127,6 +127,14 @@ fn generic_tpl_pattern_match_inner(
             }
         }
         _ => {
+            if let Some(typ) =
+                super::try_expand_generic_alias_for_pattern(context.db, source_generic)
+                && LuaType::from(source_generic.clone()) != typ
+            {
+                tpl_pattern_match(context, &typ, target)?;
+                return Ok(());
+            }
+
             // 对于 @alias 类型, 我们能拿到的 target 实际上很有可能是实例化后的类型, 因此我们需要实例化后再进行匹配
             let substitutor = TypeSubstitutor::new();
             let typ = instantiate_generic(context.db, source_generic, &substitutor);

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -508,15 +508,32 @@ fn mapped_tpl_pattern_match(
     mapped: &LuaMappedType,
     target: &LuaType,
 ) -> TplPatternMatchResult {
-    let Some(source_info) = mapped_source_info(mapped) else {
+    let source_info = mapped_source_info(mapped);
+    let key_constraint_tpl_id = mapped_key_constraint_tpl_id(mapped);
+    if source_info.is_none() && key_constraint_tpl_id.is_none() {
         return Ok(());
-    };
+    }
 
     let target_fields = mapped_target_fields(context, target)?;
     if target_fields.is_empty() {
         return Ok(());
     }
 
+    if let Some(source_info) = source_info {
+        homomorphic_mapped_tpl_pattern_match(context, mapped, target_fields, source_info)?;
+    } else if let Some(key_constraint_tpl_id) = key_constraint_tpl_id {
+        constrained_mapped_tpl_pattern_match(context, mapped, target_fields, key_constraint_tpl_id)?;
+    }
+
+    Ok(())
+}
+
+fn homomorphic_mapped_tpl_pattern_match(
+    context: &mut TplContext,
+    mapped: &LuaMappedType,
+    target_fields: Vec<(LuaMemberKey, LuaType)>,
+    source_info: MappedSourceInfo,
+) -> TplPatternMatchResult {
     let mut fields = HashMap::new();
     let mut key_types = Vec::new();
     let mut saw_uninferred_field = false;
@@ -584,6 +601,57 @@ fn mapped_tpl_pattern_match(
     }
 
     Ok(())
+}
+
+fn constrained_mapped_tpl_pattern_match(
+    context: &mut TplContext,
+    mapped: &LuaMappedType,
+    target_fields: Vec<(LuaMemberKey, LuaType)>,
+    key_constraint_tpl_id: GenericTplId,
+) -> TplPatternMatchResult {
+    let mut key_types = Vec::new();
+    let mut prop_types = Vec::new();
+    for (member_key, target_type) in target_fields {
+        if let Some(key_type) = member_key_to_key_type(&member_key) {
+            key_types.push(key_type);
+        }
+
+        let target_type = reverse_mapped_source_field_type(context, mapped, target_type);
+        if target_type != LuaType::Never {
+            prop_types.push(mapped_inference_value_type(target_type));
+        }
+    }
+
+    if !key_types.is_empty() {
+        let key_type = LuaType::from_vec(key_types);
+        context.with_inference_priority(InferencePriority::MappedTypeConstraint, true, |context| {
+            context
+                .substitutor
+                .insert_type(key_constraint_tpl_id, key_type, false);
+        });
+    }
+
+    if !prop_types.is_empty() {
+        let prop_type = LuaType::from_vec(prop_types);
+        context.with_inference_priority(InferencePriority::Direct, true, |context| {
+            tpl_pattern_match(context, &mapped.value, &prop_type)
+        })?;
+    }
+
+    Ok(())
+}
+
+fn mapped_inference_value_type(ty: LuaType) -> LuaType {
+    match ty {
+        LuaType::Union(union) => LuaType::from_vec(
+            union
+                .into_vec()
+                .into_iter()
+                .map(constant_decay)
+                .collect(),
+        ),
+        _ => constant_decay(ty),
+    }
 }
 
 fn reverse_mapped_source_field_type(
@@ -662,6 +730,11 @@ struct MappedSourceInfo {
 fn mapped_source_info(mapped: &LuaMappedType) -> Option<MappedSourceInfo> {
     let constraint = mapped.param.1.type_constraint.as_ref()?;
     mapped_source_info_from_constraint(constraint, 0)
+}
+
+fn mapped_key_constraint_tpl_id(mapped: &LuaMappedType) -> Option<GenericTplId> {
+    let constraint = mapped.param.1.type_constraint.as_ref()?;
+    tpl_id_from_type(constraint)
 }
 
 fn mapped_source_info_from_constraint(
@@ -1174,11 +1247,11 @@ fn table_generic_tpl_pattern_match(
                     }
                     _ => {}
                 };
-                values.push(v.clone());
+                values.push(mapped_inference_value_type(v.clone()));
             }
             for (k, v) in obj.get_index_access() {
                 keys.push(k.clone());
-                values.push(v.clone());
+                values.push(mapped_inference_value_type(v.clone()));
             }
 
             let key_type = LuaType::Union(LuaUnionType::from_vec(keys).into());
@@ -1243,7 +1316,7 @@ fn table_generic_tpl_pattern_member_owner_match(
         };
 
         if !target_key_type.is_generic()
-            && check_type_compact(context.db, &target_key_type, &key_type).is_err()
+            && !is_table_generic_key_match(context.db, &target_key_type, &key_type)
         {
             continue;
         }
@@ -1262,7 +1335,7 @@ fn table_generic_tpl_pattern_member_owner_match(
             }
         };
 
-        values.push(resolve_type);
+        values.push(mapped_inference_value_type(resolve_type));
     }
 
     if keys.is_empty() {
@@ -1277,9 +1350,9 @@ fn table_generic_tpl_pattern_member_owner_match(
                     LuaMemberKey::ExprType(typ) => typ.clone(),
                     _ => return,
                 };
-                if check_type_compact(context.db, &target_key_type, &key_type).is_ok() {
+                if is_table_generic_key_match(context.db, &target_key_type, &key_type) {
                     keys.push(key_type);
-                    values.push(m.typ.clone());
+                    values.push(mapped_inference_value_type(m.typ.clone()));
                 }
             });
     }
@@ -1298,6 +1371,10 @@ fn table_generic_tpl_pattern_member_owner_match(
     tpl_pattern_match(context, &table_generic_params[1], &value_type)?;
 
     Ok(())
+}
+
+fn is_table_generic_key_match(db: &DbIndex, target_key_type: &LuaType, key_type: &LuaType) -> bool {
+    check_type_compact(db, key_type, target_key_type).is_ok()
 }
 
 fn union_tpl_pattern_match(

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -560,20 +560,31 @@ fn mapped_tpl_pattern_match(
 
 fn mapped_source_tpl_id(mapped: &LuaMappedType) -> Option<GenericTplId> {
     let constraint = mapped.param.1.type_constraint.as_ref()?;
-    let LuaType::Call(alias_call) = constraint else {
-        return None;
-    };
+    mapped_source_tpl_id_from_constraint(constraint, 0)
+}
 
-    if alias_call.get_call_kind() != LuaAliasCallKind::KeyOf {
-        return None;
-    }
-
-    let operands = alias_call.get_operands();
-    if operands.len() != 1 {
+fn mapped_source_tpl_id_from_constraint(
+    constraint: &LuaType,
+    depth: usize,
+) -> Option<GenericTplId> {
+    if depth > 8 {
         return None;
     }
 
-    tpl_id_from_type(&operands[0])
+    match constraint {
+        LuaType::Call(alias_call) if alias_call.get_call_kind() == LuaAliasCallKind::KeyOf => {
+            let operands = alias_call.get_operands();
+            if operands.len() != 1 {
+                return None;
+            }
+
+            tpl_id_from_type(&operands[0])
+        }
+        LuaType::TplRef(tpl) | LuaType::ConstTplRef(tpl) => tpl
+            .get_constraint()
+            .and_then(|constraint| mapped_source_tpl_id_from_constraint(constraint, depth + 1)),
+        _ => None,
+    }
 }
 
 fn mapped_target_fields(

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -9,10 +9,10 @@ use rowan::NodeOrToken;
 use smol_str::SmolStr;
 
 use crate::{
-    GenericTplId, InferFailReason, InferencePriority, LuaAliasCallKind, LuaAliasCallType,
-    LuaArrayType, LuaFunctionType, LuaMappedType, LuaMemberInfo, LuaMemberKey, LuaMemberOwner,
-    LuaObjectType, LuaSemanticDeclId, LuaTupleStatus, LuaTupleType, LuaTypeDeclId, LuaUnionType,
-    SemanticDeclLevel, TypeOps, VariadicType, check_type_compact,
+    GenericTplId, InferFailReason, InferencePriority, InferenceVariance, LuaAliasCallKind,
+    LuaAliasCallType, LuaArrayType, LuaFunctionType, LuaMappedType, LuaMemberInfo, LuaMemberKey,
+    LuaMemberOwner, LuaObjectType, LuaSemanticDeclId, LuaTupleStatus, LuaTupleType, LuaTypeDeclId,
+    LuaUnionType, SemanticDeclLevel, TypeOps, VariadicType, check_type_compact,
     db_index::{DbIndex, LuaGenericType, LuaType},
     infer_node_semantic_decl,
     semantic::{
@@ -522,7 +522,12 @@ fn mapped_tpl_pattern_match(
     if let Some(source_info) = source_info {
         homomorphic_mapped_tpl_pattern_match(context, mapped, target_fields, source_info)?;
     } else if let Some(key_constraint_tpl_id) = key_constraint_tpl_id {
-        constrained_mapped_tpl_pattern_match(context, mapped, target_fields, key_constraint_tpl_id)?;
+        constrained_mapped_tpl_pattern_match(
+            context,
+            mapped,
+            target_fields,
+            key_constraint_tpl_id,
+        )?;
     }
 
     Ok(())
@@ -587,17 +592,11 @@ fn homomorphic_mapped_tpl_pattern_match(
         } else {
             InferencePriority::HomomorphicMappedType
         };
-        context.with_inference_priority(
-            priority,
-            true,
-            |context| {
-                context.substitutor.insert_type(
-                    source_info.source_tpl_id,
-                    source_type,
-                    true,
-                );
-            },
-        );
+        context.with_inference_priority(priority, true, |context| {
+            context
+                .substitutor
+                .insert_type(source_info.source_tpl_id, source_type, true);
+        });
     }
 
     Ok(())
@@ -643,13 +642,9 @@ fn constrained_mapped_tpl_pattern_match(
 
 fn mapped_inference_value_type(ty: LuaType) -> LuaType {
     match ty {
-        LuaType::Union(union) => LuaType::from_vec(
-            union
-                .into_vec()
-                .into_iter()
-                .map(constant_decay)
-                .collect(),
-        ),
+        LuaType::Union(union) => {
+            LuaType::from_vec(union.into_vec().into_iter().map(constant_decay).collect())
+        }
         _ => constant_decay(ty),
     }
 }
@@ -1453,7 +1448,9 @@ fn func_tpl_pattern_match_doc_func(
 
     let tpl_return = tpl_func.get_ret();
     let target_return = target_func.get_ret();
-    return_type_pattern_match_target_type(context, tpl_return, target_return)?;
+    context.with_inference_priority(InferencePriority::Direct, true, |context| {
+        return_type_pattern_match_target_type(context, tpl_return, target_return)
+    })?;
 
     Ok(())
 }
@@ -1527,7 +1524,12 @@ fn param_type_list_pattern_match_type_list(
                     Some(t) => t.1.clone().unwrap_or(LuaType::Any),
                     None => break,
                 };
-                tpl_pattern_match(context, &source, &target)?;
+                context.with_inference_priority_and_variance(
+                    InferencePriority::Direct,
+                    true,
+                    InferenceVariance::Contravariant,
+                    |context| tpl_pattern_match(context, &source, &target),
+                )?;
             }
         }
     }

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     GenericTplId, InferFailReason, InferencePriority, LuaAliasCallKind, LuaAliasCallType,
     LuaArrayType, LuaFunctionType, LuaMappedType, LuaMemberInfo, LuaMemberKey, LuaMemberOwner,
     LuaObjectType, LuaSemanticDeclId, LuaTupleType, LuaTypeDeclId, LuaUnionType, SemanticDeclLevel,
-    VariadicType, check_type_compact,
+    TypeOps, VariadicType, check_type_compact,
     db_index::{DbIndex, LuaGenericType, LuaType},
     infer_node_semantic_decl,
     semantic::{
@@ -525,6 +525,11 @@ fn mapped_tpl_pattern_match(
         };
 
         key_types.push(key_type.clone());
+        let target_type = reverse_mapped_source_field_type(context, mapped, target_type);
+        if target_type == LuaType::Never {
+            continue;
+        }
+
         let mut inferred = Vec::new();
         collect_reverse_mapped_field_inferences(
             context,
@@ -569,6 +574,18 @@ fn mapped_tpl_pattern_match(
     }
 
     Ok(())
+}
+
+fn reverse_mapped_source_field_type(
+    context: &TplContext,
+    mapped: &LuaMappedType,
+    target_type: LuaType,
+) -> LuaType {
+    if mapped.is_optional {
+        return TypeOps::Remove.apply(context.db, &target_type, &LuaType::Nil);
+    }
+
+    target_type
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -9,10 +9,11 @@ use rowan::NodeOrToken;
 use smol_str::SmolStr;
 
 use crate::{
-    GenericTplId, InferFailReason, InferencePriority, InferenceVariance, LuaAliasCallKind,
-    LuaAliasCallType, LuaArrayType, LuaFunctionType, LuaMappedType, LuaMemberInfo, LuaMemberKey,
-    LuaMemberOwner, LuaObjectType, LuaSemanticDeclId, LuaTupleStatus, LuaTupleType, LuaTypeDeclId,
-    LuaUnionType, SemanticDeclLevel, TypeOps, VariadicType, check_type_compact,
+    GenericTplId, InferFailReason, InferenceContext, InferencePriority, InferenceVariance,
+    LuaAliasCallKind, LuaAliasCallType, LuaArrayType, LuaFunctionType, LuaMappedType,
+    LuaMemberInfo, LuaMemberKey, LuaMemberOwner, LuaObjectType, LuaSemanticDeclId, LuaTupleStatus,
+    LuaTupleType, LuaTypeDeclId, LuaUnionType, SemanticDeclLevel, TypeOps, VariadicType,
+    check_type_compact,
     db_index::{DbIndex, LuaGenericType, LuaType},
     infer_node_semantic_decl,
     semantic::{
@@ -174,15 +175,15 @@ pub fn tpl_pattern_match(
         LuaType::TplRef(tpl) => {
             if tpl.get_tpl_id().is_func() {
                 context
-                    .substitutor
-                    .insert_type(tpl.get_tpl_id(), target.clone(), true);
+                    .inference
+                    .infer_type(tpl.get_tpl_id(), target.clone(), true);
             }
         }
         LuaType::ConstTplRef(tpl) => {
             if tpl.get_tpl_id().is_func() {
                 context
-                    .substitutor
-                    .insert_type(tpl.get_tpl_id(), target, false);
+                    .inference
+                    .infer_type(tpl.get_tpl_id(), target, false);
             }
         }
         LuaType::StrTplRef(str_tpl) => {
@@ -194,8 +195,8 @@ pub fn tpl_pattern_match(
                 let inferred_type =
                     get_str_tpl_infer_type(context, &type_name, constraint.as_ref());
                 context
-                    .substitutor
-                    .insert_type(str_tpl.get_tpl_id(), inferred_type, true);
+                    .inference
+                    .infer_type(str_tpl.get_tpl_id(), inferred_type, true);
             }
         }
         LuaType::Array(array_type) => {
@@ -580,8 +581,8 @@ fn homomorphic_mapped_tpl_pattern_match(
         let key_type = LuaType::from_vec(key_types);
         context.with_inference_priority(InferencePriority::MappedTypeConstraint, true, |context| {
             context
-                .substitutor
-                .insert_type(key_constraint_tpl_id, key_type, false);
+                .inference
+                .infer_type(key_constraint_tpl_id, key_type, false);
         });
     }
 
@@ -594,8 +595,8 @@ fn homomorphic_mapped_tpl_pattern_match(
         };
         context.with_inference_priority(priority, true, |context| {
             context
-                .substitutor
-                .insert_type(source_info.source_tpl_id, source_type, true);
+                .inference
+                .infer_type(source_info.source_tpl_id, source_type, true);
         });
     }
 
@@ -625,8 +626,8 @@ fn constrained_mapped_tpl_pattern_match(
         let key_type = LuaType::from_vec(key_types);
         context.with_inference_priority(InferencePriority::MappedTypeConstraint, true, |context| {
             context
-                .substitutor
-                .insert_type(key_constraint_tpl_id, key_type, false);
+                .inference
+                .infer_type(key_constraint_tpl_id, key_type, false);
         });
     }
 
@@ -1457,7 +1458,7 @@ fn func_tpl_pattern_match_doc_func(
 }
 
 fn active_inference_priority(context: &TplContext) -> InferencePriority {
-    match context.substitutor.priority() {
+    match context.inference.priority() {
         InferencePriority::None => InferencePriority::Direct,
         priority => priority,
     }
@@ -1482,14 +1483,14 @@ fn param_type_list_pattern_match_type_list(
                 if i >= targets.len() {
                     if let VariadicType::Base(LuaType::TplRef(tpl_ref)) = inner.deref() {
                         let tpl_id = tpl_ref.get_tpl_id();
-                        context.substitutor.insert_type(tpl_id, LuaType::Nil, true);
+                        context.inference.infer_type(tpl_id, LuaType::Nil, true);
                     }
                     break;
                 }
 
                 if let VariadicType::Base(LuaType::TplRef(generic_tpl)) = inner.deref() {
                     let tpl_id = generic_tpl.get_tpl_id();
-                    if let Some(inferred_type_value) = context.substitutor.get(tpl_id) {
+                    if let Some(inferred_type_value) = context.inference.get(tpl_id) {
                         match inferred_type_value {
                             SubstitutorValue::Type(_) => {
                                 continue;
@@ -1525,7 +1526,7 @@ fn param_type_list_pattern_match_type_list(
                     }
                 }
 
-                func_varargs_tpl_pattern_match(inner, target_rest_params, context.substitutor)?;
+                func_varargs_tpl_pattern_match(inner, target_rest_params, context.inference)?;
             }
             _ => {
                 let target = match targets.get(i + target_offset) {
@@ -1559,8 +1560,8 @@ fn return_type_pattern_match_target_type(
                         if let LuaType::TplRef(type_ref) = source_base {
                             let tpl_id = type_ref.get_tpl_id();
                             context
-                                .substitutor
-                                .insert_type(tpl_id, target_base.clone(), true);
+                                .inference
+                                .infer_type(tpl_id, target_base.clone(), true);
                         }
                     }
                     VariadicType::Multi(source_multi) => {
@@ -1571,7 +1572,7 @@ fn return_type_pattern_match_target_type(
                                         && let LuaType::TplRef(type_ref) = base
                                     {
                                         let tpl_id = type_ref.get_tpl_id();
-                                        context.substitutor.insert_type(
+                                        context.inference.infer_type(
                                             tpl_id,
                                             target_base.clone(),
                                             true,
@@ -1582,7 +1583,7 @@ fn return_type_pattern_match_target_type(
                                 }
                                 LuaType::TplRef(tpl_ref) => {
                                     let tpl_id = tpl_ref.get_tpl_id();
-                                    context.substitutor.insert_type(
+                                    context.inference.infer_type(
                                         tpl_id,
                                         target_base.clone(),
                                         true,
@@ -1619,13 +1620,13 @@ fn return_type_pattern_match_target_type(
 fn func_varargs_tpl_pattern_match(
     variadic: &VariadicType,
     target_rest_params: &[(String, Option<LuaType>)],
-    substitutor: &mut TypeSubstitutor,
+    inference: &mut InferenceContext,
 ) -> TplPatternMatchResult {
     match variadic {
         VariadicType::Base(base) => {
             if let LuaType::TplRef(tpl_ref) = base {
                 let tpl_id = tpl_ref.get_tpl_id();
-                substitutor.insert_params(
+                inference.infer_params(
                     tpl_id,
                     target_rest_params
                         .iter()
@@ -1651,7 +1652,7 @@ pub fn variadic_tpl_pattern_match(
                 let tpl_id = tpl_ref.get_tpl_id();
                 match target_rest_types.len() {
                     0 => {
-                        context.substitutor.insert_type(tpl_id, LuaType::Nil, true);
+                        context.inference.infer_type(tpl_id, LuaType::Nil, true);
                     }
                     1 => {
                         // If the single argument is itself a multi-return (e.g. a function call
@@ -1661,17 +1662,17 @@ pub fn variadic_tpl_pattern_match(
                             LuaType::Variadic(variadic) => match variadic.deref() {
                                 VariadicType::Multi(types) => match types.len() {
                                     0 => {
-                                        context.substitutor.insert_type(tpl_id, LuaType::Nil, true);
+                                        context.inference.infer_type(tpl_id, LuaType::Nil, true);
                                     }
                                     1 => {
-                                        context.substitutor.insert_type(
+                                        context.inference.infer_type(
                                             tpl_id,
                                             types[0].clone(),
                                             true,
                                         );
                                     }
                                     _ => {
-                                        context.substitutor.insert_multi_types(
+                                        context.inference.infer_multi_types(
                                             tpl_id,
                                             types
                                                 .iter()
@@ -1681,16 +1682,16 @@ pub fn variadic_tpl_pattern_match(
                                     }
                                 },
                                 VariadicType::Base(base) => {
-                                    context.substitutor.insert_multi_base(tpl_id, base.clone());
+                                    context.inference.infer_multi_base(tpl_id, base.clone());
                                 }
                             },
                             arg => {
-                                context.substitutor.insert_type(tpl_id, arg.clone(), true);
+                                context.inference.infer_type(tpl_id, arg.clone(), true);
                             }
                         }
                     }
                     _ => {
-                        context.substitutor.insert_multi_types(
+                        context.inference.infer_multi_types(
                             tpl_id,
                             target_rest_types
                                 .iter()
@@ -1704,10 +1705,10 @@ pub fn variadic_tpl_pattern_match(
                 let tpl_id = tpl_ref.get_tpl_id();
                 match target_rest_types.len() {
                     0 => {
-                        context.substitutor.insert_type(tpl_id, LuaType::Nil, false);
+                        context.inference.infer_type(tpl_id, LuaType::Nil, false);
                     }
                     1 => {
-                        context.substitutor.insert_type(
+                        context.inference.infer_type(
                             tpl_id,
                             target_rest_types[0].clone(),
                             false,
@@ -1715,8 +1716,8 @@ pub fn variadic_tpl_pattern_match(
                     }
                     _ => {
                         context
-                            .substitutor
-                            .insert_multi_types(tpl_id, target_rest_types.to_vec());
+                            .inference
+                            .infer_multi_types(tpl_id, target_rest_types.to_vec());
                     }
                 }
             }
@@ -1736,7 +1737,7 @@ pub fn variadic_tpl_pattern_match(
                         let tpl_id = tpl_ref.get_tpl_id();
                         match target_rest_types.get(i) {
                             Some(t) => {
-                                context.substitutor.insert_type(tpl_id, t.clone(), true);
+                                context.inference.infer_type(tpl_id, t.clone(), true);
                             }
                             None => {
                                 break;
@@ -1788,8 +1789,8 @@ fn tuple_tpl_pattern_match(
                         if let LuaType::TplRef(tpl_ref) = base {
                             let tpl_id = tpl_ref.get_tpl_id();
                             context
-                                .substitutor
-                                .insert_multi_base(tpl_id, target_array_base.get_base().clone());
+                                .inference
+                                .infer_multi_base(tpl_id, target_array_base.get_base().clone());
                         }
                     }
                     VariadicType::Multi(_) => {}

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -578,6 +578,8 @@ fn homomorphic_mapped_tpl_pattern_match(
     if let Some(key_constraint_tpl_id) = source_info.key_constraint_tpl_id
         && !key_types.is_empty()
     {
+        // TS-Go first infers source keys into the mapped key parameter
+        // before using an extended keyof constraint such as Pick<T, K>.
         let key_type = LuaType::from_vec(key_types);
         context.with_inference_priority(InferencePriority::MappedTypeConstraint, true, |context| {
             context
@@ -588,6 +590,8 @@ fn homomorphic_mapped_tpl_pattern_match(
 
     if !fields.is_empty() {
         let source_type = reverse_mapped_source_type(fields);
+        // TS-Go gives partial reverse mapped results a weaker priority so a
+        // later complete/direct inference can replace them.
         let priority = if saw_uninferred_field {
             InferencePriority::PartialHomomorphicMappedType
         } else {
@@ -624,6 +628,8 @@ fn constrained_mapped_tpl_pattern_match(
 
     if !key_types.is_empty() {
         let key_type = LuaType::from_vec(key_types);
+        // For { [P in K]: V }, infer keyof(source) into K before inferring
+        // property values into V.
         context.with_inference_priority(InferencePriority::MappedTypeConstraint, true, |context| {
             context
                 .inference
@@ -1450,6 +1456,8 @@ fn func_tpl_pattern_match_doc_func(
     let tpl_return = tpl_func.get_ret();
     let target_return = target_func.get_ret();
     let priority = active_inference_priority(context);
+    // Function returns are covariant; keep the caller's active priority
+    // (direct, contextual return, mapped, etc.) while matching them.
     context.with_inference_priority(priority, true, |context| {
         return_type_pattern_match_target_type(context, tpl_return, target_return)
     })?;
@@ -1533,6 +1541,8 @@ fn param_type_list_pattern_match_type_list(
                     Some(t) => t.1.clone().unwrap_or(LuaType::Any),
                     None => break,
                 };
+                // Function parameters are contravariant, matching TS-Go's
+                // separate contraCandidates bucket.
                 context.with_inference_priority_and_variance(
                     active_inference_priority(context),
                     true,
@@ -1583,11 +1593,9 @@ fn return_type_pattern_match_target_type(
                                 }
                                 LuaType::TplRef(tpl_ref) => {
                                     let tpl_id = tpl_ref.get_tpl_id();
-                                    context.inference.infer_type(
-                                        tpl_id,
-                                        target_base.clone(),
-                                        true,
-                                    );
+                                    context
+                                        .inference
+                                        .infer_type(tpl_id, target_base.clone(), true);
                                 }
                                 _ => {}
                             }
@@ -1708,11 +1716,9 @@ pub fn variadic_tpl_pattern_match(
                         context.inference.infer_type(tpl_id, LuaType::Nil, false);
                     }
                     1 => {
-                        context.inference.infer_type(
-                            tpl_id,
-                            target_rest_types[0].clone(),
-                            false,
-                        );
+                        context
+                            .inference
+                            .infer_type(tpl_id, target_rest_types[0].clone(), false);
                     }
                     _ => {
                         context

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -1448,11 +1448,19 @@ fn func_tpl_pattern_match_doc_func(
 
     let tpl_return = tpl_func.get_ret();
     let target_return = target_func.get_ret();
-    context.with_inference_priority(InferencePriority::Direct, true, |context| {
+    let priority = active_inference_priority(context);
+    context.with_inference_priority(priority, true, |context| {
         return_type_pattern_match_target_type(context, tpl_return, target_return)
     })?;
 
     Ok(())
+}
+
+fn active_inference_priority(context: &TplContext) -> InferencePriority {
+    match context.substitutor.priority() {
+        InferencePriority::None => InferencePriority::Direct,
+        priority => priority,
+    }
 }
 
 fn param_type_list_pattern_match_type_list(
@@ -1525,7 +1533,7 @@ fn param_type_list_pattern_match_type_list(
                     None => break,
                 };
                 context.with_inference_priority_and_variance(
-                    InferencePriority::Direct,
+                    active_inference_priority(context),
                     true,
                     InferenceVariance::Contravariant,
                     |context| tpl_pattern_match(context, &source, &target),

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -9,10 +9,10 @@ use rowan::NodeOrToken;
 use smol_str::SmolStr;
 
 use crate::{
-    GenericTplId, InferFailReason, LuaAliasCallKind, LuaAliasCallType, LuaArrayType,
-    LuaFunctionType, LuaMappedType, LuaMemberInfo, LuaMemberKey, LuaMemberOwner, LuaObjectType,
-    LuaSemanticDeclId, LuaTupleType, LuaTypeDeclId, LuaUnionType, SemanticDeclLevel, VariadicType,
-    check_type_compact,
+    GenericTplId, InferFailReason, InferencePriority, LuaAliasCallKind, LuaAliasCallType,
+    LuaArrayType, LuaFunctionType, LuaMappedType, LuaMemberInfo, LuaMemberKey, LuaMemberOwner,
+    LuaObjectType, LuaSemanticDeclId, LuaTupleType, LuaTypeDeclId, LuaUnionType, SemanticDeclLevel,
+    VariadicType, check_type_compact,
     db_index::{DbIndex, LuaGenericType, LuaType},
     infer_node_semantic_decl,
     semantic::{
@@ -542,10 +542,16 @@ fn mapped_tpl_pattern_match(
     }
 
     if !fields.is_empty() {
-        context.substitutor.insert_type(
-            source_tpl_id,
-            LuaType::Object(LuaObjectType::new_with_fields(fields, Vec::new()).into()),
+        context.with_inference_priority(
+            InferencePriority::HomomorphicMappedType,
             true,
+            |context| {
+                context.substitutor.insert_type(
+                    source_tpl_id,
+                    LuaType::Object(LuaObjectType::new_with_fields(fields, Vec::new()).into()),
+                    true,
+                );
+            },
         );
     }
 

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -519,14 +519,17 @@ fn mapped_tpl_pattern_match(
 
     let mut fields = HashMap::new();
     let mut key_types = Vec::new();
+    let mut saw_uninferred_field = false;
     for (member_key, target_type) in target_fields {
         let Some(key_type) = member_key_to_key_type(&member_key) else {
+            saw_uninferred_field = true;
             continue;
         };
 
         key_types.push(key_type.clone());
         let target_type = reverse_mapped_source_field_type(context, mapped, target_type);
         if target_type == LuaType::Never {
+            saw_uninferred_field = true;
             continue;
         }
 
@@ -542,6 +545,7 @@ fn mapped_tpl_pattern_match(
         );
 
         if inferred.is_empty() {
+            saw_uninferred_field = true;
             continue;
         }
 
@@ -561,8 +565,13 @@ fn mapped_tpl_pattern_match(
 
     if !fields.is_empty() {
         let source_type = reverse_mapped_source_type(fields);
+        let priority = if saw_uninferred_field {
+            InferencePriority::PartialHomomorphicMappedType
+        } else {
+            InferencePriority::HomomorphicMappedType
+        };
         context.with_inference_priority(
-            InferencePriority::HomomorphicMappedType,
+            priority,
             true,
             |context| {
                 context.substitutor.insert_type(

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -508,7 +508,7 @@ fn mapped_tpl_pattern_match(
     mapped: &LuaMappedType,
     target: &LuaType,
 ) -> TplPatternMatchResult {
-    let Some(source_tpl_id) = mapped_source_tpl_id(mapped) else {
+    let Some(source_info) = mapped_source_info(mapped) else {
         return Ok(());
     };
 
@@ -518,17 +518,19 @@ fn mapped_tpl_pattern_match(
     }
 
     let mut fields = HashMap::new();
+    let mut key_types = Vec::new();
     for (member_key, target_type) in target_fields {
         let Some(key_type) = member_key_to_key_type(&member_key) else {
             continue;
         };
 
+        key_types.push(key_type.clone());
         let mut inferred = Vec::new();
         collect_reverse_mapped_field_inferences(
             context,
             &mapped.value,
             &target_type,
-            source_tpl_id,
+            source_info.source_tpl_id,
             mapped.param.0,
             &key_type,
             &mut inferred,
@@ -541,13 +543,24 @@ fn mapped_tpl_pattern_match(
         fields.insert(member_key, LuaType::from_vec(inferred));
     }
 
+    if let Some(key_constraint_tpl_id) = source_info.key_constraint_tpl_id
+        && !key_types.is_empty()
+    {
+        let key_type = LuaType::from_vec(key_types);
+        context.with_inference_priority(InferencePriority::MappedTypeConstraint, true, |context| {
+            context
+                .substitutor
+                .insert_type(key_constraint_tpl_id, key_type, false);
+        });
+    }
+
     if !fields.is_empty() {
         context.with_inference_priority(
             InferencePriority::HomomorphicMappedType,
             true,
             |context| {
                 context.substitutor.insert_type(
-                    source_tpl_id,
+                    source_info.source_tpl_id,
                     LuaType::Object(LuaObjectType::new_with_fields(fields, Vec::new()).into()),
                     true,
                 );
@@ -558,15 +571,21 @@ fn mapped_tpl_pattern_match(
     Ok(())
 }
 
-fn mapped_source_tpl_id(mapped: &LuaMappedType) -> Option<GenericTplId> {
-    let constraint = mapped.param.1.type_constraint.as_ref()?;
-    mapped_source_tpl_id_from_constraint(constraint, 0)
+#[derive(Debug, Clone, Copy)]
+struct MappedSourceInfo {
+    source_tpl_id: GenericTplId,
+    key_constraint_tpl_id: Option<GenericTplId>,
 }
 
-fn mapped_source_tpl_id_from_constraint(
+fn mapped_source_info(mapped: &LuaMappedType) -> Option<MappedSourceInfo> {
+    let constraint = mapped.param.1.type_constraint.as_ref()?;
+    mapped_source_info_from_constraint(constraint, 0)
+}
+
+fn mapped_source_info_from_constraint(
     constraint: &LuaType,
     depth: usize,
-) -> Option<GenericTplId> {
+) -> Option<MappedSourceInfo> {
     if depth > 8 {
         return None;
     }
@@ -578,11 +597,18 @@ fn mapped_source_tpl_id_from_constraint(
                 return None;
             }
 
-            tpl_id_from_type(&operands[0])
+            Some(MappedSourceInfo {
+                source_tpl_id: tpl_id_from_type(&operands[0])?,
+                key_constraint_tpl_id: None,
+            })
         }
-        LuaType::TplRef(tpl) | LuaType::ConstTplRef(tpl) => tpl
-            .get_constraint()
-            .and_then(|constraint| mapped_source_tpl_id_from_constraint(constraint, depth + 1)),
+        LuaType::TplRef(tpl) | LuaType::ConstTplRef(tpl) => {
+            let mut info = tpl
+                .get_constraint()
+                .and_then(|constraint| mapped_source_info_from_constraint(constraint, depth + 1))?;
+            info.key_constraint_tpl_id = Some(tpl.get_tpl_id());
+            Some(info)
+        }
         _ => None,
     }
 }

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -242,18 +242,13 @@ pub(super) fn try_expand_generic_alias_for_pattern(
     let origin = type_decl.get_alias_ref()?;
     let substitutor =
         TypeSubstitutor::from_alias_for_type(db, generic.get_params().clone(), base.clone());
-    Some(instantiate_type_for_pattern(db, origin, &substitutor))
+    Some(instantiate_type_for_pattern(origin, &substitutor))
 }
 
-fn instantiate_type_for_pattern(
-    db: &DbIndex,
-    ty: &LuaType,
-    substitutor: &TypeSubstitutor,
-) -> LuaType {
+fn instantiate_type_for_pattern(ty: &LuaType, substitutor: &TypeSubstitutor) -> LuaType {
     match ty {
         LuaType::Array(array_type) => LuaType::Array(
             LuaArrayType::from_base_type(instantiate_type_for_pattern(
-                db,
                 array_type.get_base(),
                 substitutor,
             ))
@@ -264,7 +259,7 @@ fn instantiate_type_for_pattern(
                 tuple
                     .get_types()
                     .iter()
-                    .map(|ty| instantiate_type_for_pattern(db, ty, substitutor))
+                    .map(|ty| instantiate_type_for_pattern(ty, substitutor))
                     .collect(),
                 tuple.status,
             )
@@ -278,11 +273,11 @@ fn instantiate_type_for_pattern(
                     (
                         name.clone(),
                         ty.as_ref()
-                            .map(|ty| instantiate_type_for_pattern(db, ty, substitutor)),
+                            .map(|ty| instantiate_type_for_pattern(ty, substitutor)),
                     )
                 })
                 .collect();
-            let ret = instantiate_type_for_pattern(db, doc_func.get_ret(), substitutor);
+            let ret = instantiate_type_for_pattern(doc_func.get_ret(), substitutor);
             LuaType::DocFunction(
                 LuaFunctionType::new(
                     doc_func.get_async_state(),
@@ -301,7 +296,7 @@ fn instantiate_type_for_pattern(
                 .map(|(key, value)| {
                     (
                         key.clone(),
-                        instantiate_type_for_pattern(db, value, substitutor),
+                        instantiate_type_for_pattern(value, substitutor),
                     )
                 })
                 .collect();
@@ -310,8 +305,8 @@ fn instantiate_type_for_pattern(
                 .iter()
                 .map(|(key, value)| {
                     (
-                        instantiate_type_for_pattern(db, key, substitutor),
-                        instantiate_type_for_pattern(db, value, substitutor),
+                        instantiate_type_for_pattern(key, substitutor),
+                        instantiate_type_for_pattern(value, substitutor),
                     )
                 })
                 .collect();
@@ -321,7 +316,7 @@ fn instantiate_type_for_pattern(
             union
                 .into_vec()
                 .into_iter()
-                .map(|ty| instantiate_type_for_pattern(db, &ty, substitutor))
+                .map(|ty| instantiate_type_for_pattern(&ty, substitutor))
                 .collect(),
         ),
         LuaType::Generic(generic) => LuaType::Generic(
@@ -330,7 +325,7 @@ fn instantiate_type_for_pattern(
                 generic
                     .get_params()
                     .iter()
-                    .map(|ty| instantiate_type_for_pattern(db, ty, substitutor))
+                    .map(|ty| instantiate_type_for_pattern(ty, substitutor))
                     .collect(),
             )
             .into(),
@@ -338,7 +333,7 @@ fn instantiate_type_for_pattern(
         LuaType::TableGeneric(params) => LuaType::TableGeneric(
             params
                 .iter()
-                .map(|ty| instantiate_type_for_pattern(db, ty, substitutor))
+                .map(|ty| instantiate_type_for_pattern(ty, substitutor))
                 .collect::<Vec<_>>()
                 .into(),
         ),
@@ -359,12 +354,12 @@ fn instantiate_type_for_pattern(
         LuaType::Variadic(variadic) => LuaType::Variadic(
             match variadic.deref() {
                 VariadicType::Base(base) => {
-                    VariadicType::Base(instantiate_type_for_pattern(db, base, substitutor))
+                    VariadicType::Base(instantiate_type_for_pattern(base, substitutor))
                 }
                 VariadicType::Multi(types) => VariadicType::Multi(
                     types
                         .iter()
-                        .map(|ty| instantiate_type_for_pattern(db, ty, substitutor))
+                        .map(|ty| instantiate_type_for_pattern(ty, substitutor))
                         .collect(),
                 ),
             }
@@ -376,7 +371,7 @@ fn instantiate_type_for_pattern(
                 alias_call
                     .get_operands()
                     .iter()
-                    .map(|ty| instantiate_type_for_pattern(db, ty, substitutor))
+                    .map(|ty| instantiate_type_for_pattern(ty, substitutor))
                     .collect(),
             )
             .into(),
@@ -386,11 +381,11 @@ fn instantiate_type_for_pattern(
             param.type_constraint = param
                 .type_constraint
                 .as_ref()
-                .map(|ty| instantiate_type_for_pattern(db, ty, substitutor));
+                .map(|ty| instantiate_type_for_pattern(ty, substitutor));
             LuaType::Mapped(
                 LuaMappedType::new(
                     (mapped.param.0, param),
-                    instantiate_type_for_pattern(db, &mapped.value, substitutor),
+                    instantiate_type_for_pattern(&mapped.value, substitutor),
                     mapped.is_readonly,
                     mapped.is_optional,
                 )
@@ -398,10 +393,10 @@ fn instantiate_type_for_pattern(
             )
         }
         LuaType::TypeGuard(inner) => {
-            LuaType::TypeGuard(instantiate_type_for_pattern(db, inner, substitutor).into())
+            LuaType::TypeGuard(instantiate_type_for_pattern(inner, substitutor).into())
         }
         LuaType::TableOf(inner) => {
-            LuaType::TableOf(instantiate_type_for_pattern(db, inner, substitutor).into())
+            LuaType::TableOf(instantiate_type_for_pattern(inner, substitutor).into())
         }
         _ => ty.clone(),
     }

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -11,8 +11,8 @@ use smol_str::SmolStr;
 use crate::{
     GenericTplId, InferFailReason, InferencePriority, LuaAliasCallKind, LuaAliasCallType,
     LuaArrayType, LuaFunctionType, LuaMappedType, LuaMemberInfo, LuaMemberKey, LuaMemberOwner,
-    LuaObjectType, LuaSemanticDeclId, LuaTupleType, LuaTypeDeclId, LuaUnionType, SemanticDeclLevel,
-    TypeOps, VariadicType, check_type_compact,
+    LuaObjectType, LuaSemanticDeclId, LuaTupleStatus, LuaTupleType, LuaTypeDeclId, LuaUnionType,
+    SemanticDeclLevel, TypeOps, VariadicType, check_type_compact,
     db_index::{DbIndex, LuaGenericType, LuaType},
     infer_node_semantic_decl,
     semantic::{
@@ -560,13 +560,14 @@ fn mapped_tpl_pattern_match(
     }
 
     if !fields.is_empty() {
+        let source_type = reverse_mapped_source_type(fields);
         context.with_inference_priority(
             InferencePriority::HomomorphicMappedType,
             true,
             |context| {
                 context.substitutor.insert_type(
                     source_info.source_tpl_id,
-                    LuaType::Object(LuaObjectType::new_with_fields(fields, Vec::new()).into()),
+                    source_type,
                     true,
                 );
             },
@@ -586,6 +587,61 @@ fn reverse_mapped_source_field_type(
     }
 
     target_type
+}
+
+fn reverse_mapped_source_type(fields: HashMap<LuaMemberKey, LuaType>) -> LuaType {
+    if let Some(array_type) = reverse_mapped_array_source_type(&fields) {
+        return array_type;
+    }
+
+    if let Some(tuple_type) = reverse_mapped_tuple_source_type(&fields) {
+        return tuple_type;
+    }
+
+    LuaType::Object(LuaObjectType::new_with_fields(fields, Vec::new()).into())
+}
+
+fn reverse_mapped_array_source_type(fields: &HashMap<LuaMemberKey, LuaType>) -> Option<LuaType> {
+    if fields.len() != 1 {
+        return None;
+    }
+
+    let (key, value) = fields.iter().next()?;
+    match key {
+        LuaMemberKey::ExprType(LuaType::Integer | LuaType::Number) => Some(LuaType::Array(
+            LuaArrayType::from_base_type(value.clone()).into(),
+        )),
+        _ => None,
+    }
+}
+
+fn reverse_mapped_tuple_source_type(fields: &HashMap<LuaMemberKey, LuaType>) -> Option<LuaType> {
+    let mut members = Vec::with_capacity(fields.len());
+    for (key, value) in fields {
+        let LuaMemberKey::Integer(index) = key else {
+            return None;
+        };
+        if *index <= 0 {
+            return None;
+        }
+
+        members.push((*index as usize, value.clone()));
+    }
+
+    members.sort_by_key(|(index, _)| *index);
+    for (offset, (index, _)) in members.iter().enumerate() {
+        if *index != offset + 1 {
+            return None;
+        }
+    }
+
+    Some(LuaType::Tuple(
+        LuaTupleType::new(
+            members.into_iter().map(|(_, value)| value).collect(),
+            LuaTupleStatus::InferResolve,
+        )
+        .into(),
+    ))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -639,6 +695,16 @@ fn mapped_target_fields(
             .get_fields()
             .iter()
             .map(|(key, ty)| (key.clone(), ty.clone()))
+            .collect()),
+        LuaType::Array(target_array) => Ok(vec![(
+            LuaMemberKey::ExprType(LuaType::Integer),
+            target_array.get_base().clone(),
+        )]),
+        LuaType::Tuple(target_tuple) => Ok(target_tuple
+            .get_types()
+            .iter()
+            .enumerate()
+            .map(|(index, ty)| (LuaMemberKey::Integer((index + 1) as i64), ty.clone()))
             .collect()),
         LuaType::TableConst(_) | LuaType::Ref(_) | LuaType::Def(_) | LuaType::Generic(_) => {
             let members = get_member_map(context.db, target).ok_or(InferFailReason::None)?;

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -9,7 +9,8 @@ use rowan::NodeOrToken;
 use smol_str::SmolStr;
 
 use crate::{
-    InferFailReason, LuaFunctionType, LuaMemberInfo, LuaMemberKey, LuaMemberOwner, LuaObjectType,
+    GenericTplId, InferFailReason, LuaAliasCallKind, LuaAliasCallType, LuaArrayType,
+    LuaFunctionType, LuaMappedType, LuaMemberInfo, LuaMemberKey, LuaMemberOwner, LuaObjectType,
     LuaSemanticDeclId, LuaTupleType, LuaTypeDeclId, LuaUnionType, SemanticDeclLevel, VariadicType,
     check_type_compact,
     db_index::{DbIndex, LuaGenericType, LuaType},
@@ -218,10 +219,191 @@ pub fn tpl_pattern_match(
         LuaType::Object(obj) => {
             object_tpl_pattern_match(context, obj, &target)?;
         }
+        LuaType::Mapped(mapped) => {
+            mapped_tpl_pattern_match(context, mapped, &target)?;
+        }
         _ => {}
     }
 
     Ok(())
+}
+
+pub(super) fn try_expand_generic_alias_for_pattern(
+    db: &DbIndex,
+    generic: &LuaGenericType,
+) -> Option<LuaType> {
+    let base = generic.get_base_type_id_ref();
+    let type_decl = db.get_type_index().get_type_decl(base)?;
+    if !type_decl.is_alias() {
+        return None;
+    }
+
+    let origin = type_decl.get_alias_ref()?;
+    let substitutor =
+        TypeSubstitutor::from_alias_for_type(db, generic.get_params().clone(), base.clone());
+    Some(instantiate_type_for_pattern(db, origin, &substitutor))
+}
+
+fn instantiate_type_for_pattern(
+    db: &DbIndex,
+    ty: &LuaType,
+    substitutor: &TypeSubstitutor,
+) -> LuaType {
+    match ty {
+        LuaType::Array(array_type) => LuaType::Array(
+            LuaArrayType::from_base_type(instantiate_type_for_pattern(
+                db,
+                array_type.get_base(),
+                substitutor,
+            ))
+            .into(),
+        ),
+        LuaType::Tuple(tuple) => LuaType::Tuple(
+            LuaTupleType::new(
+                tuple
+                    .get_types()
+                    .iter()
+                    .map(|ty| instantiate_type_for_pattern(db, ty, substitutor))
+                    .collect(),
+                tuple.status,
+            )
+            .into(),
+        ),
+        LuaType::DocFunction(doc_func) => {
+            let params = doc_func
+                .get_params()
+                .iter()
+                .map(|(name, ty)| {
+                    (
+                        name.clone(),
+                        ty.as_ref()
+                            .map(|ty| instantiate_type_for_pattern(db, ty, substitutor)),
+                    )
+                })
+                .collect();
+            let ret = instantiate_type_for_pattern(db, doc_func.get_ret(), substitutor);
+            LuaType::DocFunction(
+                LuaFunctionType::new(
+                    doc_func.get_async_state(),
+                    doc_func.is_colon_define(),
+                    doc_func.is_variadic(),
+                    params,
+                    ret,
+                )
+                .into(),
+            )
+        }
+        LuaType::Object(object) => {
+            let fields = object
+                .get_fields()
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        instantiate_type_for_pattern(db, value, substitutor),
+                    )
+                })
+                .collect();
+            let index_access = object
+                .get_index_access()
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        instantiate_type_for_pattern(db, key, substitutor),
+                        instantiate_type_for_pattern(db, value, substitutor),
+                    )
+                })
+                .collect();
+            LuaType::Object(LuaObjectType::new_with_fields(fields, index_access).into())
+        }
+        LuaType::Union(union) => LuaType::from_vec(
+            union
+                .into_vec()
+                .into_iter()
+                .map(|ty| instantiate_type_for_pattern(db, &ty, substitutor))
+                .collect(),
+        ),
+        LuaType::Generic(generic) => LuaType::Generic(
+            LuaGenericType::new(
+                generic.get_base_type_id(),
+                generic
+                    .get_params()
+                    .iter()
+                    .map(|ty| instantiate_type_for_pattern(db, ty, substitutor))
+                    .collect(),
+            )
+            .into(),
+        ),
+        LuaType::TableGeneric(params) => LuaType::TableGeneric(
+            params
+                .iter()
+                .map(|ty| instantiate_type_for_pattern(db, ty, substitutor))
+                .collect::<Vec<_>>()
+                .into(),
+        ),
+        LuaType::TplRef(tpl) | LuaType::ConstTplRef(tpl) => {
+            match substitutor.get(tpl.get_tpl_id()) {
+                Some(SubstitutorValue::Type(ty)) => ty.default().clone(),
+                Some(SubstitutorValue::MultiTypes(types)) => {
+                    LuaType::Variadic(VariadicType::Multi(types.clone()).into())
+                }
+                Some(SubstitutorValue::MultiBase(base)) => base.clone(),
+                Some(SubstitutorValue::Params(params)) => params
+                    .first()
+                    .and_then(|(_, ty)| ty.clone())
+                    .unwrap_or(LuaType::Unknown),
+                _ => ty.clone(),
+            }
+        }
+        LuaType::Variadic(variadic) => LuaType::Variadic(
+            match variadic.deref() {
+                VariadicType::Base(base) => {
+                    VariadicType::Base(instantiate_type_for_pattern(db, base, substitutor))
+                }
+                VariadicType::Multi(types) => VariadicType::Multi(
+                    types
+                        .iter()
+                        .map(|ty| instantiate_type_for_pattern(db, ty, substitutor))
+                        .collect(),
+                ),
+            }
+            .into(),
+        ),
+        LuaType::Call(alias_call) => LuaType::Call(
+            LuaAliasCallType::new(
+                alias_call.get_call_kind(),
+                alias_call
+                    .get_operands()
+                    .iter()
+                    .map(|ty| instantiate_type_for_pattern(db, ty, substitutor))
+                    .collect(),
+            )
+            .into(),
+        ),
+        LuaType::Mapped(mapped) => {
+            let mut param = mapped.param.1.clone();
+            param.type_constraint = param
+                .type_constraint
+                .as_ref()
+                .map(|ty| instantiate_type_for_pattern(db, ty, substitutor));
+            LuaType::Mapped(
+                LuaMappedType::new(
+                    (mapped.param.0, param),
+                    instantiate_type_for_pattern(db, &mapped.value, substitutor),
+                    mapped.is_readonly,
+                    mapped.is_optional,
+                )
+                .into(),
+            )
+        }
+        LuaType::TypeGuard(inner) => {
+            LuaType::TypeGuard(instantiate_type_for_pattern(db, inner, substitutor).into())
+        }
+        LuaType::TableOf(inner) => {
+            LuaType::TableOf(instantiate_type_for_pattern(db, inner, substitutor).into())
+        }
+        _ => ty.clone(),
+    }
 }
 
 pub fn constant_decay(typ: LuaType) -> LuaType {
@@ -319,6 +501,425 @@ fn object_tpl_pattern_match_member_owner_match(
     }
 
     Ok(())
+}
+
+fn mapped_tpl_pattern_match(
+    context: &mut TplContext,
+    mapped: &LuaMappedType,
+    target: &LuaType,
+) -> TplPatternMatchResult {
+    let Some(source_tpl_id) = mapped_source_tpl_id(mapped) else {
+        return Ok(());
+    };
+
+    let target_fields = mapped_target_fields(context, target)?;
+    if target_fields.is_empty() {
+        return Ok(());
+    }
+
+    let mut fields = HashMap::new();
+    for (member_key, target_type) in target_fields {
+        let Some(key_type) = member_key_to_key_type(&member_key) else {
+            continue;
+        };
+
+        let mut inferred = Vec::new();
+        collect_reverse_mapped_field_inferences(
+            context,
+            &mapped.value,
+            &target_type,
+            source_tpl_id,
+            mapped.param.0,
+            &key_type,
+            &mut inferred,
+        );
+
+        if inferred.is_empty() {
+            continue;
+        }
+
+        fields.insert(member_key, LuaType::from_vec(inferred));
+    }
+
+    if !fields.is_empty() {
+        context.substitutor.insert_type(
+            source_tpl_id,
+            LuaType::Object(LuaObjectType::new_with_fields(fields, Vec::new()).into()),
+            true,
+        );
+    }
+
+    Ok(())
+}
+
+fn mapped_source_tpl_id(mapped: &LuaMappedType) -> Option<GenericTplId> {
+    let constraint = mapped.param.1.type_constraint.as_ref()?;
+    let LuaType::Call(alias_call) = constraint else {
+        return None;
+    };
+
+    if alias_call.get_call_kind() != LuaAliasCallKind::KeyOf {
+        return None;
+    }
+
+    let operands = alias_call.get_operands();
+    if operands.len() != 1 {
+        return None;
+    }
+
+    tpl_id_from_type(&operands[0])
+}
+
+fn mapped_target_fields(
+    context: &TplContext,
+    target: &LuaType,
+) -> Result<Vec<(LuaMemberKey, LuaType)>, InferFailReason> {
+    match target {
+        LuaType::Object(target_object) => Ok(target_object
+            .get_fields()
+            .iter()
+            .map(|(key, ty)| (key.clone(), ty.clone()))
+            .collect()),
+        LuaType::TableConst(_) | LuaType::Ref(_) | LuaType::Def(_) | LuaType::Generic(_) => {
+            let members = get_member_map(context.db, target).ok_or(InferFailReason::None)?;
+            let mut fields = Vec::new();
+            for (key, infos) in members {
+                let resolve_type = member_infos_to_type(&infos)?;
+                fields.push((key, resolve_type));
+            }
+            Ok(fields)
+        }
+        _ => Ok(Vec::new()),
+    }
+}
+
+fn member_infos_to_type(infos: &[LuaMemberInfo]) -> Result<LuaType, InferFailReason> {
+    let resolve_type = match infos.len() {
+        0 => LuaType::Any,
+        1 => infos[0].typ.clone(),
+        _ => LuaType::from_vec(infos.iter().map(|info| info.typ.clone()).collect()),
+    };
+
+    if resolve_type.is_unknown()
+        && !infos.is_empty()
+        && let Some(LuaSemanticDeclId::Member(member_id)) = &infos[0].property_owner_id
+    {
+        return Err(InferFailReason::UnResolveMemberType(*member_id));
+    }
+
+    Ok(resolve_type)
+}
+
+fn member_key_to_key_type(key: &LuaMemberKey) -> Option<LuaType> {
+    match key {
+        LuaMemberKey::Integer(i) => Some(LuaType::IntegerConst(*i)),
+        LuaMemberKey::Name(s) => Some(LuaType::StringConst(s.clone().into())),
+        LuaMemberKey::ExprType(ty) => Some(ty.clone()),
+        _ => None,
+    }
+}
+
+fn tpl_id_from_type(ty: &LuaType) -> Option<GenericTplId> {
+    match ty {
+        LuaType::TplRef(tpl) | LuaType::ConstTplRef(tpl) => Some(tpl.get_tpl_id()),
+        _ => None,
+    }
+}
+
+fn collect_reverse_mapped_field_inferences(
+    context: &TplContext,
+    pattern: &LuaType,
+    target: &LuaType,
+    source_tpl_id: GenericTplId,
+    mapped_key_tpl_id: GenericTplId,
+    key_type: &LuaType,
+    inferred: &mut Vec<LuaType>,
+) -> bool {
+    let target = escape_alias(context.db, target);
+    match pattern {
+        LuaType::Call(alias_call)
+            if mapped_index_call_matches(
+                alias_call,
+                source_tpl_id,
+                mapped_key_tpl_id,
+                key_type,
+            ) =>
+        {
+            inferred.push(target);
+            true
+        }
+        LuaType::Call(pattern_call) => {
+            let LuaType::Call(target_call) = &target else {
+                return false;
+            };
+            if pattern_call.get_call_kind() != target_call.get_call_kind()
+                || pattern_call.get_operands().len() != target_call.get_operands().len()
+            {
+                return false;
+            }
+
+            let mut matched = false;
+            for (pattern_operand, target_operand) in pattern_call
+                .get_operands()
+                .iter()
+                .zip(target_call.get_operands().iter())
+            {
+                matched |= collect_reverse_mapped_field_inferences(
+                    context,
+                    pattern_operand,
+                    target_operand,
+                    source_tpl_id,
+                    mapped_key_tpl_id,
+                    key_type,
+                    inferred,
+                );
+            }
+            matched
+        }
+        LuaType::Generic(pattern_generic) => {
+            if let Some(expanded) =
+                try_expand_generic_alias_for_pattern(context.db, pattern_generic)
+            {
+                return collect_reverse_mapped_field_inferences(
+                    context,
+                    &expanded,
+                    &target,
+                    source_tpl_id,
+                    mapped_key_tpl_id,
+                    key_type,
+                    inferred,
+                );
+            }
+
+            let LuaType::Generic(target_generic) = &target else {
+                return false;
+            };
+            if pattern_generic.get_base_type_id_ref() != target_generic.get_base_type_id_ref() {
+                return false;
+            }
+
+            let mut matched = false;
+            for (pattern_param, target_param) in pattern_generic
+                .get_params()
+                .iter()
+                .zip(target_generic.get_params().iter())
+            {
+                matched |= collect_reverse_mapped_field_inferences(
+                    context,
+                    pattern_param,
+                    target_param,
+                    source_tpl_id,
+                    mapped_key_tpl_id,
+                    key_type,
+                    inferred,
+                );
+            }
+            matched
+        }
+        LuaType::DocFunction(pattern_func) => collect_reverse_mapped_function_inferences(
+            context,
+            pattern_func,
+            &target,
+            source_tpl_id,
+            mapped_key_tpl_id,
+            key_type,
+            inferred,
+        ),
+        LuaType::Array(pattern_array) => {
+            let LuaType::Array(target_array) = &target else {
+                return false;
+            };
+            collect_reverse_mapped_field_inferences(
+                context,
+                pattern_array.get_base(),
+                target_array.get_base(),
+                source_tpl_id,
+                mapped_key_tpl_id,
+                key_type,
+                inferred,
+            )
+        }
+        LuaType::Tuple(pattern_tuple) => {
+            let LuaType::Tuple(target_tuple) = &target else {
+                return false;
+            };
+            let mut matched = false;
+            for (pattern_ty, target_ty) in pattern_tuple
+                .get_types()
+                .iter()
+                .zip(target_tuple.get_types().iter())
+            {
+                matched |= collect_reverse_mapped_field_inferences(
+                    context,
+                    pattern_ty,
+                    target_ty,
+                    source_tpl_id,
+                    mapped_key_tpl_id,
+                    key_type,
+                    inferred,
+                );
+            }
+            matched
+        }
+        LuaType::Object(pattern_object) => {
+            let LuaType::Object(target_object) = &target else {
+                return false;
+            };
+            let mut matched = false;
+            for (field_key, pattern_ty) in pattern_object.get_fields() {
+                if let Some(target_ty) = target_object.get_fields().get(field_key) {
+                    matched |= collect_reverse_mapped_field_inferences(
+                        context,
+                        pattern_ty,
+                        target_ty,
+                        source_tpl_id,
+                        mapped_key_tpl_id,
+                        key_type,
+                        inferred,
+                    );
+                }
+            }
+            matched
+        }
+        LuaType::TableGeneric(pattern_params) => {
+            let LuaType::TableGeneric(target_params) = &target else {
+                return false;
+            };
+            let mut matched = false;
+            for (pattern_param, target_param) in pattern_params.iter().zip(target_params.iter()) {
+                matched |= collect_reverse_mapped_field_inferences(
+                    context,
+                    pattern_param,
+                    target_param,
+                    source_tpl_id,
+                    mapped_key_tpl_id,
+                    key_type,
+                    inferred,
+                );
+            }
+            matched
+        }
+        LuaType::Union(pattern_union) => {
+            let mut matched = false;
+            for pattern_ty in pattern_union.into_vec() {
+                matched |= collect_reverse_mapped_field_inferences(
+                    context,
+                    &pattern_ty,
+                    &target,
+                    source_tpl_id,
+                    mapped_key_tpl_id,
+                    key_type,
+                    inferred,
+                );
+            }
+            matched
+        }
+        LuaType::Ref(type_id) | LuaType::Def(type_id) => {
+            let Some(type_decl) = context.db.get_type_index().get_type_decl(type_id) else {
+                return false;
+            };
+            let Some(origin) = type_decl.get_alias_ref() else {
+                return false;
+            };
+            collect_reverse_mapped_field_inferences(
+                context,
+                origin,
+                &target,
+                source_tpl_id,
+                mapped_key_tpl_id,
+                key_type,
+                inferred,
+            )
+        }
+        _ => false,
+    }
+}
+
+fn collect_reverse_mapped_function_inferences(
+    context: &TplContext,
+    pattern_func: &LuaFunctionType,
+    target: &LuaType,
+    source_tpl_id: GenericTplId,
+    mapped_key_tpl_id: GenericTplId,
+    key_type: &LuaType,
+    inferred: &mut Vec<LuaType>,
+) -> bool {
+    let target_func = match target {
+        LuaType::DocFunction(func) => Some(func.clone()),
+        LuaType::Signature(signature_id) => context
+            .db
+            .get_signature_index()
+            .get(signature_id)
+            .map(|signature| signature.to_doc_func_type()),
+        _ => None,
+    };
+    let Some(target_func) = target_func else {
+        return false;
+    };
+
+    let mut pattern_params = pattern_func.get_params().to_vec();
+    if pattern_func.is_colon_define() {
+        pattern_params.insert(0, ("self".to_string(), Some(LuaType::Any)));
+    }
+
+    let mut target_params = target_func.get_params().to_vec();
+    if target_func.is_colon_define() {
+        target_params.insert(0, ("self".to_string(), Some(LuaType::Any)));
+    }
+
+    let mut matched = false;
+    for ((_, pattern_param), (_, target_param)) in pattern_params.iter().zip(target_params.iter()) {
+        let Some(pattern_param) = pattern_param else {
+            continue;
+        };
+        let target_param = target_param.as_ref().unwrap_or(&LuaType::Any);
+        matched |= collect_reverse_mapped_field_inferences(
+            context,
+            pattern_param,
+            target_param,
+            source_tpl_id,
+            mapped_key_tpl_id,
+            key_type,
+            inferred,
+        );
+    }
+
+    matched |= collect_reverse_mapped_field_inferences(
+        context,
+        pattern_func.get_ret(),
+        target_func.get_ret(),
+        source_tpl_id,
+        mapped_key_tpl_id,
+        key_type,
+        inferred,
+    );
+
+    matched
+}
+
+fn mapped_index_call_matches(
+    alias_call: &LuaAliasCallType,
+    source_tpl_id: GenericTplId,
+    mapped_key_tpl_id: GenericTplId,
+    key_type: &LuaType,
+) -> bool {
+    if !matches!(
+        alias_call.get_call_kind(),
+        LuaAliasCallKind::Index | LuaAliasCallKind::RawGet
+    ) {
+        return false;
+    }
+
+    let operands = alias_call.get_operands();
+    if operands.len() != 2 || tpl_id_from_type(&operands[0]) != Some(source_tpl_id) {
+        return false;
+    }
+
+    if tpl_id_from_type(&operands[1]) == Some(mapped_key_tpl_id) {
+        return true;
+    }
+
+    &operands[1] == key_type
 }
 
 fn array_tpl_pattern_match(

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use super::{InferencePriority, InferenceVariance, tpl_pattern::constant_decay};
+use super::tpl_pattern::constant_decay;
 use crate::{
     DbIndex, GenericTplId, LuaType, LuaTypeDeclId, LuaUnionType,
     semantic::type_check::{check_type_compact, is_sub_type_of},
@@ -9,10 +9,8 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct TypeSubstitutor {
     tpl_replace_map: HashMap<GenericTplId, SubstitutorValue>,
-    type_inferences: HashMap<GenericTplId, TypeInferenceInfo>,
     alias_type_id: Option<LuaTypeDeclId>,
     self_type: Option<LuaType>,
-    collect_type_candidates: bool,
 }
 
 impl Default for TypeSubstitutor {
@@ -25,10 +23,8 @@ impl TypeSubstitutor {
     pub fn new() -> Self {
         Self {
             tpl_replace_map: HashMap::new(),
-            type_inferences: HashMap::new(),
             alias_type_id: None,
             self_type: None,
-            collect_type_candidates: false,
         }
     }
 
@@ -42,10 +38,8 @@ impl TypeSubstitutor {
         }
         Self {
             tpl_replace_map,
-            type_inferences: HashMap::new(),
             alias_type_id: None,
             self_type: None,
-            collect_type_candidates: false,
         }
     }
 
@@ -69,10 +63,8 @@ impl TypeSubstitutor {
         }
         Self {
             tpl_replace_map,
-            type_inferences: HashMap::new(),
             alias_type_id: Some(alias_type_id),
             self_type: None,
-            collect_type_candidates: false,
         }
     }
 
@@ -118,22 +110,6 @@ impl TypeSubstitutor {
         }
     }
 
-    pub(super) fn set_type_candidate_collection_enabled(&mut self, enabled: bool) -> bool {
-        let previous = self.collect_type_candidates;
-        self.collect_type_candidates = enabled;
-        previous
-    }
-
-    pub(super) fn normalize_type_inferences(&mut self, db: &DbIndex) {
-        for (tpl_id, inference) in self.type_inferences.iter_mut() {
-            inference.normalize_with_common_supertype(db);
-            if let Some(inferred) = inference.inferred() {
-                self.tpl_replace_map
-                    .insert(*tpl_id, SubstitutorValue::Type(inferred.clone()));
-            }
-        }
-    }
-
     pub fn is_infer_all_tpl(&self) -> bool {
         for value in self.tpl_replace_map.values() {
             if let SubstitutorValue::None = value {
@@ -143,53 +119,11 @@ impl TypeSubstitutor {
         true
     }
 
-    pub fn has_non_direct_type_inferences(&self) -> bool {
-        self.type_inferences.values().any(|inference| {
-            !matches!(
-                inference.priority(),
-                InferencePriority::None | InferencePriority::Direct
-            )
-        })
-    }
-
     pub fn insert_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
-        self.insert_type_with_priority(
-            tpl_id,
-            replace_type,
-            decay,
-            InferencePriority::Direct,
-            InferenceVariance::Covariant,
-        );
+        self.insert_type_value(tpl_id, SubstitutorTypeValue::new(replace_type, decay));
     }
 
-    pub(super) fn insert_type_with_priority(
-        &mut self,
-        tpl_id: GenericTplId,
-        replace_type: LuaType,
-        decay: bool,
-        priority: InferencePriority,
-        variance: InferenceVariance,
-    ) {
-        self.insert_type_value(
-            tpl_id,
-            SubstitutorTypeValue::new(replace_type, decay),
-            priority,
-            variance,
-        );
-    }
-
-    fn insert_type_value(
-        &mut self,
-        tpl_id: GenericTplId,
-        value: SubstitutorTypeValue,
-        priority: InferencePriority,
-        variance: InferenceVariance,
-    ) {
-        if self.collect_type_candidates {
-            self.insert_type_candidate(tpl_id, value, priority, variance);
-            return;
-        }
-
+    pub(super) fn insert_type_value(&mut self, tpl_id: GenericTplId, value: SubstitutorTypeValue) {
         if !self.can_insert_type(tpl_id) {
             return;
         }
@@ -198,42 +132,16 @@ impl TypeSubstitutor {
             .insert(tpl_id, SubstitutorValue::Type(value));
     }
 
-    fn insert_type_candidate(
+    pub(super) fn set_inferred_type_value(
         &mut self,
         tpl_id: GenericTplId,
         value: SubstitutorTypeValue,
-        priority: InferencePriority,
-        variance: InferenceVariance,
     ) {
-        let existing_type = match self.tpl_replace_map.get(&tpl_id) {
-            Some(SubstitutorValue::Type(existing)) => Some(existing.clone()),
-            Some(SubstitutorValue::None) | None => None,
-            Some(_) => return,
-        };
-        let had_inference = self.type_inferences.contains_key(&tpl_id);
-        let include_existing_type = !had_inference
-            && existing_type.is_some()
-            && self
-                .type_inferences
-                .get(&tpl_id)
-                .is_none_or(|inference| !priority.is_higher_than(inference.priority()));
-
-        let inference = self
-            .type_inferences
-            .entry(tpl_id)
-            .or_insert_with(TypeInferenceInfo::new);
-        if include_existing_type && let Some(existing) = existing_type {
-            inference.add_candidate(existing, priority, InferenceVariance::Covariant);
-        }
-        inference.add_candidate(value, priority, variance);
-
-        if let Some(inferred) = inference.inferred() {
-            self.tpl_replace_map
-                .insert(tpl_id, SubstitutorValue::Type(inferred.clone()));
-        }
+        self.tpl_replace_map
+            .insert(tpl_id, SubstitutorValue::Type(value));
     }
 
-    fn can_insert_type(&self, tpl_id: GenericTplId) -> bool {
+    pub(super) fn can_insert_type(&self, tpl_id: GenericTplId) -> bool {
         if let Some(value) = self.tpl_replace_map.get(&tpl_id) {
             return value.is_none();
         }
@@ -303,144 +211,6 @@ impl TypeSubstitutor {
     }
 }
 
-#[derive(Debug, Clone)]
-struct TypeInferenceInfo {
-    candidates: Vec<SubstitutorTypeValue>,
-    contra_candidates: Vec<SubstitutorTypeValue>,
-    inferred: Option<SubstitutorTypeValue>,
-    priority: Option<InferencePriority>,
-}
-
-impl TypeInferenceInfo {
-    fn new() -> Self {
-        Self {
-            candidates: Vec::new(),
-            contra_candidates: Vec::new(),
-            inferred: None,
-            priority: None,
-        }
-    }
-
-    fn add_candidate(
-        &mut self,
-        candidate: SubstitutorTypeValue,
-        priority: InferencePriority,
-        variance: InferenceVariance,
-    ) {
-        match self.priority {
-            Some(existing) if priority.is_higher_than(existing) => {
-                self.candidates.clear();
-                self.contra_candidates.clear();
-                self.inferred = None;
-                self.priority = Some(priority);
-            }
-            Some(existing) if existing.is_higher_than(priority) => {
-                return;
-            }
-            Some(_) => {}
-            None => {
-                self.priority = Some(priority);
-            }
-        }
-
-        let candidates = match variance {
-            InferenceVariance::Covariant => &mut self.candidates,
-            InferenceVariance::Contravariant => &mut self.contra_candidates,
-        };
-
-        if candidates.contains(&candidate) {
-            return;
-        }
-
-        if let Some(inferred) = &mut self.inferred {
-            inferred.union_with(candidate.clone());
-        } else {
-            self.inferred = Some(candidate.clone());
-        }
-        candidates.push(candidate);
-    }
-
-    fn normalize_with_common_supertype(&mut self, db: &DbIndex) {
-        self.inferred = self.infer_candidate(db);
-    }
-
-    fn infer_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
-        let covariant = self.infer_covariant_candidate(db);
-        let contravariant = self.infer_contravariant_candidate(db);
-
-        match (covariant, contravariant) {
-            (Some(covariant), Some(contravariant)) => {
-                if self.prefer_covariant_candidate(db, &covariant) {
-                    Some(covariant)
-                } else {
-                    Some(contravariant)
-                }
-            }
-            (Some(covariant), None) => Some(covariant),
-            (None, Some(contravariant)) => Some(contravariant),
-            (None, None) => None,
-        }
-    }
-
-    fn infer_covariant_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
-        let Some((first, rest)) = self.candidates.split_first() else {
-            return None;
-        };
-
-        let mut inferred = first.clone();
-        let combine_candidates = self
-            .priority
-            .is_some_and(InferencePriority::implies_candidate_combination);
-        for candidate in rest {
-            if combine_candidates {
-                inferred.union_with(candidate.clone());
-            } else {
-                inferred.combine_with_common_supertype(db, candidate.clone());
-            }
-        }
-
-        Some(inferred)
-    }
-
-    fn infer_contravariant_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
-        let Some((first, rest)) = self.contra_candidates.split_first() else {
-            return None;
-        };
-
-        let mut inferred = first.clone();
-        let combine_candidates = self
-            .priority
-            .is_some_and(InferencePriority::implies_candidate_combination);
-        for candidate in rest {
-            if combine_candidates {
-                inferred.union_with(candidate.clone());
-            } else {
-                inferred.combine_with_common_subtype(db, candidate.clone());
-            }
-        }
-
-        Some(inferred)
-    }
-
-    fn prefer_covariant_candidate(&self, db: &DbIndex, covariant: &SubstitutorTypeValue) -> bool {
-        if matches!(covariant.default(), LuaType::Any | LuaType::Never) {
-            return false;
-        }
-
-        self.contra_candidates
-            .iter()
-            .any(|candidate| candidate_assignable_to(db, covariant.default(), candidate.default()))
-    }
-
-    fn inferred(&self) -> Option<&SubstitutorTypeValue> {
-        self.inferred.as_ref()
-    }
-
-    fn priority(&self) -> InferencePriority {
-        self.priority.unwrap_or(InferencePriority::Direct)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubstitutorTypeValue {
     raw: LuaType,
@@ -466,17 +236,25 @@ impl SubstitutorTypeValue {
         &self.default
     }
 
-    fn union_with(&mut self, other: SubstitutorTypeValue) {
+    pub(super) fn union_with(&mut self, other: SubstitutorTypeValue) {
         self.raw = union_candidate_type(self.raw.clone(), other.raw);
         self.default = union_candidate_type(self.default.clone(), other.default);
     }
 
-    fn combine_with_common_supertype(&mut self, db: &DbIndex, other: SubstitutorTypeValue) {
+    pub(super) fn combine_with_common_supertype(
+        &mut self,
+        db: &DbIndex,
+        other: SubstitutorTypeValue,
+    ) {
         self.raw = common_candidate_type(db, self.raw.clone(), other.raw);
         self.default = common_candidate_type(db, self.default.clone(), other.default);
     }
 
-    fn combine_with_common_subtype(&mut self, db: &DbIndex, other: SubstitutorTypeValue) {
+    pub(super) fn combine_with_common_subtype(
+        &mut self,
+        db: &DbIndex,
+        other: SubstitutorTypeValue,
+    ) {
         self.raw = common_subtype_candidate_type(db, self.raw.clone(), other.raw);
         self.default = common_subtype_candidate_type(db, self.default.clone(), other.default);
     }
@@ -635,7 +413,7 @@ fn common_subtype_candidate_type(db: &DbIndex, left: LuaType, right: LuaType) ->
     left
 }
 
-fn candidate_assignable_to(db: &DbIndex, source: &LuaType, target: &LuaType) -> bool {
+pub(super) fn candidate_assignable_to(db: &DbIndex, source: &LuaType, target: &LuaType) -> bool {
     if source == target {
         return true;
     }

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -467,21 +467,19 @@ fn nullable_any_type() -> LuaType {
 }
 
 fn literal_types_with_same_base(left: &LuaType, right: &LuaType) -> bool {
-    match (left, right) {
+    matches!(
+        (left, right),
         (
             LuaType::StringConst(_) | LuaType::DocStringConst(_),
             LuaType::StringConst(_) | LuaType::DocStringConst(_),
-        )
-        | (
+        ) | (
             LuaType::IntegerConst(_) | LuaType::DocIntegerConst(_) | LuaType::FloatConst(_),
             LuaType::IntegerConst(_) | LuaType::DocIntegerConst(_) | LuaType::FloatConst(_),
+        ) | (
+            LuaType::BooleanConst(_) | LuaType::DocBooleanConst(_),
+            LuaType::BooleanConst(_) | LuaType::DocBooleanConst(_),
         )
-        | (
-            LuaType::BooleanConst(_) | LuaType::DocBooleanConst(_),
-            LuaType::BooleanConst(_) | LuaType::DocBooleanConst(_),
-        ) => true,
-        _ => false,
-    }
+    )
 }
 
 fn object_or_array_literal_candidate(ty: &LuaType) -> bool {

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use super::{
-    InferencePriority, instantiate_type::instantiate_type_generic, tpl_pattern::constant_decay,
+    InferencePriority, InferenceVariance, instantiate_type::instantiate_type_generic,
+    tpl_pattern::constant_decay,
 };
 use crate::{
     DbIndex, GenericTplId, LuaGenericType, LuaType, LuaTypeDeclId, LuaUnionType,
@@ -155,7 +156,13 @@ impl TypeSubstitutor {
     }
 
     pub fn insert_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
-        self.insert_type_with_priority(tpl_id, replace_type, decay, InferencePriority::Direct);
+        self.insert_type_with_priority(
+            tpl_id,
+            replace_type,
+            decay,
+            InferencePriority::Direct,
+            InferenceVariance::Covariant,
+        );
     }
 
     pub(super) fn insert_type_with_priority(
@@ -164,11 +171,13 @@ impl TypeSubstitutor {
         replace_type: LuaType,
         decay: bool,
         priority: InferencePriority,
+        variance: InferenceVariance,
     ) {
         self.insert_type_value(
             tpl_id,
             SubstitutorTypeValue::new(replace_type, decay),
             priority,
+            variance,
         );
     }
 
@@ -177,9 +186,10 @@ impl TypeSubstitutor {
         tpl_id: GenericTplId,
         value: SubstitutorTypeValue,
         priority: InferencePriority,
+        variance: InferenceVariance,
     ) {
         if self.collect_type_candidates {
-            self.insert_type_candidate(tpl_id, value, priority);
+            self.insert_type_candidate(tpl_id, value, priority, variance);
             return;
         }
 
@@ -196,12 +206,14 @@ impl TypeSubstitutor {
         tpl_id: GenericTplId,
         value: SubstitutorTypeValue,
         priority: InferencePriority,
+        variance: InferenceVariance,
     ) {
         let existing_type = match self.tpl_replace_map.get(&tpl_id) {
             Some(SubstitutorValue::Type(existing)) => Some(existing.clone()),
             Some(SubstitutorValue::None) | None => None,
             Some(_) => return,
         };
+        let had_inference = self.type_inferences.contains_key(&tpl_id);
         let include_existing_type = self
             .type_inferences
             .get(&tpl_id)
@@ -212,9 +224,14 @@ impl TypeSubstitutor {
             .entry(tpl_id)
             .or_insert_with(TypeInferenceInfo::new);
         if include_existing_type && let Some(existing) = existing_type {
-            inference.add_candidate(existing, priority);
+            let existing_variance = if had_inference {
+                variance
+            } else {
+                InferenceVariance::Covariant
+            };
+            inference.add_candidate(existing, priority, existing_variance);
         }
-        inference.add_candidate(value, priority);
+        inference.add_candidate(value, priority, variance);
 
         if let Some(inferred) = inference.inferred() {
             self.tpl_replace_map
@@ -295,6 +312,7 @@ impl TypeSubstitutor {
 #[derive(Debug, Clone)]
 struct TypeInferenceInfo {
     candidates: Vec<SubstitutorTypeValue>,
+    contra_candidates: Vec<SubstitutorTypeValue>,
     inferred: Option<SubstitutorTypeValue>,
     priority: Option<InferencePriority>,
 }
@@ -303,15 +321,22 @@ impl TypeInferenceInfo {
     fn new() -> Self {
         Self {
             candidates: Vec::new(),
+            contra_candidates: Vec::new(),
             inferred: None,
             priority: None,
         }
     }
 
-    fn add_candidate(&mut self, candidate: SubstitutorTypeValue, priority: InferencePriority) {
+    fn add_candidate(
+        &mut self,
+        candidate: SubstitutorTypeValue,
+        priority: InferencePriority,
+        variance: InferenceVariance,
+    ) {
         match self.priority {
             Some(existing) if priority.is_higher_than(existing) => {
                 self.candidates.clear();
+                self.contra_candidates.clear();
                 self.inferred = None;
                 self.priority = Some(priority);
             }
@@ -324,7 +349,12 @@ impl TypeInferenceInfo {
             }
         }
 
-        if self.candidates.contains(&candidate) {
+        let candidates = match variance {
+            InferenceVariance::Covariant => &mut self.candidates,
+            InferenceVariance::Contravariant => &mut self.contra_candidates,
+        };
+
+        if candidates.contains(&candidate) {
             return;
         }
 
@@ -333,13 +363,34 @@ impl TypeInferenceInfo {
         } else {
             self.inferred = Some(candidate.clone());
         }
-        self.candidates.push(candidate);
+        candidates.push(candidate);
     }
 
     fn normalize_with_common_supertype(&mut self, db: &DbIndex) {
+        self.inferred = self.infer_candidate(db);
+    }
+
+    fn infer_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
+        let covariant = self.infer_covariant_candidate(db);
+        let contravariant = self.infer_contravariant_candidate(db);
+
+        match (covariant, contravariant) {
+            (Some(covariant), Some(contravariant)) => {
+                if self.prefer_covariant_candidate(db, &covariant) {
+                    Some(covariant)
+                } else {
+                    Some(contravariant)
+                }
+            }
+            (Some(covariant), None) => Some(covariant),
+            (None, Some(contravariant)) => Some(contravariant),
+            (None, None) => None,
+        }
+    }
+
+    fn infer_covariant_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
         let Some((first, rest)) = self.candidates.split_first() else {
-            self.inferred = None;
-            return;
+            return None;
         };
 
         let mut inferred = first.clone();
@@ -354,7 +405,33 @@ impl TypeInferenceInfo {
             }
         }
 
-        self.inferred = Some(inferred);
+        Some(inferred)
+    }
+
+    fn infer_contravariant_candidate(&self, db: &DbIndex) -> Option<SubstitutorTypeValue> {
+        let Some((first, rest)) = self.contra_candidates.split_first() else {
+            return None;
+        };
+
+        let mut inferred = first.clone();
+        let combine_candidates = self
+            .priority
+            .is_some_and(InferencePriority::implies_candidate_combination);
+        for candidate in rest {
+            if combine_candidates {
+                inferred.union_with(candidate.clone());
+            } else {
+                inferred.combine_with_common_subtype(db, candidate.clone());
+            }
+        }
+
+        Some(inferred)
+    }
+
+    fn prefer_covariant_candidate(&self, db: &DbIndex, covariant: &SubstitutorTypeValue) -> bool {
+        self.contra_candidates.iter().any(|candidate| {
+            check_type_compact(db, covariant.default(), candidate.default()).is_ok()
+        })
     }
 
     fn inferred(&self) -> Option<&SubstitutorTypeValue> {
@@ -399,6 +476,11 @@ impl SubstitutorTypeValue {
     fn combine_with_common_supertype(&mut self, db: &DbIndex, other: SubstitutorTypeValue) {
         self.raw = common_candidate_type(db, self.raw.clone(), other.raw);
         self.default = common_candidate_type(db, self.default.clone(), other.default);
+    }
+
+    fn combine_with_common_subtype(&mut self, db: &DbIndex, other: SubstitutorTypeValue) {
+        self.raw = common_subtype_candidate_type(db, self.raw.clone(), other.raw);
+        self.default = common_subtype_candidate_type(db, self.default.clone(), other.default);
     }
 }
 
@@ -522,6 +604,29 @@ fn common_candidate_type(db: &DbIndex, left: LuaType, right: LuaType) -> LuaType
     }
 
     union_candidate_type(left, right)
+}
+
+fn common_subtype_candidate_type(db: &DbIndex, left: LuaType, right: LuaType) -> LuaType {
+    if left == right {
+        return left;
+    }
+
+    match (&left, &right) {
+        (LuaType::Any, right) if right.is_nullable() => return nullable_any_type(),
+        (left, LuaType::Any) if left.is_nullable() => return nullable_any_type(),
+        (LuaType::Any, _) => return right,
+        (_, LuaType::Any) => return left,
+        (LuaType::Never, _) | (_, LuaType::Never) => return LuaType::Never,
+        (LuaType::Unknown, _) => return right,
+        (_, LuaType::Unknown) => return left,
+        _ => {}
+    }
+
+    if check_type_compact(db, &right, &left).is_ok() {
+        return right;
+    }
+
+    left
 }
 
 fn common_nominal_supertype(db: &DbIndex, left: &LuaType, right: &LuaType) -> Option<LuaType> {

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::{
     DbIndex, GenericTplId, LuaGenericType, LuaType, LuaTypeDeclId, LuaUnionType,
-    semantic::type_check::check_type_compact,
+    semantic::type_check::{check_type_compact, is_sub_type_of},
 };
 
 #[derive(Debug, Clone)]
@@ -214,22 +214,19 @@ impl TypeSubstitutor {
             Some(_) => return,
         };
         let had_inference = self.type_inferences.contains_key(&tpl_id);
-        let include_existing_type = self
-            .type_inferences
-            .get(&tpl_id)
-            .is_none_or(|inference| !priority.is_higher_than(inference.priority()));
+        let include_existing_type = !had_inference
+            && existing_type.is_some()
+            && self
+                .type_inferences
+                .get(&tpl_id)
+                .is_none_or(|inference| !priority.is_higher_than(inference.priority()));
 
         let inference = self
             .type_inferences
             .entry(tpl_id)
             .or_insert_with(TypeInferenceInfo::new);
         if include_existing_type && let Some(existing) = existing_type {
-            let existing_variance = if had_inference {
-                variance
-            } else {
-                InferenceVariance::Covariant
-            };
-            inference.add_candidate(existing, priority, existing_variance);
+            inference.add_candidate(existing, priority, InferenceVariance::Covariant);
         }
         inference.add_candidate(value, priority, variance);
 
@@ -429,9 +426,13 @@ impl TypeInferenceInfo {
     }
 
     fn prefer_covariant_candidate(&self, db: &DbIndex, covariant: &SubstitutorTypeValue) -> bool {
-        self.contra_candidates.iter().any(|candidate| {
-            check_type_compact(db, covariant.default(), candidate.default()).is_ok()
-        })
+        if matches!(covariant.default(), LuaType::Any | LuaType::Never) {
+            return false;
+        }
+
+        self.contra_candidates
+            .iter()
+            .any(|candidate| candidate_assignable_to(db, covariant.default(), candidate.default()))
     }
 
     fn inferred(&self) -> Option<&SubstitutorTypeValue> {
@@ -627,6 +628,39 @@ fn common_subtype_candidate_type(db: &DbIndex, left: LuaType, right: LuaType) ->
     }
 
     left
+}
+
+fn candidate_assignable_to(db: &DbIndex, source: &LuaType, target: &LuaType) -> bool {
+    if source == target {
+        return true;
+    }
+
+    match (source, target) {
+        (
+            LuaType::Ref(source_id) | LuaType::Def(source_id),
+            LuaType::Ref(target_id) | LuaType::Def(target_id),
+        ) => is_sub_type_of(db, source_id, target_id),
+        (LuaType::Generic(source_generic), LuaType::Ref(target_id) | LuaType::Def(target_id)) => {
+            let source_id = source_generic.get_base_type_id_ref();
+            source_id == target_id || is_sub_type_of(db, source_id, target_id)
+        }
+        (LuaType::Ref(source_id) | LuaType::Def(source_id), LuaType::Generic(target_generic)) => {
+            let target_id = target_generic.get_base_type_id_ref();
+            source_id == target_id || is_sub_type_of(db, source_id, target_id)
+        }
+        (LuaType::Generic(source_generic), LuaType::Generic(target_generic)) => {
+            source_generic.get_base_type_id_ref() == target_generic.get_base_type_id_ref()
+                && source_generic.get_params().len() == target_generic.get_params().len()
+                && source_generic
+                    .get_params()
+                    .iter()
+                    .zip(target_generic.get_params().iter())
+                    .all(|(source_param, target_param)| {
+                        candidate_assignable_to(db, source_param, target_param)
+                    })
+        }
+        _ => check_type_compact(db, source, target).is_ok(),
+    }
 }
 
 fn common_nominal_supertype(db: &DbIndex, left: &LuaType, right: &LuaType) -> Option<LuaType> {

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -145,6 +145,15 @@ impl TypeSubstitutor {
         true
     }
 
+    pub fn has_non_direct_type_inferences(&self) -> bool {
+        self.type_inferences.values().any(|inference| {
+            !matches!(
+                inference.priority(),
+                InferencePriority::None | InferencePriority::Direct
+            )
+        })
+    }
+
     pub fn insert_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
         self.insert_type_with_priority(tpl_id, replace_type, decay, InferencePriority::Direct);
     }

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -118,13 +118,13 @@ impl TypeSubstitutor {
         }
     }
 
-    pub fn set_type_candidate_collection_enabled(&mut self, enabled: bool) -> bool {
+    pub(super) fn set_type_candidate_collection_enabled(&mut self, enabled: bool) -> bool {
         let previous = self.collect_type_candidates;
         self.collect_type_candidates = enabled;
         previous
     }
 
-    pub fn normalize_type_inferences(&mut self, db: &DbIndex) {
+    pub(super) fn normalize_type_inferences(&mut self, db: &DbIndex) {
         for (tpl_id, inference) in self.type_inferences.iter_mut() {
             inference.normalize_with_common_supertype(db);
             if let Some(inferred) = inference.inferred() {

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -237,6 +237,13 @@ impl SubstitutorTypeValue {
         Self { raw, default }
     }
 
+    pub(super) fn with_raw_default(raw: LuaType, default: LuaType) -> Self {
+        Self {
+            raw: into_ref_type(raw),
+            default: into_ref_type(default),
+        }
+    }
+
     pub fn raw(&self) -> &LuaType {
         &self.raw
     }

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -325,7 +325,7 @@ fn into_ref_type(ty: LuaType) -> LuaType {
     }
 }
 
-fn union_candidate_type(left: LuaType, right: LuaType) -> LuaType {
+pub(super) fn union_candidate_type(left: LuaType, right: LuaType) -> LuaType {
     if left == right {
         return left;
     }

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -119,11 +119,20 @@ impl TypeSubstitutor {
         true
     }
 
-    pub fn insert_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
-        self.insert_type_value(tpl_id, SubstitutorTypeValue::new(replace_type, decay));
+    pub(super) fn set_fixed_type(
+        &mut self,
+        tpl_id: GenericTplId,
+        replace_type: LuaType,
+        decay: bool,
+    ) {
+        self.set_fixed_type_value(tpl_id, SubstitutorTypeValue::new(replace_type, decay));
     }
 
-    pub(super) fn insert_type_value(&mut self, tpl_id: GenericTplId, value: SubstitutorTypeValue) {
+    pub(super) fn set_fixed_type_value(
+        &mut self,
+        tpl_id: GenericTplId,
+        value: SubstitutorTypeValue,
+    ) {
         if !self.can_insert_type(tpl_id) {
             return;
         }

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -1,11 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use super::{
-    InferencePriority, InferenceVariance, instantiate_type::instantiate_type_generic,
-    tpl_pattern::constant_decay,
-};
+use super::{InferencePriority, InferenceVariance, tpl_pattern::constant_decay};
 use crate::{
-    DbIndex, GenericTplId, LuaGenericType, LuaType, LuaTypeDeclId, LuaUnionType,
+    DbIndex, GenericTplId, LuaType, LuaTypeDeclId, LuaUnionType,
     semantic::type_check::{check_type_compact, is_sub_type_of},
 };
 
@@ -393,7 +390,7 @@ impl TypeInferenceInfo {
         let mut inferred = first.clone();
         let combine_candidates = self
             .priority
-            .is_some_and(InferencePriority::implies_covariant_candidate_combination);
+            .is_some_and(InferencePriority::implies_candidate_combination);
         for candidate in rest {
             if combine_candidates {
                 inferred.union_with(candidate.clone());
@@ -593,18 +590,22 @@ fn common_candidate_type(db: &DbIndex, left: LuaType, right: LuaType) -> LuaType
     }
 
     if check_type_compact(db, &left, &right).is_ok() {
-        return right;
-    }
-
-    if check_type_compact(db, &right, &left).is_ok() {
         return left;
     }
 
-    if let Some(common) = common_nominal_supertype(db, &left, &right) {
-        return common;
+    if check_type_compact(db, &right, &left).is_ok() {
+        return right;
     }
 
-    union_candidate_type(left, right)
+    if literal_types_with_same_base(&left, &right) {
+        return union_candidate_type(left, right);
+    }
+
+    if object_or_array_literal_candidate(&left) && object_or_array_literal_candidate(&right) {
+        return union_candidate_type(left, right);
+    }
+
+    left
 }
 
 fn common_subtype_candidate_type(db: &DbIndex, left: LuaType, right: LuaType) -> LuaType {
@@ -623,8 +624,12 @@ fn common_subtype_candidate_type(db: &DbIndex, left: LuaType, right: LuaType) ->
         _ => {}
     }
 
-    if check_type_compact(db, &right, &left).is_ok() {
+    if check_type_compact(db, &left, &right).is_ok() {
         return right;
+    }
+
+    if check_type_compact(db, &right, &left).is_ok() {
+        return left;
     }
 
     left
@@ -659,148 +664,35 @@ fn candidate_assignable_to(db: &DbIndex, source: &LuaType, target: &LuaType) -> 
                         candidate_assignable_to(db, source_param, target_param)
                     })
         }
-        _ => check_type_compact(db, source, target).is_ok(),
+        _ => check_type_compact(db, target, source).is_ok(),
     }
-}
-
-fn common_nominal_supertype(db: &DbIndex, left: &LuaType, right: &LuaType) -> Option<LuaType> {
-    let left_supers = nominal_super_types_with_self(db, left)?;
-    let right_supers = nominal_super_types_with_self(db, right)?;
-
-    for left_candidate in &left_supers {
-        for right_candidate in &right_supers {
-            if let Some(common) = common_generic_candidate_type(db, left_candidate, right_candidate)
-            {
-                return Some(common);
-            }
-
-            if left_candidate == right_candidate {
-                return Some(left_candidate.clone());
-            }
-        }
-    }
-
-    None
-}
-
-fn nominal_super_types_with_self(db: &DbIndex, ty: &LuaType) -> Option<Vec<LuaType>> {
-    let mut super_types = Vec::new();
-    let mut visited = HashSet::new();
-
-    match ty {
-        LuaType::Ref(type_id) | LuaType::Def(type_id) => {
-            push_nominal_super_type(&mut super_types, LuaType::Ref(type_id.clone()));
-            collect_decl_super_types(db, type_id, None, &mut super_types, &mut visited);
-            Some(super_types)
-        }
-        LuaType::Generic(generic) => {
-            push_nominal_super_type(&mut super_types, LuaType::Generic(generic.clone().into()));
-
-            let base_type_id = generic.get_base_type_id_ref();
-            let substitutor = TypeSubstitutor::from_type_array_for_type(
-                db,
-                base_type_id,
-                generic.get_params().clone(),
-            );
-            collect_decl_super_types(
-                db,
-                base_type_id,
-                Some(&substitutor),
-                &mut super_types,
-                &mut visited,
-            );
-            Some(super_types)
-        }
-        _ => None,
-    }
-}
-
-fn collect_decl_super_types(
-    db: &DbIndex,
-    type_id: &LuaTypeDeclId,
-    substitutor: Option<&TypeSubstitutor>,
-    super_types: &mut Vec<LuaType>,
-    visited: &mut HashSet<LuaTypeDeclId>,
-) {
-    if !visited.insert(type_id.clone()) {
-        return;
-    }
-
-    let Some(decl_super_types) = db.get_type_index().get_super_types(type_id) else {
-        return;
-    };
-
-    for super_type in decl_super_types {
-        let instantiated_super = match substitutor {
-            Some(substitutor) => instantiate_type_generic(db, &super_type, substitutor),
-            None => super_type,
-        };
-
-        push_nominal_super_type(super_types, instantiated_super.clone());
-
-        match instantiated_super {
-            LuaType::Ref(super_type_id) | LuaType::Def(super_type_id) => {
-                collect_decl_super_types(db, &super_type_id, None, super_types, visited);
-            }
-            LuaType::Generic(generic) => {
-                let base_type_id = generic.get_base_type_id_ref();
-                let substitutor = TypeSubstitutor::from_type_array_for_type(
-                    db,
-                    base_type_id,
-                    generic.get_params().clone(),
-                );
-                collect_decl_super_types(
-                    db,
-                    base_type_id,
-                    Some(&substitutor),
-                    super_types,
-                    visited,
-                );
-            }
-            _ => {}
-        }
-    }
-}
-
-fn push_nominal_super_type(super_types: &mut Vec<LuaType>, ty: LuaType) {
-    if !super_types.contains(&ty) {
-        super_types.push(ty.clone());
-    }
-
-    if let LuaType::Generic(generic) = ty {
-        let base = LuaType::Ref(generic.get_base_type_id());
-        if !super_types.contains(&base) {
-            super_types.push(base);
-        }
-    }
-}
-
-fn common_generic_candidate_type(db: &DbIndex, left: &LuaType, right: &LuaType) -> Option<LuaType> {
-    let (LuaType::Generic(left_generic), LuaType::Generic(right_generic)) = (left, right) else {
-        return None;
-    };
-
-    if left_generic.get_base_type_id_ref() != right_generic.get_base_type_id_ref() {
-        return None;
-    }
-
-    let left_params = left_generic.get_params();
-    let right_params = right_generic.get_params();
-    if left_params.len() != right_params.len() {
-        return None;
-    }
-
-    let params = left_params
-        .iter()
-        .zip(right_params.iter())
-        .map(|(left_param, right_param)| {
-            common_candidate_type(db, left_param.clone(), right_param.clone())
-        })
-        .collect();
-
-    Some(LuaGenericType::new(left_generic.get_base_type_id(), params).into())
 }
 
 fn nullable_any_type() -> LuaType {
     LuaType::Union(LuaUnionType::Nullable(LuaType::Any).into())
+}
+
+fn literal_types_with_same_base(left: &LuaType, right: &LuaType) -> bool {
+    match (left, right) {
+        (
+            LuaType::StringConst(_) | LuaType::DocStringConst(_),
+            LuaType::StringConst(_) | LuaType::DocStringConst(_),
+        )
+        | (
+            LuaType::IntegerConst(_) | LuaType::DocIntegerConst(_) | LuaType::FloatConst(_),
+            LuaType::IntegerConst(_) | LuaType::DocIntegerConst(_) | LuaType::FloatConst(_),
+        )
+        | (
+            LuaType::BooleanConst(_) | LuaType::DocBooleanConst(_),
+            LuaType::BooleanConst(_) | LuaType::DocBooleanConst(_),
+        ) => true,
+        _ => false,
+    }
+}
+
+fn object_or_array_literal_candidate(ty: &LuaType) -> bool {
+    matches!(
+        ty,
+        LuaType::Object(_) | LuaType::TableConst(_) | LuaType::Array(_) | LuaType::Tuple(_)
+    )
 }

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -1,7 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
 use super::tpl_pattern::constant_decay;
-use crate::{DbIndex, GenericTplId, LuaType, LuaTypeDeclId, LuaUnionType};
+use crate::{
+    DbIndex, GenericTplId, LuaGenericType, LuaType, LuaTypeDeclId, LuaUnionType,
+    semantic::type_check::check_type_compact,
+};
 
 #[derive(Debug, Clone)]
 pub struct TypeSubstitutor {
@@ -119,6 +122,16 @@ impl TypeSubstitutor {
         let previous = self.collect_type_candidates;
         self.collect_type_candidates = enabled;
         previous
+    }
+
+    pub fn normalize_type_inferences(&mut self, db: &DbIndex) {
+        for (tpl_id, inference) in self.type_inferences.iter_mut() {
+            inference.normalize_with_common_supertype(db);
+            if let Some(inferred) = inference.inferred() {
+                self.tpl_replace_map
+                    .insert(*tpl_id, SubstitutorValue::Type(inferred.clone()));
+            }
+        }
     }
 
     pub fn is_infer_all_tpl(&self) -> bool {
@@ -267,6 +280,20 @@ impl TypeInferenceInfo {
         self.candidates.push(candidate);
     }
 
+    fn normalize_with_common_supertype(&mut self, db: &DbIndex) {
+        let Some((first, rest)) = self.candidates.split_first() else {
+            self.inferred = None;
+            return;
+        };
+
+        let mut inferred = first.clone();
+        for candidate in rest {
+            inferred.combine_with_common_supertype(db, candidate.clone());
+        }
+
+        self.inferred = Some(inferred);
+    }
+
     fn inferred(&self) -> Option<&SubstitutorTypeValue> {
         self.inferred.as_ref()
     }
@@ -300,6 +327,11 @@ impl SubstitutorTypeValue {
     fn union_with(&mut self, other: SubstitutorTypeValue) {
         self.raw = union_candidate_type(self.raw.clone(), other.raw);
         self.default = union_candidate_type(self.default.clone(), other.default);
+    }
+
+    fn combine_with_common_supertype(&mut self, db: &DbIndex, other: SubstitutorTypeValue) {
+        self.raw = common_candidate_type(db, self.raw.clone(), other.raw);
+        self.default = common_candidate_type(db, self.default.clone(), other.default);
     }
 }
 
@@ -392,6 +424,64 @@ pub(super) fn union_candidate_type(left: LuaType, right: LuaType) -> LuaType {
         }
         _ => LuaType::from_vec(vec![left, right]),
     }
+}
+
+fn common_candidate_type(db: &DbIndex, left: LuaType, right: LuaType) -> LuaType {
+    if left == right {
+        return left;
+    }
+
+    match (&left, &right) {
+        (LuaType::Any, right) if right.is_nullable() => return nullable_any_type(),
+        (left, LuaType::Any) if left.is_nullable() => return nullable_any_type(),
+        (LuaType::Any, _) | (_, LuaType::Any) => return LuaType::Any,
+        (LuaType::Never, _) => return right,
+        (_, LuaType::Never) => return left,
+        (LuaType::Unknown, _) => return right,
+        (_, LuaType::Unknown) => return left,
+        _ => {}
+    }
+
+    if check_type_compact(db, &left, &right).is_ok() {
+        return right;
+    }
+
+    if check_type_compact(db, &right, &left).is_ok() {
+        return left;
+    }
+
+    if let Some(common) = common_nominal_supertype(db, &left, &right) {
+        return common;
+    }
+
+    union_candidate_type(left, right)
+}
+
+fn common_nominal_supertype(db: &DbIndex, left: &LuaType, right: &LuaType) -> Option<LuaType> {
+    let left_supers = nominal_super_types_with_self(db, left)?;
+    let right_supers = nominal_super_types_with_self(db, right)?;
+
+    left_supers
+        .into_iter()
+        .find(|candidate| right_supers.contains(candidate))
+}
+
+fn nominal_super_types_with_self(db: &DbIndex, ty: &LuaType) -> Option<Vec<LuaType>> {
+    match ty {
+        LuaType::Ref(type_id) | LuaType::Def(type_id) => {
+            Some(type_id.collect_super_types_with_self(db, LuaType::Ref(type_id.clone())))
+        }
+        LuaType::Generic(generic) => generic_super_types_with_self(db, generic),
+        _ => None,
+    }
+}
+
+fn generic_super_types_with_self(db: &DbIndex, generic: &LuaGenericType) -> Option<Vec<LuaType>> {
+    let base_type_id = generic.get_base_type_id_ref();
+    let mut super_types =
+        base_type_id.collect_super_types_with_self(db, LuaType::Ref(base_type_id.clone()));
+    super_types.insert(0, LuaType::Generic(generic.clone().into()));
+    Some(super_types)
 }
 
 fn nullable_any_type() -> LuaType {

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::tpl_pattern::constant_decay;
-use crate::{GenericTplId, LuaType, LuaTypeDeclId};
+use crate::{DbIndex, GenericTplId, LuaType, LuaTypeDeclId};
 
 #[derive(Debug, Clone)]
 pub struct TypeSubstitutor {
@@ -40,6 +40,16 @@ impl TypeSubstitutor {
         }
     }
 
+    pub fn from_type_array_for_type(
+        db: &DbIndex,
+        type_decl_id: &LuaTypeDeclId,
+        type_array: Vec<LuaType>,
+    ) -> Self {
+        let mut substitutor = Self::from_type_array(type_array.clone());
+        substitutor.insert_decl_type_params(db, type_decl_id, type_array);
+        substitutor
+    }
+
     pub fn from_alias(type_array: Vec<LuaType>, alias_type_id: LuaTypeDeclId) -> Self {
         let mut tpl_replace_map = HashMap::new();
         for (i, ty) in type_array.into_iter().enumerate() {
@@ -52,6 +62,40 @@ impl TypeSubstitutor {
             tpl_replace_map,
             alias_type_id: Some(alias_type_id),
             self_type: None,
+        }
+    }
+
+    pub fn from_alias_for_type(
+        db: &DbIndex,
+        type_array: Vec<LuaType>,
+        alias_type_id: LuaTypeDeclId,
+    ) -> Self {
+        let mut substitutor = Self::from_type_array_for_type(db, &alias_type_id, type_array);
+        substitutor.alias_type_id = Some(alias_type_id);
+        substitutor
+    }
+
+    fn insert_decl_type_params(
+        &mut self,
+        db: &DbIndex,
+        type_decl_id: &LuaTypeDeclId,
+        type_array: Vec<LuaType>,
+    ) {
+        let Some(generic_params) = db.get_type_index().get_generic_params(type_decl_id) else {
+            return;
+        };
+
+        for (i, generic_param) in generic_params.iter().enumerate() {
+            let Some(tpl_id) = generic_param.tpl_id else {
+                continue;
+            };
+            let Some(ty) = type_array.get(i) else {
+                continue;
+            };
+            self.tpl_replace_map.insert(
+                tpl_id,
+                SubstitutorValue::Type(SubstitutorTypeValue::new(ty.clone(), true)),
+            );
         }
     }
 

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
-use super::{instantiate_type::instantiate_type_generic, tpl_pattern::constant_decay};
+use super::{
+    InferencePriority, instantiate_type::instantiate_type_generic, tpl_pattern::constant_decay,
+};
 use crate::{
     DbIndex, GenericTplId, LuaGenericType, LuaType, LuaTypeDeclId, LuaUnionType,
     semantic::type_check::check_type_compact,
@@ -144,12 +146,31 @@ impl TypeSubstitutor {
     }
 
     pub fn insert_type(&mut self, tpl_id: GenericTplId, replace_type: LuaType, decay: bool) {
-        self.insert_type_value(tpl_id, SubstitutorTypeValue::new(replace_type, decay));
+        self.insert_type_with_priority(tpl_id, replace_type, decay, InferencePriority::Direct);
     }
 
-    fn insert_type_value(&mut self, tpl_id: GenericTplId, value: SubstitutorTypeValue) {
+    pub(super) fn insert_type_with_priority(
+        &mut self,
+        tpl_id: GenericTplId,
+        replace_type: LuaType,
+        decay: bool,
+        priority: InferencePriority,
+    ) {
+        self.insert_type_value(
+            tpl_id,
+            SubstitutorTypeValue::new(replace_type, decay),
+            priority,
+        );
+    }
+
+    fn insert_type_value(
+        &mut self,
+        tpl_id: GenericTplId,
+        value: SubstitutorTypeValue,
+        priority: InferencePriority,
+    ) {
         if self.collect_type_candidates {
-            self.insert_type_candidate(tpl_id, value);
+            self.insert_type_candidate(tpl_id, value, priority);
             return;
         }
 
@@ -161,21 +182,30 @@ impl TypeSubstitutor {
             .insert(tpl_id, SubstitutorValue::Type(value));
     }
 
-    fn insert_type_candidate(&mut self, tpl_id: GenericTplId, value: SubstitutorTypeValue) {
+    fn insert_type_candidate(
+        &mut self,
+        tpl_id: GenericTplId,
+        value: SubstitutorTypeValue,
+        priority: InferencePriority,
+    ) {
         let existing_type = match self.tpl_replace_map.get(&tpl_id) {
             Some(SubstitutorValue::Type(existing)) => Some(existing.clone()),
             Some(SubstitutorValue::None) | None => None,
             Some(_) => return,
         };
+        let include_existing_type = self
+            .type_inferences
+            .get(&tpl_id)
+            .is_none_or(|inference| !priority.is_higher_than(inference.priority()));
 
         let inference = self
             .type_inferences
             .entry(tpl_id)
             .or_insert_with(TypeInferenceInfo::new);
-        if let Some(existing) = existing_type {
-            inference.add_candidate(existing);
+        if include_existing_type && let Some(existing) = existing_type {
+            inference.add_candidate(existing, priority);
         }
-        inference.add_candidate(value);
+        inference.add_candidate(value, priority);
 
         if let Some(inferred) = inference.inferred() {
             self.tpl_replace_map
@@ -257,6 +287,7 @@ impl TypeSubstitutor {
 struct TypeInferenceInfo {
     candidates: Vec<SubstitutorTypeValue>,
     inferred: Option<SubstitutorTypeValue>,
+    priority: Option<InferencePriority>,
 }
 
 impl TypeInferenceInfo {
@@ -264,10 +295,26 @@ impl TypeInferenceInfo {
         Self {
             candidates: Vec::new(),
             inferred: None,
+            priority: None,
         }
     }
 
-    fn add_candidate(&mut self, candidate: SubstitutorTypeValue) {
+    fn add_candidate(&mut self, candidate: SubstitutorTypeValue, priority: InferencePriority) {
+        match self.priority {
+            Some(existing) if priority.is_higher_than(existing) => {
+                self.candidates.clear();
+                self.inferred = None;
+                self.priority = Some(priority);
+            }
+            Some(existing) if existing.is_higher_than(priority) => {
+                return;
+            }
+            Some(_) => {}
+            None => {
+                self.priority = Some(priority);
+            }
+        }
+
         if self.candidates.contains(&candidate) {
             return;
         }
@@ -287,8 +334,15 @@ impl TypeInferenceInfo {
         };
 
         let mut inferred = first.clone();
+        let combine_candidates = self
+            .priority
+            .is_some_and(InferencePriority::implies_candidate_combination);
         for candidate in rest {
-            inferred.combine_with_common_supertype(db, candidate.clone());
+            if combine_candidates {
+                inferred.union_with(candidate.clone());
+            } else {
+                inferred.combine_with_common_supertype(db, candidate.clone());
+            }
         }
 
         self.inferred = Some(inferred);
@@ -296,6 +350,10 @@ impl TypeInferenceInfo {
 
     fn inferred(&self) -> Option<&SubstitutorTypeValue> {
         self.inferred.as_ref()
+    }
+
+    fn priority(&self) -> InferencePriority {
+        self.priority.unwrap_or(InferencePriority::Direct)
     }
 }
 

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use super::tpl_pattern::constant_decay;
+use super::{instantiate_type::instantiate_type_generic, tpl_pattern::constant_decay};
 use crate::{
     DbIndex, GenericTplId, LuaGenericType, LuaType, LuaTypeDeclId, LuaUnionType,
     semantic::type_check::check_type_compact,
@@ -461,27 +461,138 @@ fn common_nominal_supertype(db: &DbIndex, left: &LuaType, right: &LuaType) -> Op
     let left_supers = nominal_super_types_with_self(db, left)?;
     let right_supers = nominal_super_types_with_self(db, right)?;
 
-    left_supers
-        .into_iter()
-        .find(|candidate| right_supers.contains(candidate))
+    for left_candidate in &left_supers {
+        for right_candidate in &right_supers {
+            if let Some(common) = common_generic_candidate_type(db, left_candidate, right_candidate)
+            {
+                return Some(common);
+            }
+
+            if left_candidate == right_candidate {
+                return Some(left_candidate.clone());
+            }
+        }
+    }
+
+    None
 }
 
 fn nominal_super_types_with_self(db: &DbIndex, ty: &LuaType) -> Option<Vec<LuaType>> {
+    let mut super_types = Vec::new();
+    let mut visited = HashSet::new();
+
     match ty {
         LuaType::Ref(type_id) | LuaType::Def(type_id) => {
-            Some(type_id.collect_super_types_with_self(db, LuaType::Ref(type_id.clone())))
+            push_nominal_super_type(&mut super_types, LuaType::Ref(type_id.clone()));
+            collect_decl_super_types(db, type_id, None, &mut super_types, &mut visited);
+            Some(super_types)
         }
-        LuaType::Generic(generic) => generic_super_types_with_self(db, generic),
+        LuaType::Generic(generic) => {
+            push_nominal_super_type(&mut super_types, LuaType::Generic(generic.clone().into()));
+
+            let base_type_id = generic.get_base_type_id_ref();
+            let substitutor = TypeSubstitutor::from_type_array_for_type(
+                db,
+                base_type_id,
+                generic.get_params().clone(),
+            );
+            collect_decl_super_types(
+                db,
+                base_type_id,
+                Some(&substitutor),
+                &mut super_types,
+                &mut visited,
+            );
+            Some(super_types)
+        }
         _ => None,
     }
 }
 
-fn generic_super_types_with_self(db: &DbIndex, generic: &LuaGenericType) -> Option<Vec<LuaType>> {
-    let base_type_id = generic.get_base_type_id_ref();
-    let mut super_types =
-        base_type_id.collect_super_types_with_self(db, LuaType::Ref(base_type_id.clone()));
-    super_types.insert(0, LuaType::Generic(generic.clone().into()));
-    Some(super_types)
+fn collect_decl_super_types(
+    db: &DbIndex,
+    type_id: &LuaTypeDeclId,
+    substitutor: Option<&TypeSubstitutor>,
+    super_types: &mut Vec<LuaType>,
+    visited: &mut HashSet<LuaTypeDeclId>,
+) {
+    if !visited.insert(type_id.clone()) {
+        return;
+    }
+
+    let Some(decl_super_types) = db.get_type_index().get_super_types(type_id) else {
+        return;
+    };
+
+    for super_type in decl_super_types {
+        let instantiated_super = match substitutor {
+            Some(substitutor) => instantiate_type_generic(db, &super_type, substitutor),
+            None => super_type,
+        };
+
+        push_nominal_super_type(super_types, instantiated_super.clone());
+
+        match instantiated_super {
+            LuaType::Ref(super_type_id) | LuaType::Def(super_type_id) => {
+                collect_decl_super_types(db, &super_type_id, None, super_types, visited);
+            }
+            LuaType::Generic(generic) => {
+                let base_type_id = generic.get_base_type_id_ref();
+                let substitutor = TypeSubstitutor::from_type_array_for_type(
+                    db,
+                    base_type_id,
+                    generic.get_params().clone(),
+                );
+                collect_decl_super_types(
+                    db,
+                    base_type_id,
+                    Some(&substitutor),
+                    super_types,
+                    visited,
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+fn push_nominal_super_type(super_types: &mut Vec<LuaType>, ty: LuaType) {
+    if !super_types.contains(&ty) {
+        super_types.push(ty.clone());
+    }
+
+    if let LuaType::Generic(generic) = ty {
+        let base = LuaType::Ref(generic.get_base_type_id());
+        if !super_types.contains(&base) {
+            super_types.push(base);
+        }
+    }
+}
+
+fn common_generic_candidate_type(db: &DbIndex, left: &LuaType, right: &LuaType) -> Option<LuaType> {
+    let (LuaType::Generic(left_generic), LuaType::Generic(right_generic)) = (left, right) else {
+        return None;
+    };
+
+    if left_generic.get_base_type_id_ref() != right_generic.get_base_type_id_ref() {
+        return None;
+    }
+
+    let left_params = left_generic.get_params();
+    let right_params = right_generic.get_params();
+    if left_params.len() != right_params.len() {
+        return None;
+    }
+
+    let params = left_params
+        .iter()
+        .zip(right_params.iter())
+        .map(|(left_param, right_param)| {
+            common_candidate_type(db, left_param.clone(), right_param.clone())
+        })
+        .collect();
+
+    Some(LuaGenericType::new(left_generic.get_base_type_id(), params).into())
 }
 
 fn nullable_any_type() -> LuaType {

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -6,9 +6,10 @@ use crate::{DbIndex, GenericTplId, LuaType, LuaTypeDeclId, LuaUnionType};
 #[derive(Debug, Clone)]
 pub struct TypeSubstitutor {
     tpl_replace_map: HashMap<GenericTplId, SubstitutorValue>,
+    type_inferences: HashMap<GenericTplId, TypeInferenceInfo>,
     alias_type_id: Option<LuaTypeDeclId>,
     self_type: Option<LuaType>,
-    union_type_candidates: bool,
+    collect_type_candidates: bool,
 }
 
 impl Default for TypeSubstitutor {
@@ -21,9 +22,10 @@ impl TypeSubstitutor {
     pub fn new() -> Self {
         Self {
             tpl_replace_map: HashMap::new(),
+            type_inferences: HashMap::new(),
             alias_type_id: None,
             self_type: None,
-            union_type_candidates: false,
+            collect_type_candidates: false,
         }
     }
 
@@ -37,9 +39,10 @@ impl TypeSubstitutor {
         }
         Self {
             tpl_replace_map,
+            type_inferences: HashMap::new(),
             alias_type_id: None,
             self_type: None,
-            union_type_candidates: false,
+            collect_type_candidates: false,
         }
     }
 
@@ -63,9 +66,10 @@ impl TypeSubstitutor {
         }
         Self {
             tpl_replace_map,
+            type_inferences: HashMap::new(),
             alias_type_id: Some(alias_type_id),
             self_type: None,
-            union_type_candidates: false,
+            collect_type_candidates: false,
         }
     }
 
@@ -111,9 +115,9 @@ impl TypeSubstitutor {
         }
     }
 
-    pub fn set_union_type_candidates_enabled(&mut self, enabled: bool) -> bool {
-        let previous = self.union_type_candidates;
-        self.union_type_candidates = enabled;
+    pub fn set_type_candidate_collection_enabled(&mut self, enabled: bool) -> bool {
+        let previous = self.collect_type_candidates;
+        self.collect_type_candidates = enabled;
         previous
     }
 
@@ -131,10 +135,8 @@ impl TypeSubstitutor {
     }
 
     fn insert_type_value(&mut self, tpl_id: GenericTplId, value: SubstitutorTypeValue) {
-        if self.union_type_candidates
-            && let Some(SubstitutorValue::Type(existing)) = self.tpl_replace_map.get_mut(&tpl_id)
-        {
-            existing.union_with(value);
+        if self.collect_type_candidates {
+            self.insert_type_candidate(tpl_id, value);
             return;
         }
 
@@ -144,6 +146,28 @@ impl TypeSubstitutor {
 
         self.tpl_replace_map
             .insert(tpl_id, SubstitutorValue::Type(value));
+    }
+
+    fn insert_type_candidate(&mut self, tpl_id: GenericTplId, value: SubstitutorTypeValue) {
+        let existing_type = match self.tpl_replace_map.get(&tpl_id) {
+            Some(SubstitutorValue::Type(existing)) => Some(existing.clone()),
+            Some(SubstitutorValue::None) | None => None,
+            Some(_) => return,
+        };
+
+        let inference = self
+            .type_inferences
+            .entry(tpl_id)
+            .or_insert_with(TypeInferenceInfo::new);
+        if let Some(existing) = existing_type {
+            inference.add_candidate(existing);
+        }
+        inference.add_candidate(value);
+
+        if let Some(inferred) = inference.inferred() {
+            self.tpl_replace_map
+                .insert(tpl_id, SubstitutorValue::Type(inferred.clone()));
+        }
     }
 
     fn can_insert_type(&self, tpl_id: GenericTplId) -> bool {
@@ -217,6 +241,38 @@ impl TypeSubstitutor {
 }
 
 #[derive(Debug, Clone)]
+struct TypeInferenceInfo {
+    candidates: Vec<SubstitutorTypeValue>,
+    inferred: Option<SubstitutorTypeValue>,
+}
+
+impl TypeInferenceInfo {
+    fn new() -> Self {
+        Self {
+            candidates: Vec::new(),
+            inferred: None,
+        }
+    }
+
+    fn add_candidate(&mut self, candidate: SubstitutorTypeValue) {
+        if self.candidates.contains(&candidate) {
+            return;
+        }
+
+        if let Some(inferred) = &mut self.inferred {
+            inferred.union_with(candidate.clone());
+        } else {
+            self.inferred = Some(candidate.clone());
+        }
+        self.candidates.push(candidate);
+    }
+
+    fn inferred(&self) -> Option<&SubstitutorTypeValue> {
+        self.inferred.as_ref()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubstitutorTypeValue {
     raw: LuaType,
     default: LuaType,

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -393,7 +393,7 @@ impl TypeInferenceInfo {
         let mut inferred = first.clone();
         let combine_candidates = self
             .priority
-            .is_some_and(InferencePriority::implies_candidate_combination);
+            .is_some_and(InferencePriority::implies_covariant_candidate_combination);
         for candidate in rest {
             if combine_candidates {
                 inferred.union_with(candidate.clone());

--- a/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/type_substitutor.rs
@@ -1,13 +1,14 @@
 use std::collections::{HashMap, HashSet};
 
 use super::tpl_pattern::constant_decay;
-use crate::{DbIndex, GenericTplId, LuaType, LuaTypeDeclId};
+use crate::{DbIndex, GenericTplId, LuaType, LuaTypeDeclId, LuaUnionType};
 
 #[derive(Debug, Clone)]
 pub struct TypeSubstitutor {
     tpl_replace_map: HashMap<GenericTplId, SubstitutorValue>,
     alias_type_id: Option<LuaTypeDeclId>,
     self_type: Option<LuaType>,
+    union_type_candidates: bool,
 }
 
 impl Default for TypeSubstitutor {
@@ -22,6 +23,7 @@ impl TypeSubstitutor {
             tpl_replace_map: HashMap::new(),
             alias_type_id: None,
             self_type: None,
+            union_type_candidates: false,
         }
     }
 
@@ -37,6 +39,7 @@ impl TypeSubstitutor {
             tpl_replace_map,
             alias_type_id: None,
             self_type: None,
+            union_type_candidates: false,
         }
     }
 
@@ -62,6 +65,7 @@ impl TypeSubstitutor {
             tpl_replace_map,
             alias_type_id: Some(alias_type_id),
             self_type: None,
+            union_type_candidates: false,
         }
     }
 
@@ -107,6 +111,12 @@ impl TypeSubstitutor {
         }
     }
 
+    pub fn set_union_type_candidates_enabled(&mut self, enabled: bool) -> bool {
+        let previous = self.union_type_candidates;
+        self.union_type_candidates = enabled;
+        previous
+    }
+
     pub fn is_infer_all_tpl(&self) -> bool {
         for value in self.tpl_replace_map.values() {
             if let SubstitutorValue::None = value {
@@ -121,6 +131,13 @@ impl TypeSubstitutor {
     }
 
     fn insert_type_value(&mut self, tpl_id: GenericTplId, value: SubstitutorTypeValue) {
+        if self.union_type_candidates
+            && let Some(SubstitutorValue::Type(existing)) = self.tpl_replace_map.get_mut(&tpl_id)
+        {
+            existing.union_with(value);
+            return;
+        }
+
         if !self.can_insert_type(tpl_id) {
             return;
         }
@@ -223,6 +240,11 @@ impl SubstitutorTypeValue {
     pub fn default(&self) -> &LuaType {
         &self.default
     }
+
+    fn union_with(&mut self, other: SubstitutorTypeValue) {
+        self.raw = union_candidate_type(self.raw.clone(), other.raw);
+        self.default = union_candidate_type(self.default.clone(), other.default);
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -245,4 +267,77 @@ fn into_ref_type(ty: LuaType) -> LuaType {
         LuaType::Def(type_decl_id) => LuaType::Ref(type_decl_id),
         _ => ty,
     }
+}
+
+fn union_candidate_type(left: LuaType, right: LuaType) -> LuaType {
+    if left == right {
+        return left;
+    }
+
+    match (&left, &right) {
+        (LuaType::Any, right) if right.is_nullable() => nullable_any_type(),
+        (left, LuaType::Any) if left.is_nullable() => nullable_any_type(),
+        (LuaType::Any, _) | (_, LuaType::Any) => LuaType::Any,
+        (LuaType::Never, _) => right,
+        (_, LuaType::Never) => left,
+        (LuaType::Unknown, _) => right,
+        (_, LuaType::Unknown) => left,
+        (LuaType::Integer, LuaType::IntegerConst(_) | LuaType::DocIntegerConst(_))
+        | (LuaType::IntegerConst(_) | LuaType::DocIntegerConst(_), LuaType::Integer) => {
+            LuaType::Integer
+        }
+        (LuaType::Number, right) if right.is_number() => LuaType::Number,
+        (left, LuaType::Number) if left.is_number() => LuaType::Number,
+        (LuaType::String, LuaType::StringConst(_) | LuaType::DocStringConst(_))
+        | (LuaType::StringConst(_) | LuaType::DocStringConst(_), LuaType::String) => {
+            LuaType::String
+        }
+        (LuaType::Boolean, LuaType::BooleanConst(_) | LuaType::DocBooleanConst(_))
+        | (LuaType::BooleanConst(_) | LuaType::DocBooleanConst(_), LuaType::Boolean) => {
+            LuaType::Boolean
+        }
+        (LuaType::BooleanConst(left), LuaType::BooleanConst(right)) => {
+            if left == right {
+                LuaType::BooleanConst(*left)
+            } else {
+                LuaType::Boolean
+            }
+        }
+        (LuaType::DocBooleanConst(left), LuaType::DocBooleanConst(right)) => {
+            if left == right {
+                LuaType::DocBooleanConst(*left)
+            } else {
+                LuaType::Boolean
+            }
+        }
+        (LuaType::Table, LuaType::TableConst(_)) | (LuaType::TableConst(_), LuaType::Table) => {
+            LuaType::Table
+        }
+        (LuaType::Function, LuaType::DocFunction(_) | LuaType::Signature(_))
+        | (LuaType::DocFunction(_) | LuaType::Signature(_), LuaType::Function) => LuaType::Function,
+        (LuaType::Union(left_union), right) if !right.is_union() => {
+            let mut types = left_union.into_vec();
+            if !types.contains(right) {
+                types.push(right.clone());
+            }
+            LuaType::from_vec(types)
+        }
+        (left, LuaType::Union(right_union)) if !left.is_union() => {
+            let mut types = right_union.into_vec();
+            if !types.contains(left) {
+                types.push(left.clone());
+            }
+            LuaType::from_vec(types)
+        }
+        (LuaType::Union(left_union), LuaType::Union(right_union)) => {
+            let mut types = left_union.into_vec();
+            types.extend(right_union.into_vec());
+            LuaType::from_vec(types)
+        }
+        _ => LuaType::from_vec(vec![left, right]),
+    }
+}
+
+fn nullable_any_type() -> LuaType {
+    LuaType::Union(LuaUnionType::Nullable(LuaType::Any).into())
 }

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -5,7 +5,7 @@ use rowan::TextRange;
 
 use super::{
     super::{InferGuard, LuaInferCache, instantiate_type_generic, resolve_signature},
-    InferFailReason, InferResult,
+    InferFailReason, InferResult, infer_bind_value_type,
 };
 use crate::compilation::analyzer::unresolve::get_wrapped_callable_target_expr;
 use crate::{
@@ -839,10 +839,11 @@ fn infer_contextual_return_type(
 
 fn get_contextual_return_hint(
     db: &DbIndex,
-    cache: &LuaInferCache,
+    cache: &mut LuaInferCache,
     call_expr: &LuaCallExpr,
 ) -> Option<LuaType> {
     get_local_contextual_return_hint(db, cache, call_expr)
+        .or_else(|| infer_bind_value_type(db, cache, LuaExpr::CallExpr(call_expr.clone())))
 }
 
 fn get_local_contextual_return_hint(

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use glua_parser::{LuaAstNode, LuaCallExpr, LuaExpr, LuaSyntaxKind};
+use glua_parser::{LuaAstNode, LuaCallExpr, LuaExpr, LuaLocalStat, LuaSyntaxKind};
 use rowan::TextRange;
 
 use super::{
@@ -9,14 +9,18 @@ use super::{
 };
 use crate::compilation::analyzer::unresolve::get_wrapped_callable_target_expr;
 use crate::{
-    CacheEntry, DbIndex, InFiled, LuaArrayType, LuaFunctionType, LuaGenericType, LuaInstanceType,
-    LuaIntersectionType, LuaOperatorMetaMethod, LuaOperatorOwner, LuaSignature, LuaSignatureId,
-    LuaTupleType, LuaType, LuaTypeDeclId, LuaUnionType, ReturnTypeKind, VariadicType,
+    CacheEntry, DbIndex, InFiled, LuaArrayType, LuaDeclId, LuaFunctionType, LuaGenericType,
+    LuaInstanceType, LuaIntersectionType, LuaOperatorMetaMethod, LuaOperatorOwner, LuaSignature,
+    LuaSignatureId, LuaTupleType, LuaType, LuaTypeCache, LuaTypeDeclId, LuaUnionType,
+    ReturnTypeKind, VariadicType,
 };
 use crate::{
     InferGuardRef,
     semantic::{
-        generic::{TypeSubstitutor, get_tpl_ref_extend_type, instantiate_doc_function},
+        generic::{
+            TplContext, TypeSubstitutor, get_tpl_ref_extend_type, instantiate_doc_function,
+            tpl_pattern_match,
+        },
         infer::narrow::get_type_at_call_expr_inline_cast,
         infer_expr_semantic_decl,
     },
@@ -776,7 +780,7 @@ pub fn infer_call_expr(
 
     let prefix_expr = call_expr.get_prefix_expr().ok_or(InferFailReason::None)?;
     let prefix_type = infer_expr(db, cache, prefix_expr)?;
-    let ret_type = infer_call_expr_func(
+    let call_func = infer_call_expr_func(
         db,
         cache,
         call_expr.clone(),
@@ -784,8 +788,14 @@ pub fn infer_call_expr(
         &InferGuard::new(),
         None,
     )?
-    .get_ret()
     .clone();
+    let mut ret_type = call_func.get_ret().clone();
+    if ret_type.contain_tpl()
+        && let Some(context_ret_type) =
+            infer_contextual_return_type(db, cache, &call_expr, call_func.as_ref())
+    {
+        ret_type = context_ret_type;
+    }
 
     if let Some(tree) = db.get_flow_index().get_flow_tree(&cache.get_file_id())
         && let Some(flow_id) = tree.get_flow_id(call_expr.get_syntax_id())
@@ -796,6 +806,60 @@ pub fn infer_call_expr(
     }
 
     Ok(ret_type)
+}
+
+fn infer_contextual_return_type(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    call_expr: &LuaCallExpr,
+    call_func: &LuaFunctionType,
+) -> Option<LuaType> {
+    let return_hint = get_contextual_return_hint(db, cache, call_expr)?;
+    let ret_type = call_func.get_ret();
+    if !ret_type.contain_tpl() {
+        return None;
+    }
+
+    let mut substitutor = TypeSubstitutor::new();
+    let mut context = TplContext {
+        db,
+        cache,
+        substitutor: &mut substitutor,
+        call_expr: Some(call_expr.clone()),
+    };
+    tpl_pattern_match(&mut context, ret_type, &return_hint).ok()?;
+
+    let instantiated = instantiate_type_generic(db, ret_type, &substitutor);
+    if &instantiated == ret_type {
+        None
+    } else {
+        Some(instantiated)
+    }
+}
+
+fn get_contextual_return_hint(
+    db: &DbIndex,
+    cache: &LuaInferCache,
+    call_expr: &LuaCallExpr,
+) -> Option<LuaType> {
+    get_local_contextual_return_hint(db, cache, call_expr)
+}
+
+fn get_local_contextual_return_hint(
+    db: &DbIndex,
+    cache: &LuaInferCache,
+    call_expr: &LuaCallExpr,
+) -> Option<LuaType> {
+    let local_stat = call_expr.get_parent::<LuaLocalStat>()?;
+    let value_index = local_stat
+        .get_value_exprs()
+        .position(|expr| expr.syntax() == call_expr.syntax())?;
+    let local_name = local_stat.get_local_name_list().nth(value_index)?;
+    let decl_id = LuaDeclId::new(cache.get_file_id(), local_name.get_position());
+    match db.get_type_index().get_type_cache(&decl_id.into())? {
+        LuaTypeCache::DocType(typ) => Some(typ.clone()),
+        _ => None,
+    }
 }
 
 fn check_can_infer(

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -4,7 +4,10 @@ use glua_parser::{LuaAstNode, LuaCallExpr, LuaExpr, LuaLocalStat, LuaSyntaxKind}
 use rowan::TextRange;
 
 use super::{
-    super::{InferGuard, LuaInferCache, instantiate_type_generic, resolve_signature},
+    super::{
+        InferGuard, LuaInferCache, instantiate_type_generic, resolve_signature,
+        resolve_signature_with_context,
+    },
     InferFailReason, InferResult, infer_bind_value_type,
 };
 use crate::compilation::analyzer::unresolve::get_wrapped_callable_target_expr;
@@ -313,7 +316,17 @@ fn infer_generic_doc_function_union(
         })
         .collect::<Vec<_>>();
 
-    resolve_signature(db, cache, overloads, call_expr.clone(), false, args_count)
+    let is_generic = overloads.iter().any(|func| func.contain_tpl());
+    let contextual_return_hint = get_contextual_return_hint(db, cache, &call_expr);
+    resolve_signature_with_context(
+        db,
+        cache,
+        overloads,
+        call_expr.clone(),
+        is_generic,
+        args_count,
+        contextual_return_hint,
+    )
 }
 
 fn infer_signature_doc_function(
@@ -369,13 +382,15 @@ fn infer_signature_doc_function(
             &fake_doc_function,
         ));
 
-        resolve_signature(
+        let contextual_return_hint = get_contextual_return_hint(db, cache, &call_expr);
+        resolve_signature_with_context(
             db,
             cache,
             new_overloads,
             call_expr.clone(),
             is_generic,
             args_count,
+            contextual_return_hint,
         )
     }
 }
@@ -415,6 +430,7 @@ fn infer_type_doc_function(
         .get_operators(&type_id.clone().into(), LuaOperatorMetaMethod::Call)
         .ok_or(InferFailReason::UnResolveOperatorCall)?;
     let mut overloads = Vec::new();
+    let contextual_return_hint = get_contextual_return_hint(db, cache, &call_expr);
     for overload_id in operator_ids {
         let operator = operator_index
             .get_operator(overload_id)
@@ -431,7 +447,13 @@ fn infer_type_doc_function(
                         overloads.push(f);
                     }
                 } else if f.contain_tpl() {
-                    let result = instantiate_func_generic(db, cache, &f, call_expr.clone())?;
+                    let result = instantiate_func_generic_with_context(
+                        db,
+                        cache,
+                        &f,
+                        call_expr.clone(),
+                        contextual_return_hint.clone(),
+                    )?;
                     overloads.push(Arc::new(result));
                 } else {
                     overloads.push(f.clone());
@@ -497,6 +519,7 @@ fn infer_generic_type_doc_function(
         .get_operators(&type_id.into(), LuaOperatorMetaMethod::Call)
         .ok_or(InferFailReason::None)?;
     let mut overloads = Vec::new();
+    let contextual_return_hint = get_contextual_return_hint(db, cache, &call_expr);
     for overload_id in operator_ids {
         let operator = operator_index
             .get_operator(overload_id)
@@ -506,7 +529,18 @@ fn infer_generic_type_doc_function(
             LuaType::DocFunction(_) => {
                 let new_f = instantiate_type_generic(db, &func, &substitutor);
                 if let LuaType::DocFunction(f) = new_f {
-                    overloads.push(f.clone());
+                    if f.contain_tpl() {
+                        let result = instantiate_func_generic_with_context(
+                            db,
+                            cache,
+                            &f,
+                            call_expr.clone(),
+                            contextual_return_hint.clone(),
+                        )?;
+                        overloads.push(Arc::new(result));
+                    } else {
+                        overloads.push(f.clone());
+                    }
                 }
             }
             LuaType::Signature(signature_id) => {
@@ -603,6 +637,7 @@ fn infer_union(
     // 此时一般是 signature + doc_function 的联合体
     let mut all_overloads = Vec::new();
     let mut base_signatures = Vec::new();
+    let contextual_return_hint = get_contextual_return_hint(db, cache, &call_expr);
 
     for ty in union.into_vec() {
         match ty {
@@ -614,11 +649,12 @@ fn infer_union(
                             .overloads
                             .iter()
                             .map(|func| {
-                                Ok(Arc::new(instantiate_func_generic(
+                                Ok(Arc::new(instantiate_func_generic_with_context(
                                     db,
                                     cache,
                                     func,
                                     call_expr.clone(),
+                                    contextual_return_hint.clone(),
                                 )?))
                             })
                             .collect::<Result<Vec<_>, _>>()?
@@ -636,11 +672,12 @@ fn infer_union(
                         signature.get_return_type(),
                     );
                     if signature.is_generic() {
-                        fake_doc_function = instantiate_func_generic(
+                        fake_doc_function = instantiate_func_generic_with_context(
                             db,
                             cache,
                             &fake_doc_function,
                             call_expr.clone(),
+                            contextual_return_hint.clone(),
                         )?;
                     }
                     base_signatures.push(apply_signature_return_kinds_to_function(
@@ -651,11 +688,12 @@ fn infer_union(
             }
             LuaType::DocFunction(func) => {
                 let func_to_push = if func.contain_tpl() {
-                    Arc::new(instantiate_func_generic(
+                    Arc::new(instantiate_func_generic_with_context(
                         db,
                         cache,
                         &func,
                         call_expr.clone(),
+                        contextual_return_hint.clone(),
                     )?)
                 } else {
                     func.clone()

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -91,8 +91,16 @@ pub fn infer_call_expr_func(
             infer_guard,
             args_count,
         ),
-        LuaType::Instance(inst) => infer_instance_type_doc_function(db, inst),
-        LuaType::TableConst(meta_table) => infer_table_type_doc_function(db, meta_table.clone()),
+        LuaType::Instance(inst) => {
+            infer_instance_type_doc_function(db, cache, inst, call_expr.clone(), args_count)
+        }
+        LuaType::TableConst(meta_table) => infer_table_type_doc_function(
+            db,
+            cache,
+            meta_table.clone(),
+            call_expr.clone(),
+            args_count,
+        ),
         LuaType::TplRef(_) | LuaType::ConstTplRef(_) | LuaType::StrTplRef(_) => infer_tpl_ref_call(
             db,
             cache,
@@ -568,21 +576,30 @@ fn infer_generic_type_doc_function(
 
 fn infer_instance_type_doc_function(
     db: &DbIndex,
+    cache: &mut LuaInferCache,
     instance: &LuaInstanceType,
+    call_expr: LuaCallExpr,
+    args_count: Option<usize>,
 ) -> InferCallFuncResult {
     let base = instance.get_base();
     let base_table = match &base {
         LuaType::TableConst(meta_table) => meta_table.clone(),
         LuaType::Instance(inst) => {
-            return infer_instance_type_doc_function(db, inst);
+            return infer_instance_type_doc_function(db, cache, inst, call_expr, args_count);
         }
         _ => return Err(InferFailReason::None),
     };
 
-    infer_table_type_doc_function(db, base_table)
+    infer_table_type_doc_function(db, cache, base_table, call_expr, args_count)
 }
 
-fn infer_table_type_doc_function(db: &DbIndex, table: InFiled<TextRange>) -> InferCallFuncResult {
+fn infer_table_type_doc_function(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    table: InFiled<TextRange>,
+    call_expr: LuaCallExpr,
+    args_count: Option<usize>,
+) -> InferCallFuncResult {
     let meta_table = db
         .get_metatable_index()
         .get(&table)
@@ -604,21 +621,10 @@ fn infer_table_type_doc_function(db: &DbIndex, table: InFiled<TextRange>) -> Inf
         let func = operator.get_operator_func(db);
         match func {
             LuaType::DocFunction(func) => {
-                return Ok(func);
+                return infer_doc_function(db, cache, &func, call_expr, args_count);
             }
             LuaType::Signature(signature_id) => {
-                let signature = db
-                    .get_signature_index()
-                    .get(&signature_id)
-                    .ok_or(InferFailReason::None)?;
-                if !signature.is_resolve_return() {
-                    return Err(InferFailReason::UnResolveSignatureReturn(signature_id));
-                }
-
-                return Ok(apply_signature_return_kinds_to_function(
-                    signature,
-                    signature.to_call_operator_func_type().as_ref(),
-                ));
+                return infer_signature_doc_function(db, cache, signature_id, call_expr, args_count);
             }
             _ => {}
         }

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -21,8 +21,8 @@ use crate::{
     InferGuardRef,
     semantic::{
         generic::{
-            InferenceContext, TplContext, TypeSubstitutor, get_tpl_ref_extend_type,
-            instantiate_doc_function, tpl_pattern_match,
+            InferenceContext, InferencePriority, TplContext, TypeSubstitutor,
+            get_tpl_ref_extend_type, instantiate_doc_function, tpl_pattern_match,
         },
         infer::narrow::get_type_at_call_expr_inline_cast,
         infer_expr_semantic_decl,
@@ -892,7 +892,11 @@ fn infer_contextual_return_type(
             substitutor: &mut inference,
             call_expr: Some(call_expr.clone()),
         };
-        tpl_pattern_match(&mut context, ret_type, &return_hint).ok()?;
+        context
+            .with_inference_priority(InferencePriority::ContextualReturn, true, |context| {
+                tpl_pattern_match(context, ret_type, &return_hint)
+            })
+            .ok()?;
     }
 
     let instantiated = instantiate_type_generic(db, ret_type, inference.substitutor());

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -624,13 +624,28 @@ fn infer_table_type_doc_function(
                 return infer_doc_function(db, cache, &func, call_expr, args_count);
             }
             LuaType::Signature(signature_id) => {
-                return infer_signature_doc_function(
-                    db,
-                    cache,
-                    signature_id,
-                    call_expr,
-                    args_count,
-                );
+                let signature = db
+                    .get_signature_index()
+                    .get(&signature_id)
+                    .ok_or(InferFailReason::None)?;
+                if !signature.is_resolve_return() {
+                    return Err(InferFailReason::UnResolveSignatureReturn(signature_id));
+                }
+
+                let signature_params = signature.get_type_params();
+                let has_call_self_param = args_count
+                    .is_some_and(|args_count| signature_params.len() == args_count + 1)
+                    || signature_params
+                        .first()
+                        .is_some_and(|(name, _)| name == "_" || name == "self");
+                let operator_func = if has_call_self_param {
+                    signature.to_call_operator_func_type()
+                } else {
+                    signature.to_doc_func_type()
+                };
+                let call_operator_func =
+                    apply_signature_return_kinds_to_function(signature, operator_func.as_ref());
+                return infer_doc_function(db, cache, &call_operator_func, call_expr, args_count);
             }
             _ => {}
         }

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -21,8 +21,8 @@ use crate::{
     InferGuardRef,
     semantic::{
         generic::{
-            TplContext, TypeSubstitutor, get_tpl_ref_extend_type, instantiate_doc_function,
-            tpl_pattern_match,
+            InferenceContext, TplContext, TypeSubstitutor, get_tpl_ref_extend_type,
+            instantiate_doc_function, tpl_pattern_match,
         },
         infer::narrow::get_type_at_call_expr_inline_cast,
         infer_expr_semantic_decl,
@@ -624,7 +624,13 @@ fn infer_table_type_doc_function(
                 return infer_doc_function(db, cache, &func, call_expr, args_count);
             }
             LuaType::Signature(signature_id) => {
-                return infer_signature_doc_function(db, cache, signature_id, call_expr, args_count);
+                return infer_signature_doc_function(
+                    db,
+                    cache,
+                    signature_id,
+                    call_expr,
+                    args_count,
+                );
             }
             _ => {}
         }
@@ -878,16 +884,18 @@ fn infer_contextual_return_type(
         return None;
     }
 
-    let mut substitutor = TypeSubstitutor::new();
-    let mut context = TplContext {
-        db,
-        cache,
-        substitutor: &mut substitutor,
-        call_expr: Some(call_expr.clone()),
-    };
-    tpl_pattern_match(&mut context, ret_type, &return_hint).ok()?;
+    let mut inference = InferenceContext::new();
+    {
+        let mut context = TplContext {
+            db,
+            cache,
+            substitutor: &mut inference,
+            call_expr: Some(call_expr.clone()),
+        };
+        tpl_pattern_match(&mut context, ret_type, &return_hint).ok()?;
+    }
 
-    let instantiated = instantiate_type_generic(db, ret_type, &substitutor);
+    let instantiated = instantiate_type_generic(db, ret_type, inference.substitutor());
     if &instantiated == ret_type {
         None
     } else {

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 use crate::{
     SemanticDeclGuard, SemanticDeclLevel, build_self_type, infer_self_type,
-    instantiate_func_generic, semantic::infer_expr,
+    instantiate_func_generic, instantiate_func_generic_with_context, semantic::infer_expr,
 };
 use infer_require::infer_require_call;
 use infer_setmetatable::infer_setmetatable_call;
@@ -264,7 +264,14 @@ fn infer_doc_function(
     _: Option<usize>,
 ) -> InferCallFuncResult {
     if func.contain_tpl() {
-        let result = instantiate_func_generic(db, cache, func, call_expr.clone())?;
+        let contextual_return_hint = get_contextual_return_hint(db, cache, &call_expr);
+        let result = instantiate_func_generic_with_context(
+            db,
+            cache,
+            func,
+            call_expr.clone(),
+            contextual_return_hint,
+        )?;
         return Ok(Arc::new(result));
     }
 
@@ -334,7 +341,14 @@ fn infer_signature_doc_function(
             signature.get_return_type(),
         );
         if is_generic {
-            fake_doc_function = instantiate_func_generic(db, cache, &fake_doc_function, call_expr)?;
+            let contextual_return_hint = get_contextual_return_hint(db, cache, &call_expr);
+            fake_doc_function = instantiate_func_generic_with_context(
+                db,
+                cache,
+                &fake_doc_function,
+                call_expr,
+                contextual_return_hint,
+            )?;
         }
 
         Ok(apply_signature_return_kinds_to_function(

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -904,7 +904,7 @@ fn infer_contextual_return_type(
         let mut context = TplContext {
             db,
             cache,
-            substitutor: &mut inference,
+            inference: &mut inference,
             call_expr: Some(call_expr.clone()),
         };
         context

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -451,7 +451,8 @@ fn infer_generic_type_doc_function(
     let type_id = generic.get_base_type_id();
     infer_guard.check(&type_id)?;
     let generic_params = generic.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor =
+        TypeSubstitutor::from_type_array_for_type(db, &type_id, generic_params.clone());
 
     let type_decl = db
         .get_type_index()

--- a/crates/glua_code_analysis/src/semantic/infer/infer_index/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_index/mod.rs
@@ -27,8 +27,8 @@ use crate::{
             narrow::infer_expr_narrow_type,
         },
         member::get_buildin_type_map_type_id,
-        member::member_key_matches_type,
         member::intersect_member_types,
+        member::member_key_matches_type,
         type_check::{self, check_type_compact},
     },
 };
@@ -764,7 +764,12 @@ fn infer_generic_member(
     let base_type = generic_type.get_base_type();
 
     let generic_params = generic_type.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor = match &base_type {
+        LuaType::Ref(base_type_decl_id) => {
+            TypeSubstitutor::from_type_array_for_type(db, base_type_decl_id, generic_params.clone())
+        }
+        _ => TypeSubstitutor::from_type_array(generic_params.clone()),
+    };
 
     if let LuaType::Ref(base_type_decl_id) = &base_type {
         let type_index = db.get_type_index();
@@ -1135,7 +1140,8 @@ fn infer_member_by_index_generic(
         return Err(InferFailReason::None);
     };
     let generic_params = generic.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor =
+        TypeSubstitutor::from_type_array_for_type(db, &type_decl_id, generic_params.clone());
     let type_index = db.get_type_index();
     let type_decl = type_index
         .get_type_decl(&type_decl_id)

--- a/crates/glua_code_analysis/src/semantic/member/find_index.rs
+++ b/crates/glua_code_analysis/src/semantic/member/find_index.rs
@@ -308,7 +308,8 @@ fn find_index_generic(
     };
 
     let generic_params = generic.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor =
+        TypeSubstitutor::from_type_array_for_type(db, &type_decl_id, generic_params.clone());
     let type_index = db.get_type_index();
     let type_decl = type_index.get_type_decl(&type_decl_id)?;
 

--- a/crates/glua_code_analysis/src/semantic/member/find_members.rs
+++ b/crates/glua_code_analysis/src/semantic/member/find_members.rs
@@ -694,7 +694,8 @@ fn find_generic_members(
         .iter()
         .map(|param| ctx.instantiate_type(db, param))
         .collect();
-    let substitutor = TypeSubstitutor::from_type_array(instantiated_params);
+    let substitutor =
+        TypeSubstitutor::from_type_array_for_type(db, base_ref_id, instantiated_params);
     let type_decl = db.get_type_index().get_type_decl(&base_ref_id)?;
     let ctx_with_substitutor = ctx.with_substitutor(substitutor.clone());
     if let Some(origin) = type_decl.get_alias_origin(db, Some(&substitutor)) {

--- a/crates/glua_code_analysis/src/semantic/member/infer_raw_member.rs
+++ b/crates/glua_code_analysis/src/semantic/member/infer_raw_member.rs
@@ -87,7 +87,10 @@ fn infer_owner_raw_member_type(
     member_owner: LuaMemberOwner,
     member_key: &LuaMemberKey,
 ) -> RawGetMemberTypeResult {
-    if let Some(member_item) = db.get_member_index().get_member_item(&member_owner, member_key) {
+    if let Some(member_item) = db
+        .get_member_index()
+        .get_member_item(&member_owner, member_key)
+    {
         return member_item.resolve_type(db);
     }
 
@@ -117,7 +120,10 @@ fn infer_owner_raw_member_type(
         return Err(InferFailReason::FieldNotFound);
     }
 
-    if matches!(access_key_type, LuaType::String | LuaType::Number | LuaType::Integer) {
+    if matches!(
+        access_key_type,
+        LuaType::String | LuaType::Number | LuaType::Integer
+    ) {
         result_type = TypeOps::Union.apply(db, &result_type, &LuaType::Nil);
     }
 
@@ -275,7 +281,8 @@ fn infer_generic_raw_member_type(
 ) -> RawGetMemberTypeResult {
     let base_ref_id = generic_type.get_base_type_id_ref();
     let generic_params = generic_type.get_params();
-    let substitutor = TypeSubstitutor::from_type_array(generic_params.clone());
+    let substitutor =
+        TypeSubstitutor::from_type_array_for_type(db, base_ref_id, generic_params.clone());
     let type_decl = db
         .get_type_index()
         .get_type_decl(&base_ref_id)

--- a/crates/glua_code_analysis/src/semantic/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/mod.rs
@@ -60,7 +60,7 @@ pub use infer::InferFailReason;
 pub use infer::infer_call_expr_func;
 pub(crate) use infer::infer_expr;
 pub use infer::infer_param;
-use overload_resolve::resolve_signature;
+use overload_resolve::{resolve_signature, resolve_signature_with_context};
 pub use semantic_info::SemanticDeclLevel;
 pub use type_check::{TypeCheckFailReason, TypeCheckResult};
 

--- a/crates/glua_code_analysis/src/semantic/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/mod.rs
@@ -47,7 +47,7 @@ pub use crate::semantic::member::{
     find_members_with_key_in_workspace_for_file,
     find_members_with_key_in_workspace_for_file_at_offset,
 };
-use crate::semantic::type_check::check_type_compact_detail;
+use crate::semantic::type_check::{check_type_compact_detail, check_type_compact_detail_no_excess};
 use crate::{Emmyrc, LuaDocument, LuaSemanticDeclId, ModuleInfo, db_index::LuaTypeDeclId};
 use crate::{
     FileId,
@@ -288,6 +288,14 @@ impl<'a> SemanticModel<'a> {
 
     pub fn type_check_detail(&self, source: &LuaType, compact_type: &LuaType) -> TypeCheckResult {
         check_type_compact_detail(self.db, source, compact_type)
+    }
+
+    pub fn type_check_detail_no_excess(
+        &self,
+        source: &LuaType,
+        compact_type: &LuaType,
+    ) -> TypeCheckResult {
+        check_type_compact_detail_no_excess(self.db, source, compact_type)
     }
 
     pub fn infer_call_expr_func(

--- a/crates/glua_code_analysis/src/semantic/overload_resolve/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/overload_resolve/mod.rs
@@ -12,7 +12,7 @@ use crate::{
 
 use super::{
     LuaInferCache,
-    generic::instantiate_func_generic,
+    generic::{instantiate_func_generic, instantiate_func_generic_with_context},
     infer::{InferCallFuncResult, InferFailReason},
 };
 
@@ -26,6 +26,18 @@ pub fn resolve_signature(
     is_generic: bool,
     arg_count: Option<usize>,
 ) -> InferCallFuncResult {
+    resolve_signature_with_context(db, cache, overloads, call_expr, is_generic, arg_count, None)
+}
+
+pub fn resolve_signature_with_context(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    overloads: Vec<Arc<LuaFunctionType>>,
+    call_expr: LuaCallExpr,
+    is_generic: bool,
+    arg_count: Option<usize>,
+    contextual_return_hint: Option<LuaType>,
+) -> InferCallFuncResult {
     let args = call_expr.get_args_list().ok_or(InferFailReason::None)?;
     let expr_types = infer_expr_list_types(
         db,
@@ -34,7 +46,15 @@ pub fn resolve_signature(
         arg_count,
     );
     if is_generic {
-        resolve_signature_by_generic(db, cache, overloads, call_expr, expr_types, arg_count)
+        resolve_signature_by_generic(
+            db,
+            cache,
+            overloads,
+            call_expr,
+            expr_types,
+            arg_count,
+            contextual_return_hint.as_ref(),
+        )
     } else {
         resolve_signature_by_args(
             db,
@@ -53,10 +73,21 @@ fn resolve_signature_by_generic(
     call_expr: LuaCallExpr,
     expr_types: Vec<LuaType>,
     arg_count: Option<usize>,
+    contextual_return_hint: Option<&LuaType>,
 ) -> InferCallFuncResult {
     let mut instantiate_funcs = Vec::new();
     for func in overloads {
-        let instantiate_func = instantiate_func_generic(db, cache, &func, call_expr.clone())?;
+        let instantiate_func = if contextual_return_hint.is_some() {
+            instantiate_func_generic_with_context(
+                db,
+                cache,
+                &func,
+                call_expr.clone(),
+                contextual_return_hint.cloned(),
+            )?
+        } else {
+            instantiate_func_generic(db, cache, &func, call_expr.clone())?
+        };
         instantiate_funcs.push(Arc::new(instantiate_func));
     }
     resolve_signature_by_args(

--- a/crates/glua_code_analysis/src/semantic/type_check/complex_type/intersection_type_check.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/complex_type/intersection_type_check.rs
@@ -15,12 +15,24 @@ pub fn check_intersection_type_compact(
     check_guard: TypeCheckGuard,
 ) -> TypeCheckResult {
     match compact_type {
-        LuaType::TableConst(range) => check_intersection_type_compact_table(
-            context,
-            source_intersection,
-            LuaMemberOwner::Element(range.clone()),
-            check_guard.next_level()?,
-        ),
+        LuaType::TableConst(range) => {
+            if let Some(object_type) = intersection_to_object(context.db, source_intersection) {
+                let object_type = LuaType::Object(Arc::new(object_type));
+                check_general_type_compact(
+                    context,
+                    &object_type,
+                    compact_type,
+                    check_guard.next_level()?,
+                )
+            } else {
+                check_intersection_type_compact_table(
+                    context,
+                    source_intersection,
+                    LuaMemberOwner::Element(range.clone()),
+                    check_guard.next_level()?,
+                )
+            }
+        }
         LuaType::Def(_) | LuaType::Ref(_) => {
             if let Some(object_type) = intersection_to_object(context.db, source_intersection) {
                 let object_type = LuaType::Object(Arc::new(object_type));

--- a/crates/glua_code_analysis/src/semantic/type_check/complex_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/complex_type/mod.rs
@@ -13,8 +13,8 @@ use table_generic_check::check_table_generic_type_compact;
 use tuple_type_check::check_tuple_type_compact;
 
 use crate::{
-    LuaType, LuaUnionType, TypeSubstitutor,
-    semantic::type_check::type_check_context::TypeCheckContext,
+    LuaMemberKey, LuaMemberOwner, LuaType, LuaUnionType, TypeSubstitutor,
+    semantic::{member::find_members, type_check::type_check_context::TypeCheckContext},
 };
 
 use super::{
@@ -101,6 +101,14 @@ pub fn check_complex_type_compact(
             }
         }
         LuaType::Union(union_type) => {
+            if matches!(compact_type, LuaType::TableConst(_)) {
+                return check_union_type_compact_table_const(
+                    context,
+                    union_type,
+                    compact_type,
+                    check_guard.next_level()?,
+                );
+            }
             if let LuaType::Union(compact_union) = compact_type {
                 return check_union_type_compact_union(
                     context,
@@ -179,4 +187,210 @@ fn check_union_type_compact_union(
     }
 
     Ok(())
+}
+
+fn check_union_type_compact_table_const(
+    context: &mut TypeCheckContext,
+    source_union: &LuaUnionType,
+    compact_type: &LuaType,
+    check_guard: TypeCheckGuard,
+) -> TypeCheckResult {
+    let union_targets = source_union.into_vec();
+    let table_members = table_const_members(context, compact_type);
+    let narrowed_targets = narrow_union_targets_by_table_literals(
+        context,
+        &union_targets,
+        &table_members,
+        check_guard,
+    )?;
+
+    check_table_const_excess_against_targets(
+        context,
+        &narrowed_targets,
+        &table_members,
+        check_guard,
+    )?;
+
+    for sub_type in narrowed_targets {
+        let mut branch_context = context.clone();
+        branch_context.skip_excess_property_checks = true;
+        match check_general_type_compact(
+            &mut branch_context,
+            &sub_type,
+            compact_type,
+            check_guard.next_level()?,
+        ) {
+            Ok(_) => return Ok(()),
+            Err(e) if e.is_type_not_match() => {}
+            Err(e) => return Err(e),
+        }
+    }
+
+    Err(TypeCheckFailReason::TypeNotMatch)
+}
+
+fn table_const_members(
+    context: &TypeCheckContext,
+    compact_type: &LuaType,
+) -> Vec<(LuaMemberKey, LuaType)> {
+    let LuaType::TableConst(table_range) = compact_type else {
+        return Vec::new();
+    };
+
+    let member_owner = LuaMemberOwner::Element(table_range.clone());
+    let member_index = context.db.get_member_index();
+    let Some(members) = member_index.get_members(&member_owner) else {
+        return Vec::new();
+    };
+
+    let type_index = context.db.get_type_index();
+    members
+        .iter()
+        .filter_map(|member| {
+            type_index
+                .get_type_cache(&member.get_id().into())
+                .map(|cache| (member.get_key().clone(), cache.as_type().clone()))
+        })
+        .collect()
+}
+
+fn narrow_union_targets_by_table_literals(
+    context: &mut TypeCheckContext,
+    union_targets: &[LuaType],
+    table_members: &[(LuaMemberKey, LuaType)],
+    check_guard: TypeCheckGuard,
+) -> Result<Vec<LuaType>, TypeCheckFailReason> {
+    let mut narrowed_targets = Vec::new();
+    let mut rejected = false;
+
+    for target in union_targets {
+        let Some(target_members) = find_members(context.db, target) else {
+            narrowed_targets.push(target.clone());
+            continue;
+        };
+
+        let mut compatible = true;
+        for (table_key, table_type) in table_members {
+            if !is_discriminant_type(table_type) {
+                continue;
+            }
+
+            let Some(target_member) = target_members
+                .iter()
+                .find(|target_member| &target_member.key == table_key)
+            else {
+                continue;
+            };
+
+            if !is_discriminant_type(&target_member.typ) {
+                continue;
+            }
+
+            let mut check_context = context.clone();
+            match check_general_type_compact(
+                &mut check_context,
+                &target_member.typ,
+                table_type,
+                check_guard.next_level()?,
+            ) {
+                Ok(_) => {}
+                Err(err) if err.is_type_not_match() => {
+                    compatible = false;
+                    rejected = true;
+                    break;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        if compatible {
+            narrowed_targets.push(target.clone());
+        }
+    }
+
+    if rejected && !narrowed_targets.is_empty() {
+        Ok(narrowed_targets)
+    } else {
+        Ok(union_targets.to_vec())
+    }
+}
+
+fn check_table_const_excess_against_targets(
+    context: &mut TypeCheckContext,
+    targets: &[LuaType],
+    table_members: &[(LuaMemberKey, LuaType)],
+    check_guard: TypeCheckGuard,
+) -> TypeCheckResult {
+    let target_members = targets
+        .iter()
+        .filter_map(|target| find_members(context.db, target))
+        .flatten()
+        .collect::<Vec<_>>();
+
+    if target_members.is_empty() {
+        return Ok(());
+    }
+
+    for (table_key, _) in table_members {
+        if target_members
+            .iter()
+            .any(|target_member| &target_member.key == table_key)
+        {
+            continue;
+        }
+
+        let Some(table_key_type) = member_key_type_for_index(table_key) else {
+            continue;
+        };
+
+        let mut accepted_by_index = false;
+        for target_member in &target_members {
+            let LuaMemberKey::ExprType(index_key_type) = &target_member.key else {
+                continue;
+            };
+            match check_general_type_compact(
+                context,
+                index_key_type,
+                &table_key_type,
+                check_guard.next_level()?,
+            ) {
+                Ok(_) => {
+                    accepted_by_index = true;
+                    break;
+                }
+                Err(err) if err.is_type_not_match() => {}
+                Err(err) => return Err(err),
+            }
+        }
+
+        if accepted_by_index {
+            continue;
+        }
+
+        return Err(TypeCheckFailReason::TypeNotMatch);
+    }
+
+    Ok(())
+}
+
+fn member_key_type_for_index(member_key: &LuaMemberKey) -> Option<LuaType> {
+    match member_key {
+        LuaMemberKey::Integer(i) => Some(LuaType::IntegerConst(*i)),
+        LuaMemberKey::Name(name) => Some(LuaType::StringConst(name.clone().into())),
+        LuaMemberKey::ExprType(typ) => Some(typ.clone()),
+        LuaMemberKey::None => None,
+    }
+}
+
+fn is_discriminant_type(typ: &LuaType) -> bool {
+    match typ {
+        LuaType::StringConst(_)
+        | LuaType::DocStringConst(_)
+        | LuaType::IntegerConst(_)
+        | LuaType::DocIntegerConst(_)
+        | LuaType::BooleanConst(_)
+        | LuaType::DocBooleanConst(_) => true,
+        LuaType::Union(union) => union.into_vec().iter().all(is_discriminant_type),
+        _ => false,
+    }
 }

--- a/crates/glua_code_analysis/src/semantic/type_check/complex_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/complex_type/mod.rs
@@ -37,8 +37,11 @@ pub fn check_complex_type_compact(
             if let Some(decl) = context.db.get_type_index().get_type_decl(&base_id)
                 && decl.is_alias()
             {
-                let substitutor =
-                    TypeSubstitutor::from_alias(generic.get_params().clone(), base_id.clone());
+                let substitutor = TypeSubstitutor::from_alias_for_type(
+                    context.db,
+                    generic.get_params().clone(),
+                    base_id.clone(),
+                );
                 if let Some(alias_origin) = decl.get_alias_origin(context.db, Some(&substitutor)) {
                     return check_general_type_compact(
                         context,

--- a/crates/glua_code_analysis/src/semantic/type_check/complex_type/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/complex_type/mod.rs
@@ -321,6 +321,13 @@ fn check_table_const_excess_against_targets(
     table_members: &[(LuaMemberKey, LuaType)],
     check_guard: TypeCheckGuard,
 ) -> TypeCheckResult {
+    if targets
+        .iter()
+        .any(|target| target_allows_unknown_properties(context, target))
+    {
+        return Ok(());
+    }
+
     let target_members = targets
         .iter()
         .filter_map(|target| find_members(context.db, target))
@@ -371,6 +378,24 @@ fn check_table_const_excess_against_targets(
     }
 
     Ok(())
+}
+
+fn target_allows_unknown_properties(context: &TypeCheckContext, target: &LuaType) -> bool {
+    match target {
+        LuaType::Any | LuaType::Unknown | LuaType::Table | LuaType::TableGeneric(_) => true,
+        LuaType::Ref(type_id) | LuaType::Def(type_id) => context
+            .db
+            .get_type_index()
+            .get_type_decl(type_id)
+            .map(|decl| !decl.is_exact())
+            .unwrap_or(true),
+        LuaType::TableOf(_) | LuaType::Generic(_) | LuaType::Instance(_) => true,
+        LuaType::Union(union) => union
+            .into_vec()
+            .iter()
+            .any(|typ| target_allows_unknown_properties(context, typ)),
+        _ => false,
+    }
 }
 
 fn member_key_type_for_index(member_key: &LuaMemberKey) -> Option<LuaType> {

--- a/crates/glua_code_analysis/src/semantic/type_check/complex_type/object_type_check.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/complex_type/object_type_check.rs
@@ -290,7 +290,9 @@ fn check_object_type_compact_table_const(
         }
     }
 
-    if source_fields.is_empty() && source_object.get_index_access().is_empty() {
+    if context.skip_excess_property_checks
+        || source_fields.is_empty() && source_object.get_index_access().is_empty()
+    {
         return Ok(());
     }
 

--- a/crates/glua_code_analysis/src/semantic/type_check/complex_type/object_type_check.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/complex_type/object_type_check.rs
@@ -174,6 +174,32 @@ fn member_key_type_for_index(member_key: &LuaMemberKey) -> Option<LuaType> {
     }
 }
 
+fn object_index_accepts_member_key(
+    context: &mut TypeCheckContext,
+    source_object: &LuaObjectType,
+    member_key: &LuaMemberKey,
+    check_guard: TypeCheckGuard,
+) -> Result<bool, TypeCheckFailReason> {
+    let Some(member_key_type) = member_key_type_for_index(member_key) else {
+        return Ok(false);
+    };
+
+    for (key_type, _) in source_object.get_index_access() {
+        match check_general_type_compact(
+            context,
+            key_type,
+            &member_key_type,
+            check_guard.next_level()?,
+        ) {
+            Ok(_) => return Ok(true),
+            Err(err) if err.is_type_not_match() => {}
+            Err(err) => return Err(err),
+        }
+    }
+
+    Ok(false)
+}
+
 fn check_object_type_compact_table_const(
     context: &mut TypeCheckContext,
     source_object: &LuaObjectType,
@@ -209,61 +235,76 @@ fn check_object_type_compact_table_const(
         check_member_value(context, key, None, source_type, &member_type, check_guard)?;
     }
 
-    if source_object.get_index_access().is_empty() {
+    // 检查索引访问字段
+    let members = member_index.get_members(&member_owner).unwrap_or_default();
+    if !source_object.get_index_access().is_empty() {
+        for (key_type, source_type) in source_object.get_index_access() {
+            for member in &members {
+                let member = *member;
+                if source_fields.contains_key(member.get_key()) {
+                    continue;
+                }
+                let Some(member_key_type) = member_key_type_for_index(member.get_key()) else {
+                    continue;
+                };
+
+                let key_match = match check_general_type_compact(
+                    context,
+                    key_type,
+                    &member_key_type,
+                    check_guard.next_level()?,
+                ) {
+                    Ok(_) => true,
+                    Err(err) => {
+                        if err.is_type_not_match() {
+                            false
+                        } else {
+                            return Err(err);
+                        }
+                    }
+                };
+
+                if !key_match {
+                    continue;
+                }
+
+                let member_type = match context
+                    .db
+                    .get_type_index()
+                    .get_type_cache(&member.get_id().into())
+                {
+                    Some(cache) => cache.as_type(),
+                    None => continue,
+                };
+
+                check_member_value(
+                    context,
+                    member.get_key(),
+                    Some(&member_key_type),
+                    source_type,
+                    member_type,
+                    check_guard,
+                )?;
+                break;
+            }
+        }
+    }
+
+    if source_fields.is_empty() && source_object.get_index_access().is_empty() {
         return Ok(());
     }
 
-    // 检查索引访问字段
-    let members = member_index.get_members(&member_owner).unwrap_or_default();
-    for (key_type, source_type) in source_object.get_index_access() {
-        for member in &members {
-            let member = *member;
-            if source_fields.contains_key(member.get_key()) {
-                continue;
-            }
-            let Some(member_key_type) = member_key_type_for_index(member.get_key()) else {
-                continue;
-            };
-
-            let key_match = match check_general_type_compact(
-                context,
-                key_type,
-                &member_key_type,
-                check_guard.next_level()?,
-            ) {
-                Ok(_) => true,
-                Err(err) => {
-                    if err.is_type_not_match() {
-                        false
-                    } else {
-                        return Err(err);
-                    }
-                }
-            };
-
-            if !key_match {
-                continue;
-            }
-
-            let member_type = match context
-                .db
-                .get_type_index()
-                .get_type_cache(&member.get_id().into())
-            {
-                Some(cache) => cache.as_type(),
-                None => continue,
-            };
-
-            check_member_value(
-                context,
-                member.get_key(),
-                Some(&member_key_type),
-                source_type,
-                member_type,
-                check_guard,
-            )?;
-            break;
+    for member in members {
+        if source_fields.contains_key(member.get_key()) {
+            continue;
         }
+        if object_index_accepts_member_key(context, source_object, member.get_key(), check_guard)? {
+            continue;
+        }
+
+        return Err(TypeCheckFailReason::TypeNotMatchWithReason(
+            t!("unknown member %{key}", key = member.get_key().to_path()).to_string(),
+        ));
     }
 
     Ok(())

--- a/crates/glua_code_analysis/src/semantic/type_check/func_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/func_type.rs
@@ -23,8 +23,11 @@ pub fn check_doc_func_type_compact(
             if let Some(decl) = context.db.get_type_index().get_type_decl(&base_id)
                 && decl.is_alias()
             {
-                let substitutor =
-                    TypeSubstitutor::from_alias(generic.get_params().clone(), base_id.clone());
+                let substitutor = TypeSubstitutor::from_alias_for_type(
+                    context.db,
+                    generic.get_params().clone(),
+                    base_id.clone(),
+                );
                 if let Some(alias_origin) = decl.get_alias_origin(context.db, Some(&substitutor)) {
                     return check_general_type_compact(
                         context,

--- a/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
@@ -24,8 +24,11 @@ pub fn check_generic_type_compact(
         .get_type_decl(&source_generic.get_base_type_id())
         && decl.is_alias()
     {
-        let substitutor =
-            TypeSubstitutor::from_alias(source_generic.get_params().clone(), base_id.clone());
+        let substitutor = TypeSubstitutor::from_alias_for_type(
+            context.db,
+            source_generic.get_params().clone(),
+            base_id.clone(),
+        );
         if let Some(alias_origin) = decl.get_alias_origin(context.db, Some(&substitutor)) {
             return check_general_type_compact(
                 context,
@@ -61,8 +64,11 @@ pub fn check_generic_type_compact(
             {
                 for mut super_type in supers {
                     if super_type.contain_tpl() {
-                        let substitutor =
-                            TypeSubstitutor::from_type_array(compact_generic.get_params().clone());
+                        let substitutor = TypeSubstitutor::from_type_array_for_type(
+                            context.db,
+                            &compact_generic.get_base_type_id(),
+                            compact_generic.get_params().clone(),
+                        );
                         super_type =
                             instantiate_type_generic(context.db, &super_type, &substitutor);
                     }

--- a/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
@@ -1,13 +1,15 @@
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
-    LuaGenericType, LuaMemberOwner, LuaType, LuaTypeCache, LuaTypeDeclId, RenderLevel,
-    TypeSubstitutor, humanize_type, instantiate_type_generic,
-    semantic::{member::find_members, type_check::type_check_context::TypeCheckContext},
+    LuaGenericType, LuaMemberId, LuaMemberKey, LuaMemberOwner, LuaType, LuaTypeCache,
+    LuaTypeDeclId, RenderLevel, TypeSubstitutor, humanize_type, instantiate_type_generic,
+    semantic::{
+        LuaMemberInfo, member::find_members, type_check::type_check_context::TypeCheckContext,
+    },
 };
 
 use super::{
-    TypeCheckResult, check_general_type_compact, is_required_structural_member,
+    TypeCheckResult, check_general_type_compact, is_required_structural_property,
     type_check_fail_reason::TypeCheckFailReason, type_check_guard::TypeCheckGuard,
 };
 
@@ -162,14 +164,14 @@ fn check_generic_type_compact_table(
     // 提前计算下一级检查守卫
     let next_guard = check_guard.next_level()?;
 
-    for source_member in source_type_members {
-        if !is_required_structural_member(source_member.feature) {
+    for source_member in &source_type_members {
+        if !is_required_structural_property(source_member.feature, &source_member.key) {
             continue;
         }
-        let source_member_type = source_member.typ;
-        let key = source_member.key;
+        let source_member_type = &source_member.typ;
+        let key = &source_member.key;
 
-        match table_member_map.get(&key) {
+        match table_member_map.get(key) {
             Some(table_member_id) => {
                 let table_member = member_index
                     .get_member(table_member_id)
@@ -183,7 +185,7 @@ fn check_generic_type_compact_table(
 
                 if let Err(err) = check_general_type_compact(
                     context,
-                    &source_member_type,
+                    source_member_type,
                     table_member_type,
                     next_guard,
                 ) && err.is_type_not_match()
@@ -196,7 +198,7 @@ fn check_generic_type_compact_table(
                             "member %{name} type not match, expect %{expect}, got %{got}",
                             name = key.to_path(),
                             expect =
-                                humanize_type(context.db, &source_member_type, RenderLevel::Simple),
+                                humanize_type(context.db, source_member_type, RenderLevel::Simple),
                             got = humanize_type(context.db, table_member_type, RenderLevel::Simple)
                         )
                         .to_string(),
@@ -216,6 +218,13 @@ fn check_generic_type_compact_table(
         }
     }
 
+    check_generic_index_members_against_table(
+        context,
+        &source_type_members,
+        &table_member_map,
+        next_guard,
+    )?;
+
     // 检查超类型
     let source_base_id = source_generic.get_base_type_id();
     if let Some(supers) = context.db.get_type_index().get_super_types(&source_base_id) {
@@ -227,6 +236,113 @@ fn check_generic_type_compact_table(
         for super_type in supers {
             check_general_type_compact(context, &super_type, &table_type, next_guard)?;
         }
+    }
+
+    Ok(())
+}
+
+fn check_generic_index_members_against_table(
+    context: &mut TypeCheckContext,
+    source_type_members: &[LuaMemberInfo],
+    table_member_map: &HashMap<LuaMemberKey, LuaMemberId>,
+    check_guard: TypeCheckGuard,
+) -> TypeCheckResult {
+    let member_index = context.db.get_member_index();
+
+    for (table_key, table_member_id) in table_member_map {
+        let Some(table_key_type) = member_key_type_for_index(table_key) else {
+            continue;
+        };
+
+        for source_member in source_type_members {
+            let LuaMemberKey::ExprType(index_key_type) = &source_member.key else {
+                continue;
+            };
+
+            if !index_key_matches(context, index_key_type, &table_key_type, check_guard)? {
+                continue;
+            }
+
+            let table_member = member_index
+                .get_member(table_member_id)
+                .ok_or(TypeCheckFailReason::TypeNotMatch)?;
+            let table_member_type = context
+                .db
+                .get_type_index()
+                .get_type_cache(&table_member.get_id().into())
+                .unwrap_or(&LuaTypeCache::InferType(LuaType::Any))
+                .as_type();
+
+            check_index_member_value(
+                context,
+                table_key,
+                &source_member.typ,
+                table_member_type,
+                check_guard,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn member_key_type_for_index(member_key: &LuaMemberKey) -> Option<LuaType> {
+    match member_key {
+        LuaMemberKey::Integer(i) => Some(LuaType::IntegerConst(*i)),
+        LuaMemberKey::Name(name) => Some(LuaType::StringConst(name.clone().into())),
+        LuaMemberKey::ExprType(typ) => Some(typ.clone()),
+        LuaMemberKey::None => None,
+    }
+}
+
+fn index_key_matches(
+    context: &mut TypeCheckContext,
+    index_key_type: &LuaType,
+    actual_key_type: &LuaType,
+    check_guard: TypeCheckGuard,
+) -> Result<bool, TypeCheckFailReason> {
+    match check_general_type_compact(
+        context,
+        index_key_type,
+        actual_key_type,
+        check_guard.next_level()?,
+    ) {
+        Ok(_) => Ok(true),
+        Err(err) if err.is_type_not_match() => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+fn check_index_member_value(
+    context: &mut TypeCheckContext,
+    key: &LuaMemberKey,
+    source_member_type: &LuaType,
+    actual_member_type: &LuaType,
+    check_guard: TypeCheckGuard,
+) -> TypeCheckResult {
+    if let Err(err) = check_general_type_compact(
+        context,
+        source_member_type,
+        actual_member_type,
+        check_guard.next_level()?,
+    ) {
+        if !err.is_type_not_match() {
+            return Err(err);
+        }
+
+        if !context.detail {
+            return Err(TypeCheckFailReason::TypeNotMatch);
+        }
+
+        return Err(TypeCheckFailReason::TypeNotMatchWithReason(
+            t!(
+                "member %{name} type not match, expect %{expect}, got %{got}",
+                name = key.to_path(),
+                expect = humanize_type(context.db, source_member_type, RenderLevel::Simple),
+                got = humanize_type(context.db, actual_member_type, RenderLevel::Simple)
+            )
+            .to_string(),
+        ));
     }
 
     Ok(())

--- a/crates/glua_code_analysis/src/semantic/type_check/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/mod.rs
@@ -21,7 +21,7 @@ pub use type_check_fail_reason::TypeCheckFailReason;
 use type_check_guard::TypeCheckGuard;
 
 use crate::{
-    LuaMemberFeature, LuaUnionType,
+    LuaMemberFeature, LuaMemberKey, LuaUnionType,
     db_index::{DbIndex, LuaType},
     semantic::type_check::type_check_context::TypeCheckContext,
 };
@@ -34,6 +34,13 @@ fn is_required_structural_member(feature: Option<LuaMemberFeature>) -> bool {
         feature,
         Some(LuaMemberFeature::FileMethodDecl | LuaMemberFeature::MetaMethodDecl)
     )
+}
+
+fn is_required_structural_property(feature: Option<LuaMemberFeature>, key: &LuaMemberKey) -> bool {
+    // TS keeps index signatures out of the required property list. Our computed
+    // member keys play the same role in relation checks: they accept matching
+    // source keys, but are not standalone required fields.
+    is_required_structural_member(feature) && !matches!(key, LuaMemberKey::ExprType(_))
 }
 
 pub fn check_type_compact(

--- a/crates/glua_code_analysis/src/semantic/type_check/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/mod.rs
@@ -55,6 +55,17 @@ pub fn check_type_compact_detail(
     check_general_type_compact(&mut context, source, compact_type, guard)
 }
 
+pub fn check_type_compact_detail_no_excess(
+    db: &DbIndex,
+    source: &LuaType,
+    compact_type: &LuaType,
+) -> TypeCheckResult {
+    let guard = TypeCheckGuard::new();
+    let mut context = TypeCheckContext::new(db, true, TypeCheckCheckLevel::Normal);
+    context.skip_excess_property_checks = true;
+    check_general_type_compact(&mut context, source, compact_type, guard)
+}
+
 pub fn check_type_compact_with_level(
     db: &DbIndex,
     source: &LuaType,

--- a/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use crate::{
-    LuaMemberKey, LuaMemberOwner, LuaObjectType, LuaTupleType, LuaType, LuaTypeCache, LuaTypeDecl,
-    LuaTypeDeclId, RenderLevel, humanize_type,
+    LuaMember, LuaMemberId, LuaMemberKey, LuaMemberOwner, LuaObjectType, LuaTupleType, LuaType,
+    LuaTypeCache, LuaTypeDecl, LuaTypeDeclId, RenderLevel, humanize_type,
     semantic::{
         LuaMemberInfo,
         member::find_members,
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use super::{
-    TypeCheckResult, check_general_type_compact, is_required_structural_member, is_sub_type_of,
+    TypeCheckResult, check_general_type_compact, is_required_structural_property, is_sub_type_of,
     sub_type::get_base_type_id, type_check_fail_reason::TypeCheckFailReason,
     type_check_guard::TypeCheckGuard,
 };
@@ -271,7 +271,10 @@ fn check_ref_type_compact_table(
 
     for source_member in &source_type_members {
         let source_member = *source_member;
-        if !is_required_structural_member(Some(source_member.get_feature())) {
+        if !is_required_structural_property(
+            Some(source_member.get_feature()),
+            source_member.get_key(),
+        ) {
             continue;
         }
         let source_member_type = context
@@ -335,6 +338,13 @@ fn check_ref_type_compact_table(
 
         context.mark_key_checked(key.clone());
     }
+
+    check_ref_index_members_against_table(
+        context,
+        &source_type_members,
+        &table_member_map,
+        check_guard,
+    )?;
 
     // 检查超类型
     if let Some(supers) = context.db.get_type_index().get_super_types(source_type_id) {
@@ -434,6 +444,58 @@ fn member_key_type_for_index(member_key: &LuaMemberKey) -> Option<LuaType> {
     }
 }
 
+fn check_ref_index_members_against_table(
+    context: &mut TypeCheckContext,
+    source_type_members: &[&LuaMember],
+    table_member_map: &HashMap<LuaMemberKey, LuaMemberId>,
+    check_guard: TypeCheckGuard,
+) -> TypeCheckResult {
+    let member_index = context.db.get_member_index();
+
+    for (table_key, table_member_id) in table_member_map {
+        let Some(table_key_type) = member_key_type_for_index(table_key) else {
+            continue;
+        };
+
+        for source_member in source_type_members {
+            let LuaMemberKey::ExprType(index_key_type) = source_member.get_key() else {
+                continue;
+            };
+
+            if !index_key_matches(context, index_key_type, &table_key_type, check_guard)? {
+                continue;
+            }
+
+            let source_member_type = context
+                .db
+                .get_type_index()
+                .get_type_cache(&source_member.get_id().into())
+                .unwrap_or(&LuaTypeCache::InferType(LuaType::Any))
+                .as_type();
+            let table_member = member_index
+                .get_member(table_member_id)
+                .ok_or(TypeCheckFailReason::TypeNotMatch)?;
+            let table_member_type = context
+                .db
+                .get_type_index()
+                .get_type_cache(&table_member.get_id().into())
+                .unwrap_or(&LuaTypeCache::InferType(LuaType::Any))
+                .as_type();
+
+            check_index_member_value(
+                context,
+                table_key,
+                None,
+                source_member_type,
+                table_member_type,
+                check_guard,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
 fn check_ref_type_compact_object(
     context: &mut TypeCheckContext,
     object_type: &LuaObjectType,
@@ -446,21 +508,21 @@ fn check_ref_type_compact_object(
         return Ok(());
     };
 
-    for source_member in source_type_members {
-        if !is_required_structural_member(source_member.feature) {
+    for source_member in &source_type_members {
+        if !is_required_structural_property(source_member.feature, &source_member.key) {
             continue;
         }
-        let source_member_type = source_member.typ;
-        let key = source_member.key;
-        if context.is_key_checked(&key) {
+        let source_member_type = &source_member.typ;
+        let key = &source_member.key;
+        if context.is_key_checked(key) {
             continue;
         }
 
-        match get_object_field_type(object_type, &key) {
+        match get_object_field_type(object_type, key) {
             Some(field_type) => {
                 if let Err(err) = check_general_type_compact(
                     context,
-                    &source_member_type,
+                    source_member_type,
                     field_type,
                     check_guard.next_level()?,
                 ) && err.is_type_not_match()
@@ -474,7 +536,7 @@ fn check_ref_type_compact_object(
                             "member %{name} type not match, expect %{expect}, got %{got}",
                             name = key.to_path(),
                             expect =
-                                humanize_type(context.db, &source_member_type, RenderLevel::Simple),
+                                humanize_type(context.db, source_member_type, RenderLevel::Simple),
                             got = humanize_type(context.db, field_type, RenderLevel::Simple)
                         )
                         .to_string(),
@@ -492,8 +554,15 @@ fn check_ref_type_compact_object(
             _ => {} // Optional member not found, continue
         }
 
-        context.mark_key_checked(key);
+        context.mark_key_checked(key.clone());
     }
+
+    check_ref_index_members_against_object(
+        context,
+        &source_type_members,
+        object_type,
+        check_guard,
+    )?;
 
     if !context.skip_excess_property_checks
         && ref_requires_excess_property_checks(context, source_type_id)
@@ -534,6 +603,123 @@ fn check_ref_type_compact_object(
     Ok(())
 }
 
+fn check_ref_index_members_against_object(
+    context: &mut TypeCheckContext,
+    source_type_members: &[LuaMemberInfo],
+    object_type: &LuaObjectType,
+    check_guard: TypeCheckGuard,
+) -> TypeCheckResult {
+    for (actual_key, actual_type) in object_type.get_fields() {
+        let Some(actual_key_type) = member_key_type_for_index(actual_key) else {
+            continue;
+        };
+
+        for source_member in source_type_members {
+            let LuaMemberKey::ExprType(index_key_type) = &source_member.key else {
+                continue;
+            };
+
+            if !index_key_matches(context, index_key_type, &actual_key_type, check_guard)? {
+                continue;
+            }
+
+            check_index_member_value(
+                context,
+                actual_key,
+                None,
+                &source_member.typ,
+                actual_type,
+                check_guard,
+            )?;
+        }
+    }
+
+    for (actual_key_type, actual_type) in object_type.get_index_access() {
+        for source_member in source_type_members {
+            let LuaMemberKey::ExprType(index_key_type) = &source_member.key else {
+                continue;
+            };
+
+            if !index_key_matches(context, index_key_type, actual_key_type, check_guard)? {
+                continue;
+            }
+
+            let display_key = LuaMemberKey::ExprType(actual_key_type.clone());
+            check_index_member_value(
+                context,
+                &display_key,
+                Some(actual_key_type),
+                &source_member.typ,
+                actual_type,
+                check_guard,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn index_key_matches(
+    context: &mut TypeCheckContext,
+    index_key_type: &LuaType,
+    actual_key_type: &LuaType,
+    check_guard: TypeCheckGuard,
+) -> Result<bool, TypeCheckFailReason> {
+    match check_general_type_compact(
+        context,
+        index_key_type,
+        actual_key_type,
+        check_guard.next_level()?,
+    ) {
+        Ok(_) => Ok(true),
+        Err(err) if err.is_type_not_match() => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+fn check_index_member_value(
+    context: &mut TypeCheckContext,
+    key: &LuaMemberKey,
+    key_type_for_display: Option<&LuaType>,
+    source_member_type: &LuaType,
+    actual_member_type: &LuaType,
+    check_guard: TypeCheckGuard,
+) -> TypeCheckResult {
+    if let Err(err) = check_general_type_compact(
+        context,
+        source_member_type,
+        actual_member_type,
+        check_guard.next_level()?,
+    ) {
+        if !err.is_type_not_match() {
+            return Err(err);
+        }
+
+        if !context.detail {
+            return Err(TypeCheckFailReason::TypeNotMatch);
+        }
+
+        let mut key_display = key.to_path();
+        if key_display.is_empty()
+            && let Some(key_type_for_display) = key_type_for_display
+        {
+            key_display = humanize_type(context.db, key_type_for_display, RenderLevel::Simple);
+        }
+
+        return Err(TypeCheckFailReason::TypeNotMatchWithReason(
+            t!(
+                "member %{name} type not match, expect %{expect}, got %{got}",
+                name = key_display,
+                expect = humanize_type(context.db, source_member_type, RenderLevel::Simple),
+                got = humanize_type(context.db, actual_member_type, RenderLevel::Simple)
+            )
+            .to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
 fn member_key_accepted_by_index(
     context: &mut TypeCheckContext,
     source_members: &[LuaMemberInfo],
@@ -548,15 +734,8 @@ fn member_key_accepted_by_index(
         let LuaMemberKey::ExprType(index_key_type) = &source_member.key else {
             continue;
         };
-        match check_general_type_compact(
-            context,
-            index_key_type,
-            &table_key_type,
-            check_guard.next_level()?,
-        ) {
-            Ok(_) => return Ok(true),
-            Err(err) if err.is_type_not_match() => {}
-            Err(err) => return Err(err),
+        if index_key_matches(context, index_key_type, &table_key_type, check_guard)? {
+            return Ok(true);
         }
     }
 

--- a/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
@@ -227,10 +227,7 @@ fn check_ref_class(
         }
         LuaType::Generic(generic) => {
             let base_type_id = generic.get_base_type_id();
-            if source_id == &base_type_id
-                || is_sub_type_of(context.db, &base_type_id, source_id)
-                || is_sub_type_of(context.db, source_id, &base_type_id)
-            {
+            if source_id == &base_type_id || is_sub_type_of(context.db, &base_type_id, source_id) {
                 Ok(())
             } else {
                 Err(TypeCheckFailReason::TypeNotMatch)

--- a/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
@@ -233,7 +233,6 @@ fn check_ref_class(
             if let Some(base_type_id) = get_base_type_id(compact_type) {
                 if source_id == &base_type_id
                     || is_sub_type_of(context.db, &base_type_id, source_id)
-                    || is_sub_type_of(context.db, source_id, &base_type_id)
                 {
                     Ok(())
                 } else {

--- a/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
@@ -155,10 +155,6 @@ fn check_ref_class(
             if is_sub_type_of(context.db, id, source_id) {
                 return Ok(());
             }
-            // 这不是正确的逻辑. 但不假设超类会自动转换为子类, 则会过于严格
-            if is_sub_type_of(context.db, source_id, id) {
-                return Ok(());
-            }
 
             // `compact`为枚举时的额外处理
             if let Some(compact_decl) = context.db.get_type_index().get_type_decl(id)

--- a/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
@@ -268,7 +268,8 @@ fn check_ref_type_compact_table(
         return Ok(()); // empty member donot need check
     };
 
-    for source_member in source_type_members {
+    for source_member in &source_type_members {
+        let source_member = *source_member;
         if !is_required_structural_member(Some(source_member.get_feature())) {
             continue;
         }
@@ -352,7 +353,63 @@ fn check_ref_type_compact_table(
         }
     }
 
+    if let Some(all_source_members) = find_members(context.db, &LuaType::Ref(source_type_id.clone()))
+        && !all_source_members.is_empty()
+    {
+        for table_key in table_member_map.keys() {
+            if all_source_members
+                .iter()
+                .any(|source_member| &source_member.key == table_key)
+            {
+                continue;
+            }
+
+            let Some(table_key_type) = member_key_type_for_index(table_key) else {
+                continue;
+            };
+            let mut accepted_by_index = false;
+            for source_member in &all_source_members {
+                let LuaMemberKey::ExprType(index_key_type) = &source_member.key else {
+                    continue;
+                };
+                match check_general_type_compact(
+                    context,
+                    index_key_type,
+                    &table_key_type,
+                    check_guard.next_level()?,
+                ) {
+                    Ok(_) => {
+                        accepted_by_index = true;
+                        break;
+                    }
+                    Err(err) if err.is_type_not_match() => {}
+                    Err(err) => return Err(err),
+                }
+            }
+            if accepted_by_index {
+                continue;
+            }
+
+            if !context.detail {
+                return Err(TypeCheckFailReason::TypeNotMatch);
+            }
+
+            return Err(TypeCheckFailReason::TypeNotMatchWithReason(
+                t!("unknown member %{name}, in table", name = table_key.to_path()).to_string(),
+            ));
+        }
+    }
+
     Ok(())
+}
+
+fn member_key_type_for_index(member_key: &LuaMemberKey) -> Option<LuaType> {
+    match member_key {
+        LuaMemberKey::Integer(i) => Some(LuaType::IntegerConst(*i)),
+        LuaMemberKey::Name(name) => Some(LuaType::StringConst(name.clone().into())),
+        LuaMemberKey::ExprType(typ) => Some(typ.clone()),
+        LuaMemberKey::None => None,
+    }
 }
 
 fn check_ref_type_compact_object(

--- a/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
@@ -4,6 +4,7 @@ use crate::{
     LuaMemberKey, LuaMemberOwner, LuaObjectType, LuaTupleType, LuaType, LuaTypeCache, LuaTypeDecl,
     LuaTypeDeclId, RenderLevel, humanize_type,
     semantic::{
+        LuaMemberInfo,
         member::find_members,
         type_check::{
             intersection_utils::intersection_to_object, type_check_context::TypeCheckContext,
@@ -344,8 +345,10 @@ fn check_ref_type_compact_table(
                 .clone(),
         );
         for super_type in supers {
+            let mut super_context = context.clone();
+            super_context.skip_excess_property_checks = true;
             check_general_type_compact(
-                context,
+                &mut super_context,
                 &super_type,
                 &table_type,
                 check_guard.next_level()?,
@@ -354,6 +357,7 @@ fn check_ref_type_compact_table(
     }
 
     if !context.skip_excess_property_checks
+        && ref_requires_excess_property_checks(context, source_type_id)
         && let Some(all_source_members) =
             find_members(context.db, &LuaType::Ref(source_type_id.clone()))
         && !all_source_members.is_empty()
@@ -397,12 +401,28 @@ fn check_ref_type_compact_table(
             }
 
             return Err(TypeCheckFailReason::TypeNotMatchWithReason(
-                t!("unknown member %{name}, in table", name = table_key.to_path()).to_string(),
+                t!(
+                    "unknown member %{name}, in table",
+                    name = table_key.to_path()
+                )
+                .to_string(),
             ));
         }
     }
 
     Ok(())
+}
+
+fn ref_requires_excess_property_checks(
+    context: &TypeCheckContext,
+    type_id: &LuaTypeDeclId,
+) -> bool {
+    context
+        .db
+        .get_type_index()
+        .get_type_decl(type_id)
+        .map(|decl| decl.is_exact())
+        .unwrap_or(false)
 }
 
 fn member_key_type_for_index(member_key: &LuaMemberKey) -> Option<LuaType> {
@@ -475,7 +495,72 @@ fn check_ref_type_compact_object(
         context.mark_key_checked(key);
     }
 
+    if !context.skip_excess_property_checks
+        && ref_requires_excess_property_checks(context, source_type_id)
+    {
+        let Some(all_source_members) =
+            find_members(context.db, &LuaType::Ref(source_type_id.clone()))
+        else {
+            return Ok(());
+        };
+
+        for actual_key in object_type.get_fields().keys() {
+            if all_source_members
+                .iter()
+                .any(|source_member| &source_member.key == actual_key)
+            {
+                continue;
+            }
+
+            if member_key_accepted_by_index(context, &all_source_members, actual_key, check_guard)?
+            {
+                continue;
+            }
+
+            if !context.detail {
+                return Err(TypeCheckFailReason::TypeNotMatch);
+            }
+
+            return Err(TypeCheckFailReason::TypeNotMatchWithReason(
+                t!(
+                    "unknown member %{name}, in table",
+                    name = actual_key.to_path()
+                )
+                .to_string(),
+            ));
+        }
+    }
+
     Ok(())
+}
+
+fn member_key_accepted_by_index(
+    context: &mut TypeCheckContext,
+    source_members: &[LuaMemberInfo],
+    table_key: &LuaMemberKey,
+    check_guard: TypeCheckGuard,
+) -> Result<bool, TypeCheckFailReason> {
+    let Some(table_key_type) = member_key_type_for_index(table_key) else {
+        return Ok(false);
+    };
+
+    for source_member in source_members {
+        let LuaMemberKey::ExprType(index_key_type) = &source_member.key else {
+            continue;
+        };
+        match check_general_type_compact(
+            context,
+            index_key_type,
+            &table_key_type,
+            check_guard.next_level()?,
+        ) {
+            Ok(_) => return Ok(true),
+            Err(err) if err.is_type_not_match() => {}
+            Err(err) => return Err(err),
+        }
+    }
+
+    Ok(false)
 }
 
 fn get_object_field_type<'a>(

--- a/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
@@ -353,7 +353,9 @@ fn check_ref_type_compact_table(
         }
     }
 
-    if let Some(all_source_members) = find_members(context.db, &LuaType::Ref(source_type_id.clone()))
+    if !context.skip_excess_property_checks
+        && let Some(all_source_members) =
+            find_members(context.db, &LuaType::Ref(source_type_id.clone()))
         && !all_source_members.is_empty()
     {
         for table_key in table_member_map.keys() {

--- a/crates/glua_code_analysis/src/semantic/type_check/simple_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/simple_type.rs
@@ -315,8 +315,11 @@ pub fn check_simple_type_compact(
                 if let Some(decl) = context.db.get_type_index().get_type_decl(&base_id)
                     && decl.is_alias()
                 {
-                    let substitutor =
-                        TypeSubstitutor::from_alias(generic.get_params().clone(), base_id.clone());
+                    let substitutor = TypeSubstitutor::from_alias_for_type(
+                        context.db,
+                        generic.get_params().clone(),
+                        base_id.clone(),
+                    );
                     if let Some(alias_origin) =
                         decl.get_alias_origin(context.db, Some(&substitutor))
                     {

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -171,6 +171,47 @@ mod test {
     }
 
     #[test]
+    fn test_nominal_subtyping_is_directional() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@class Base
+
+        ---@class Derived: Base
+
+        ---@param value Base
+        function takes_base(value) end
+
+        ---@param value Derived
+        function takes_derived(value) end
+        "#,
+        );
+
+        let base = ws.ty("Base");
+        let derived = ws.ty("Derived");
+        assert!(ws.check_type(&base, &derived));
+        assert!(!ws.check_type(&derived, &base));
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@type Derived
+            local derived
+            takes_base(derived)
+        "#
+        ));
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@type Base
+            local base
+            takes_derived(base)
+        "#
+        ));
+    }
+
+    #[test]
     fn test_issue_790() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -190,7 +190,7 @@ mod test {
         "#,
         );
 
-        assert!(!ws.check_code_for(
+        assert!(ws.check_code_for(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type Holder<string>, NumberHolder

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -162,6 +162,26 @@ mod test {
     }
 
     #[test]
+    fn test_fresh_table_literal_excess_uses_union_target_properties() {
+        let mut ws = VirtualWorkspace::new();
+
+        let union_ty = ws.ty("{ a: integer } | { b: integer }");
+        let both_literal_ty = ws.expr_ty("{ a = 1, b = 2 }");
+        assert!(ws.check_type(&union_ty, &both_literal_ty));
+
+        let extra_literal_ty = ws.expr_ty("{ a = 1, c = 3 }");
+        assert!(!ws.check_type(&union_ty, &extra_literal_ty));
+
+        let discriminated_union_ty =
+            ws.ty("{ kind: 'a', a: integer } | { kind: 'b', b: integer }");
+        let matched_discriminant_literal_ty = ws.expr_ty("{ kind = 'a', a = 1, b = 2 }");
+        assert!(!ws.check_type(
+            &discriminated_union_ty,
+            &matched_discriminant_literal_ty
+        ));
+    }
+
+    #[test]
     fn test_array_types() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -212,6 +212,28 @@ mod test {
     }
 
     #[test]
+    fn test_primitive_subtyping_is_directional() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@class UserId: string
+
+        ---@class UnitKey: integer
+        "#,
+        );
+
+        let string_ty = ws.ty("string");
+        let user_id_ty = ws.ty("UserId");
+        assert!(ws.check_type(&string_ty, &user_id_ty));
+        assert!(!ws.check_type(&user_id_ty, &string_ty));
+
+        let integer_ty = ws.ty("integer");
+        let unit_key_ty = ws.ty("UnitKey");
+        assert!(ws.check_type(&integer_ty, &unit_key_ty));
+        assert!(!ws.check_type(&unit_key_ty, &integer_ty));
+    }
+
+    #[test]
     fn test_issue_790() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -190,7 +190,15 @@ mod test {
         "#,
         );
 
-        assert!(ws.check_code_for(
+        let holder_string = ws.ty("Holder<string>");
+        let string_holder_with_table = ws.ty("StringHolderWith<table>");
+        let number_holder = ws.ty("NumberHolder");
+        assert!(ws.check_type(&holder_string, &string_holder_with_table));
+        assert!(!ws.check_type(&string_holder_with_table, &holder_string));
+        assert!(!ws.check_type(&holder_string, &number_holder));
+        assert!(!ws.check_type(&number_holder, &holder_string));
+
+        assert!(!ws.check_code_for(
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@type Holder<string>, NumberHolder

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -111,6 +111,57 @@ mod test {
     }
 
     #[test]
+    fn test_bare_table_does_not_satisfy_required_structural_members() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@class Empty
+
+        ---@class Person
+        ---@field name string
+        "#,
+        );
+
+        let table_ty = ws.ty("table");
+
+        let empty_ty = ws.ty("Empty");
+        assert!(ws.check_type(&empty_ty, &table_ty));
+
+        let person_ty = ws.ty("Person");
+        assert!(!ws.check_type(&person_ty, &table_ty));
+
+        let object_ty = ws.ty("{ name: string }");
+        assert!(!ws.check_type(&object_ty, &table_ty));
+
+        let intersection_ty = ws.ty("{ name: string } & { age: integer }");
+        assert!(!ws.check_type(&intersection_ty, &table_ty));
+    }
+
+    #[test]
+    fn test_fresh_table_literal_reports_excess_structural_members() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+        ---@class Person
+        ---@field name string
+        "#,
+        );
+
+        let named_object_ty = ws.ty("{ name: string }");
+        let widened_extra_object_ty = ws.ty("{ name: string, age: integer }");
+        assert!(ws.check_type(&named_object_ty, &widened_extra_object_ty));
+
+        let extra_literal_ty = ws.expr_ty("{ name = 'Ada', age = 1 }");
+        assert!(!ws.check_type(&named_object_ty, &extra_literal_ty));
+
+        let empty_object_ty = ws.ty("{}");
+        assert!(ws.check_type(&empty_object_ty, &extra_literal_ty));
+
+        let person_ty = ws.ty("Person");
+        assert!(!ws.check_type(&person_ty, &extra_literal_ty));
+    }
+
+    #[test]
     fn test_array_types() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -117,7 +117,7 @@ mod test {
             r#"
         ---@class Empty
 
-        ---@class Person
+        ---@class (exact) Person
         ---@field name string
         "#,
         );
@@ -142,7 +142,7 @@ mod test {
         let mut ws = VirtualWorkspace::new();
         ws.def(
             r#"
-        ---@class Person
+        ---@class (exact) Person
         ---@field name string
         "#,
         );
@@ -172,13 +172,9 @@ mod test {
         let extra_literal_ty = ws.expr_ty("{ a = 1, c = 3 }");
         assert!(!ws.check_type(&union_ty, &extra_literal_ty));
 
-        let discriminated_union_ty =
-            ws.ty("{ kind: 'a', a: integer } | { kind: 'b', b: integer }");
+        let discriminated_union_ty = ws.ty("{ kind: 'a', a: integer } | { kind: 'b', b: integer }");
         let matched_discriminant_literal_ty = ws.expr_ty("{ kind = 'a', a = 1, b = 2 }");
-        assert!(!ws.check_type(
-            &discriminated_union_ty,
-            &matched_discriminant_literal_ty
-        ));
+        assert!(!ws.check_type(&discriminated_union_ty, &matched_discriminant_literal_ty));
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/semantic/type_check/type_check_context.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/type_check_context.rs
@@ -14,6 +14,7 @@ pub struct TypeCheckContext<'db> {
     pub db: &'db DbIndex,
     pub level: TypeCheckCheckLevel,
     pub table_member_checked: Option<HashSet<LuaMemberKey>>,
+    pub skip_excess_property_checks: bool,
 }
 
 impl<'db> TypeCheckContext<'db> {
@@ -23,6 +24,7 @@ impl<'db> TypeCheckContext<'db> {
             db,
             level,
             table_member_checked: None,
+            skip_excess_property_checks: false,
         }
     }
 

--- a/crates/glua_ls/src/handlers/hover/build_hover.rs
+++ b/crates/glua_ls/src/handlers/hover/build_hover.rs
@@ -797,6 +797,16 @@ fn adjust_semantic_decls(
         semantic_decls.push(item);
         return Some(());
     }
+
+    if is_function(current_type)
+        && !current_type.contain_tpl()
+        && semantic_decls.iter().any(|(_, typ)| typ.contain_tpl())
+    {
+        semantic_decls.clear();
+        semantic_decls.push((current_semantic_decl_id.clone(), current_type.clone()));
+        return Some(());
+    }
+
     // semantic_decls 是追溯最初定义的结果, 不包含当前内容
     let current_len = semantic_decls.len();
     if current_len == 0 {

--- a/crates/glua_ls/src/handlers/hover/function/mod.rs
+++ b/crates/glua_ls/src/handlers/hover/function/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, sync::Arc, vec};
 use glua_code_analysis::{
     AsyncState, DbIndex, InferGuard, LuaDocReturnInfo, LuaFunctionType, LuaMember, LuaMemberOwner,
     LuaSemanticDeclId, LuaType, RenderLevel, ReturnTypeKind, TypeSubstitutor, VariadicType,
-    humanize_type, infer_call_expr_func, instantiate_doc_function,
+    humanize_type, infer_call_expr_func, instantiate_type_generic,
     try_extract_signature_id_from_field,
 };
 
@@ -137,8 +137,8 @@ fn build_function_define_hover(
         };
 
         if let Some(substitutor) = &builder.substitutor {
-            if let Some(lua_func) = hover_instantiate_function_type(db, &typ, substitutor) {
-                typ = LuaType::DocFunction(lua_func);
+            if let Some(instantiated) = hover_instantiate_function_type(db, &typ, substitutor) {
+                typ = instantiated;
             }
         }
 
@@ -675,19 +675,16 @@ fn hover_instantiate_function_type(
     db: &DbIndex,
     typ: &LuaType,
     substitutor: &TypeSubstitutor,
-) -> Option<Arc<LuaFunctionType>> {
+) -> Option<LuaType> {
     if !typ.contain_tpl() {
         return None;
     }
-    match typ {
-        LuaType::DocFunction(f) => {
-            if let LuaType::DocFunction(f) = instantiate_doc_function(db, f, substitutor) {
-                Some(f)
-            } else {
-                None
-            }
-        }
-        _ => None,
+
+    let instantiated = instantiate_type_generic(db, typ, substitutor);
+    if is_function(&instantiated) {
+        Some(instantiated)
+    } else {
+        None
     }
 }
 

--- a/crates/glua_ls/src/handlers/hover/hover_builder.rs
+++ b/crates/glua_ls/src/handlers/hover/hover_builder.rs
@@ -1,6 +1,6 @@
 use glua_code_analysis::{
-    GenericTplId, GmodRealm, LuaCompilation, LuaMember, LuaMemberOwner, LuaSemanticDeclId, LuaType,
-    RenderLevel, SemanticModel, TypeSubstitutor,
+    GmodRealm, LuaCompilation, LuaMember, LuaMemberOwner, LuaSemanticDeclId, LuaType, RenderLevel,
+    SemanticModel, TypeSubstitutor,
 };
 use glua_parser::{
     LuaAstNode, LuaCallExpr, LuaExpr, LuaLocalName, LuaLocalStat, LuaSyntaxKind, LuaSyntaxToken,
@@ -407,12 +407,12 @@ pub fn substitutor_form_expr(
         let prefix_type = semantic_model
             .infer_expr(index_expr.get_prefix_expr()?)
             .ok()?;
-        let mut substitutor = TypeSubstitutor::new();
         if let LuaType::Generic(generic) = prefix_type {
-            for (i, param) in generic.get_params().iter().enumerate() {
-                substitutor.insert_type(GenericTplId::Type(i as u32), param.clone(), true);
-            }
-            return Some(substitutor);
+            return Some(TypeSubstitutor::from_type_array_for_type(
+                semantic_model.get_db(),
+                generic.get_base_type_id_ref(),
+                generic.get_params().clone(),
+            ));
         } else {
             return None;
         }

--- a/docs/generic-inference-roadmap.md
+++ b/docs/generic-inference-roadmap.md
@@ -38,15 +38,6 @@ Implemented behavior:
 - Same-list generic constraints now see later params, e.g. `T: U, U`.
 - Inline comments now mark the TS-Go-inspired inference rules without copying TS-Go comments verbatim.
 
-Last full generic verification:
-
-```bash
-cargo test -q -p glua_code_analysis
-# 1438 passed after 0dd5e96c
-```
-
-`1691d06b` was comment-only after that.
-
 ## Architecture State
 
 Current architecture is intentionally TS-inspired, not a full TS engine port.
@@ -88,9 +79,13 @@ Current side step:
 - Anonymous structural object targets and `(exact)` class targets keep fresh literal excess checks.
 - Non-fresh expressions use a no-excess relation path.
 - Superclass checks do not treat derived-class fields as excess.
-- `/workspaces/gmod/garrysmod` returned to the old 200-diagnostic local baseline.
+- Computed/index-like members now follow the TS split more closely:
+  - `LuaMemberKey::ExprType` is not treated as a required property;
+  - matching actual keys and index signatures are still checked against its value type;
+  - this mirrors the TS-Go separation between normal properties and `IndexInfo`.
+- Current workspace `glua_check` on `/workspaces/gmod/garrysmod` no longer reports the options `param-type-mismatch` false positive; the current local result is 4 warnings and 200 hints.
 
-Later: relation-engine work should become a separate refactor with a real freshness model, not part of the first generic inference phase.
+Later: relation-engine work should become a separate refactor with a real freshness/index-info model, not part of the first generic inference phase.
 
 ## Next Generic Work
 
@@ -112,6 +107,7 @@ Reason:
 
 - Generic inference is now mostly TS-like for current Lua needs.
 - Remaining warnings/regressions are more likely relation/assignability/freshness issues than generic inference issues.
+- The recent computed/index-like member fix is intentionally scoped; a cleaner long-term design would model TS-like index signatures explicitly instead of letting them live as ordinary members.
 - TS-like generic behavior will be easier to trust once assignability and excess/freshness behavior is more principled.
 
 Alternative next stage: audit `/workspaces/gmod/garrysmod` on the current checker and classify any new diagnostics against the new generic/relation behavior.

--- a/docs/generic-inference-roadmap.md
+++ b/docs/generic-inference-roadmap.md
@@ -1,0 +1,117 @@
+# TS-Like Generic Inference Roadmap
+
+Goal: keep moving Lua generic inference toward TypeScript/TypeScript-Go behavior, but only by focused, test-backed steps.
+
+Current status: generic inference phase 1 is effectively closed. The useful TS-like behavior for this project is mostly in place; future generic work should start from a concrete failing Lua-expressible case.
+
+## Phase 1 Summary
+
+The first TS-like generic inference phase is complete enough to stop and move to another target.
+
+Implemented behavior:
+
+- Scoped generic template ids, so nested class/function/alias generics do not collide by position.
+- `InferenceContext` now owns candidate collection, priorities, variance, constraints, and finalization.
+- `TypeSubstitutor` is now mostly a fixed-substitution mapper/backend, not the public inference engine.
+- Candidate priorities model TS-like direct, contextual-return, homomorphic mapped, partial homomorphic mapped, mapped constraint, and naked-union fallback inference.
+- Direct repeated candidates follow the TS-Go candidate-list/common-supertype shape:
+  - preserve leftmost candidate on conflicts;
+  - do not synthesize unrelated nominal ancestors;
+  - combine only where the priority implies combination.
+- Contextual return inference supports direct bindings, assignments, member/table-field contexts, overloads, union callables, metatable `__call`, and delayed callback parameters.
+- Function inference has co/contra candidate buckets:
+  - returns infer covariantly;
+  - parameters infer contravariantly;
+  - mixed co/contra selection follows TS-Go's `preferCovariantType` rule shape.
+- Reverse mapped inference supports common Lua-expressible TS shapes:
+  - homomorphic mapped tables;
+  - `Pick<T, K>`-style key constraints;
+  - mapped value fallback `{ [P in K]: V }`;
+  - optional fields;
+  - tuple and array sources;
+  - partial mapped candidates at weaker priority.
+- Conditional `infer` supports TS-like repeated candidates, source/pattern union matching, structural preference over naked fallback, and generic type-parameter constraints such as `Pair<T, U: T>`.
+- Generic constraints are applied during finalization:
+  - invalid speculative candidates fall back to the constraint;
+  - contextual-return unions can be filtered by the constraint;
+  - dependent constraints such as `U: T` can force co/contra fallback.
+- Same-list generic constraints now see later params, e.g. `T: U, U`.
+- Inline comments now mark the TS-Go-inspired inference rules without copying TS-Go comments verbatim.
+
+Last full generic verification:
+
+```bash
+cargo test -q -p glua_code_analysis
+# 1438 passed after 0dd5e96c
+```
+
+`1691d06b` was comment-only after that.
+
+## Architecture State
+
+Current architecture is intentionally TS-inspired, not a full TS engine port.
+
+Present:
+
+- `InferenceContext` owns active inference state.
+- Explicit APIs are used for candidate inference and fixed substitutions.
+- Candidate priority and variance are explicit.
+- Constraints are stored and applied during finalization.
+- Pure instantiation still takes `&TypeSubstitutor`.
+
+Not present yet:
+
+- Full TS mapper split: `mapper`, `nonFixingMapper`, `returnMapper`, backreference mapper.
+- Full TS inference flags/signature/compareTypes model.
+- Full TS conditional type engine.
+- Full TS relation/comparer/freshness model.
+
+Decision: the full mapper split is deferred until a focused failing case proves the local adaptations are not enough.
+
+## Relation Engine Boundary
+
+Relation-engine work is separate from the generic inference phase.
+
+Out of scope for phase 1:
+
+- real freshness model;
+- fresh vs non-fresh table literal tracking;
+- excess-property architecture;
+- broad `table` / open object behavior;
+- `isKnownProperty`-style member lookup;
+- structural relation cleanup beyond what directly blocks generic inference.
+
+Current side step:
+
+- Fresh table literal excess checks were narrowed to Lua-compatible TS-like behavior.
+- Normal `---@class` targets stay open for Lua dynamic extension.
+- Anonymous structural object targets and `(exact)` class targets keep fresh literal excess checks.
+- Non-fresh expressions use a no-excess relation path.
+- Superclass checks do not treat derived-class fields as excess.
+- `/workspaces/gmod/garrysmod` returned to the old 200-diagnostic local baseline.
+
+Later: relation-engine work should become a separate refactor with a real freshness model, not part of the first generic inference phase.
+
+## Next Generic Work
+
+Generic refactoring should resume only from a focused failing test in one of these areas:
+
+- a Lua-expressible case needing a real `nonFixingMapper` / `returnMapper` split;
+- contextual-return priority leaks outside delayed closure/callback paths;
+- callable/member-assignment/overload contextual inference edge not already covered;
+- adjacent variadic/rest split gaps that Lua syntax can express cleanly;
+- mapped/reverse-mapped edge where current priority or source reconstruction loses precision.
+
+If no focused failing case exists, consider phase 1 closed and move to another target.
+
+## Suggested Next Project Stage
+
+Best next stage: relation-engine/freshness model.
+
+Reason:
+
+- Generic inference is now mostly TS-like for current Lua needs.
+- Remaining warnings/regressions are more likely relation/assignability/freshness issues than generic inference issues.
+- TS-like generic behavior will be easier to trust once assignability and excess/freshness behavior is more principled.
+
+Alternative next stage: audit `/workspaces/gmod/garrysmod` on the current checker and classify any new diagnostics against the new generic/relation behavior.


### PR DESCRIPTION
this pr moves generic inference closer to typescript behavior by making InferenceContext own candidate collection, priorities, variance, constraints, and finalization. it adds ts-like contextual return inference, mapped/reverse-mapped inference, co/contra candidate handling, and conditional infer constraints.

it also documents the current state and next steps in docs/generic-inference-roadmap.md

this provides roughly 80% of a useful generic engine for Lua

**llm-assisted**