### PR TITLE
Fix usage and definition bug with functions assigned to variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,11 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             rust:
@@ -51,6 +51,7 @@ jobs:
               - '.github/workflows/build.yml'
 
   # Lightweight dev builds for every push/PR — Linux x64, Windows x64, and experimental macOS.
+  # glua_check is shipped only for Linux and Windows.
   build-dev:
     name: Dev Build (${{ matrix.platform }})
     needs: changes
@@ -66,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ startsWith(matrix.platform, 'darwin-') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install Rust toolchain
@@ -76,25 +77,33 @@ jobs:
         with:
           key: dev-${{ matrix.target }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Build
+      - name: Build language server
         run: |
           rustup target add ${{ matrix.target }}
-          cargo build --release --target ${{ matrix.target }} -p glua_ls -p glua_check
-      - name: Copy binary (Linux)
+          cargo build --release --target ${{ matrix.target }} -p glua_ls
+      - name: Build glua_check
+        if: ${{ !startsWith(matrix.platform, 'darwin-') }}
+        run: cargo build --release --target ${{ matrix.target }} -p glua_check
+      - name: Copy language server (Unix)
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
           mkdir -p ${{ github.workspace }}/artifact/
           cp ${{ github.workspace }}/target/${{ matrix.target }}/release/glua_ls ${{ github.workspace }}/artifact/glua_ls
-          cp ${{ github.workspace }}/target/${{ matrix.target }}/release/glua_check ${{ github.workspace }}/artifact/glua_check
-      - name: Copy binary (Windows)
+      - name: Copy glua_check (Linux)
+        if: ${{ matrix.os != 'windows-latest' && !startsWith(matrix.platform, 'darwin-') }}
+        run: cp ${{ github.workspace }}/target/${{ matrix.target }}/release/glua_check ${{ github.workspace }}/artifact/glua_check
+      - name: Copy binaries (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path "${{ github.workspace }}/artifact/"
           Copy-Item "${{ github.workspace }}/target/${{ matrix.target }}/release/glua_ls.exe" "${{ github.workspace }}/artifact/glua_ls.exe"
-          Copy-Item "${{ github.workspace }}/target/${{ matrix.target }}/release/glua_check.exe" "${{ github.workspace }}/artifact/glua_check.exe"
+      - name: Copy glua_check (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
+        run: Copy-Item "${{ github.workspace }}/target/${{ matrix.target }}/release/glua_check.exe" "${{ github.workspace }}/artifact/glua_check.exe"
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: glua_ls-${{ matrix.platform }}-dev
           path: ${{ github.workspace }}/artifact/
@@ -116,8 +125,6 @@ jobs:
           - { os: macos-15,       target: aarch64-apple-darwin,      platform: darwin-arm64-experimental, cross: general, crate: glua_ls, output: glua_ls }
           - { os: ubuntu-22.04,   target: x86_64-unknown-linux-gnu, platform: linux-x64, cross: general,  crate: glua_check, output: glua_check }
           - { os: windows-latest, target: x86_64-pc-windows-msvc,   platform: win32-x64, cross: general,  crate: glua_check, output: glua_check }
-          - { os: macos-15-intel, target: x86_64-apple-darwin,       platform: darwin-x64-experimental, cross: general, crate: glua_check, output: glua_check }
-          - { os: macos-15,       target: aarch64-apple-darwin,      platform: darwin-arm64-experimental, cross: general, crate: glua_check, output: glua_check }
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ contains(matrix.platform, 'darwin') }}
     steps:
@@ -156,7 +163,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install Rust toolchain
@@ -194,13 +201,13 @@ jobs:
           Copy-Item "${{ github.workspace }}/target/${{ matrix.target }}/release/${{ matrix.crate }}.exe" "${{ github.workspace }}/artifact/${{ matrix.output }}.exe"
       - name: Upload
         if: ${{ matrix.cross != 'zigbuild' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.output }}-${{ matrix.platform }}
           path: ${{ github.workspace }}/artifact/
       - name: Upload zigbuild
         if: ${{ matrix.cross == 'zigbuild' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.output }}-${{ matrix.platform }}-glibc.${{ matrix.glibc }}
           path: ${{ github.workspace }}/artifact/
@@ -222,7 +229,7 @@ jobs:
             echo "::error::CARGO_TOKEN is required for this publish-crates run."
             exit 1
           fi
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Install Rust toolchain
@@ -286,7 +293,7 @@ jobs:
       contents: write
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
       - name: Add execute permission and compress (Linux)
         run: |
           chmod +x glua_ls-linux-x64/glua_ls
@@ -315,8 +322,6 @@ jobs:
 
           package_macos_artifact glua_ls-darwin-x64-experimental glua_ls glua_ls-darwin-x64-experimental.tar.gz
           package_macos_artifact glua_ls-darwin-arm64-experimental glua_ls glua_ls-darwin-arm64-experimental.tar.gz
-          package_macos_artifact glua_check-darwin-x64-experimental glua_check glua_check-darwin-x64-experimental.tar.gz
-          package_macos_artifact glua_check-darwin-arm64-experimental glua_check glua_check-darwin-arm64-experimental.tar.gz
       - name: Compress (Windows)
         run: |
           cd glua_ls-win32-x64
@@ -378,8 +383,6 @@ jobs:
             "glua_check-linux-x64.tar.gz"
             "glua_ls-darwin-x64-experimental.tar.gz"
             "glua_ls-darwin-arm64-experimental.tar.gz"
-            "glua_check-darwin-x64-experimental.tar.gz"
-            "glua_check-darwin-arm64-experimental.tar.gz"
           )
 
           upload_assets=()

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply area label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const body = context.payload.issue.body ?? '';

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -24,7 +24,7 @@ jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -102,7 +102,7 @@ jobs:
           git push origin "${RELEASE_TAG}"
 
       - name: Dispatch build workflow for new tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,11 +21,11 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           filters: |
             rust:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install Rust toolchain with clippy
       uses: dtolnay/rust-toolchain@stable
       with:
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Rust cache
@@ -82,22 +82,22 @@ jobs:
             target: aarch64-apple-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
-      - name: Check macOS binaries
-        run: cargo check -p glua_ls -p glua_check --target ${{ matrix.target }}
+      - name: Check macOS language server
+        run: cargo check -p glua_ls --target ${{ matrix.target }}
 
   check-schema:
     name: Check schema generation
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain
       - name: Rust cache

--- a/crates/glua_code_analysis/src/compilation/test/decl_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/decl_test.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod test {
-    use crate::{DiagnosticCode, VirtualWorkspace};
+    use glua_parser::{LuaAstNode, LuaAstToken, LuaFuncStat, LuaVarExpr};
+    use googletest::prelude::*;
+
+    use crate::{DiagnosticCode, LuaType, VirtualWorkspace};
 
     #[test]
     fn test_1() {
@@ -54,5 +57,84 @@ mod test {
                 test(len)
         "#,
         ));
+    }
+
+    #[gtest]
+    fn forward_declared_function_name_uses_function_type_and_references() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+                local create_initial_simplex4
+
+                function create_initial_simplex4(points, thread_yield)
+                    return { points, thread_yield }
+                end
+
+                local faces = create_initial_simplex4({}, nil)
+            "#,
+        );
+
+        let func_stat = ws.get_node::<LuaFuncStat>(file_id);
+        let LuaVarExpr::NameExpr(func_name) =
+            func_stat.get_func_name().expect("expected function name")
+        else {
+            panic!("expected plain function name");
+        };
+        let token = func_name.get_name_token().expect("expected name token");
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("expected semantic model");
+        let info = semantic_model
+            .get_semantic_info(token.syntax().clone().into())
+            .expect("expected semantic info for function name");
+
+        assert_that!(info.typ, matches_pattern!(LuaType::Signature(_)));
+
+        let call_name = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .expect("expected syntax tree")
+            .get_chunk_node()
+            .descendants::<glua_parser::LuaCallExpr>()
+            .find_map(|call_expr| match call_expr.get_prefix_expr()? {
+                glua_parser::LuaExpr::NameExpr(name_expr)
+                    if name_expr.get_name_text().as_deref() == Some("create_initial_simplex4") =>
+                {
+                    Some(name_expr)
+                }
+                _ => None,
+            })
+            .expect("expected call to forward-declared function");
+        let call_token = call_name
+            .get_name_token()
+            .expect("expected call name token");
+        let call_info = semantic_model
+            .get_semantic_info(call_token.syntax().clone().into())
+            .expect("expected semantic info for call name");
+
+        assert_that!(call_info.typ, matches_pattern!(LuaType::Signature(_)));
+
+        let decl_id = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_reference_index()
+            .get_local_reference(&file_id)
+            .and_then(|refs| refs.get_decl_id(&func_name.get_range()))
+            .expect("expected function name to resolve to forward local");
+        let references = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_reference_index()
+            .get_decl_references(&file_id, &decl_id)
+            .expect("expected references for forward local");
+
+        assert_that!(references.cells.len(), ge(2));
     }
 }

--- a/crates/glua_code_analysis/src/semantic/infer/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/mod.rs
@@ -454,6 +454,17 @@ pub fn infer_bind_value_type(
             }
             typ
         }
+        LuaAst::LuaFuncStat(func_stat) => {
+            let func_name = func_stat.get_func_name()?;
+            let func_expr: LuaExpr = func_name.into();
+            if expr != func_expr {
+                return None;
+            }
+
+            let signature_id =
+                LuaSignatureId::from_closure(cache.get_file_id(), &func_stat.get_closure()?);
+            Some(LuaType::Signature(signature_id))
+        }
         LuaAst::LuaTableField(table_field) => {
             let field_key = table_field.get_field_key()?;
             let table_expr = table_field.get_parent::<LuaTableExpr>()?;

--- a/crates/glua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -326,6 +326,17 @@ fn get_type_at_flow_walk(
                 };
 
                 if ref_id == *var_ref_id {
+                    if matches!(var_ref_id, VarRefId::VarRef(_)) {
+                        let Some(closure) = func_stat.get_closure() else {
+                            return Err(InferFailReason::None);
+                        };
+
+                        return Ok(LuaType::Signature(LuaSignatureId::from_closure(
+                            cache.get_file_id(),
+                            &closure,
+                        )));
+                    }
+
                     // Only use the func-stat's signature when the member isn't
                     // already declared (origin type is Nil). For Def types with
                     // @field annotations, let the flow continue so the declared

--- a/crates/glua_ls/src/handlers/code_lens/build_code_lens.rs
+++ b/crates/glua_ls/src/handlers/code_lens/build_code_lens.rs
@@ -100,7 +100,12 @@ fn add_func_stat_code_lens(
         }
         LuaVarExpr::NameExpr(name_expr) => {
             let name_token = name_expr.get_name_token()?;
-            let decl_id = LuaDeclId::new(file_id, name_token.get_position());
+            let decl_id = semantic_model
+                .get_db()
+                .get_reference_index()
+                .get_local_reference(&file_id)
+                .and_then(|refs| refs.get_decl_id(&name_expr.get_range()))
+                .unwrap_or_else(|| LuaDeclId::new(file_id, name_token.get_position()));
             let data = CodeLensResolveData {
                 uri: Some(document.get_uri().clone()),
                 payload: CodeLensData::DeclId(decl_id),
@@ -370,6 +375,50 @@ fn add_net_call_code_lens(
     });
 
     Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use glua_code_analysis::VirtualWorkspace;
+    use glua_parser::{LuaAstNode, LuaLocalName};
+    use googletest::prelude::*;
+
+    use super::build_code_lens;
+    use crate::handlers::code_lens::{CodeLensData, CodeLensResolveData};
+
+    #[gtest]
+    fn function_code_lens_uses_forward_local_decl_id() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+                local create_initial_simplex4
+
+                function create_initial_simplex4(points, thread_yield)
+                    return { points, thread_yield }
+                end
+
+                local faces = create_initial_simplex4({}, nil)
+            "#,
+        );
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("expected semantic model");
+        let lenses = build_code_lens(&semantic_model).expect("expected code lenses");
+        let data = lenses
+            .iter()
+            .filter_map(|lens| lens.data.as_ref())
+            .find_map(|value| serde_json::from_value::<CodeLensResolveData>(value.clone()).ok())
+            .expect("expected function code lens data");
+        let local_name = ws.get_node::<LuaLocalName>(file_id);
+        let expected_decl = glua_code_analysis::LuaDeclId::new(file_id, local_name.get_position());
+
+        let CodeLensData::DeclId(actual_decl) = data.payload else {
+            panic!("expected declaration code lens");
+        };
+        assert_that!(actual_decl, eq(expected_decl));
+    }
 }
 
 /// Picks the label for a `net.Start` lens. Looks up the indexed send flow

--- a/crates/glua_ls/src/handlers/code_lens/build_code_lens.rs
+++ b/crates/glua_ls/src/handlers/code_lens/build_code_lens.rs
@@ -377,50 +377,6 @@ fn add_net_call_code_lens(
     Some(())
 }
 
-#[cfg(test)]
-mod tests {
-    use glua_code_analysis::VirtualWorkspace;
-    use glua_parser::{LuaAstNode, LuaLocalName};
-    use googletest::prelude::*;
-
-    use super::build_code_lens;
-    use crate::handlers::code_lens::{CodeLensData, CodeLensResolveData};
-
-    #[gtest]
-    fn function_code_lens_uses_forward_local_decl_id() {
-        let mut ws = VirtualWorkspace::new();
-        let file_id = ws.def(
-            r#"
-                local create_initial_simplex4
-
-                function create_initial_simplex4(points, thread_yield)
-                    return { points, thread_yield }
-                end
-
-                local faces = create_initial_simplex4({}, nil)
-            "#,
-        );
-        let semantic_model = ws
-            .analysis
-            .compilation
-            .get_semantic_model(file_id)
-            .expect("expected semantic model");
-        let lenses = build_code_lens(&semantic_model).expect("expected code lenses");
-        let data = lenses
-            .iter()
-            .filter_map(|lens| lens.data.as_ref())
-            .find_map(|value| serde_json::from_value::<CodeLensResolveData>(value.clone()).ok())
-            .expect("expected function code lens data");
-        let local_name = ws.get_node::<LuaLocalName>(file_id);
-        let expected_decl = glua_code_analysis::LuaDeclId::new(file_id, local_name.get_position());
-
-        let CodeLensData::DeclId(actual_decl) = data.payload else {
-            panic!("expected declaration code lens");
-        };
-        assert_that!(actual_decl, eq(expected_decl));
-    }
-}
-
 /// Picks the label for a `net.Start` lens. Looks up the indexed send flow
 /// originating at this call site and uses the actual transport call name
 /// (e.g. `net.SendToServer`) so the lens reflects the realm/recipients
@@ -518,5 +474,49 @@ fn resolve_receive_kind_label(semantic_model: &SemanticModel, call_expr: &LuaCal
         fallback
     } else {
         kinds.join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use glua_code_analysis::VirtualWorkspace;
+    use glua_parser::{LuaAstNode, LuaLocalName};
+    use googletest::prelude::*;
+
+    use super::build_code_lens;
+    use crate::handlers::code_lens::{CodeLensData, CodeLensResolveData};
+
+    #[gtest]
+    fn function_code_lens_uses_forward_local_decl_id() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+                local create_initial_simplex4
+
+                function create_initial_simplex4(points, thread_yield)
+                    return { points, thread_yield }
+                end
+
+                local faces = create_initial_simplex4({}, nil)
+            "#,
+        );
+        let semantic_model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("expected semantic model");
+        let lenses = build_code_lens(&semantic_model).expect("expected code lenses");
+        let data = lenses
+            .iter()
+            .filter_map(|lens| lens.data.as_ref())
+            .find_map(|value| serde_json::from_value::<CodeLensResolveData>(value.clone()).ok())
+            .expect("expected function code lens data");
+        let local_name = ws.get_node::<LuaLocalName>(file_id);
+        let expected_decl = glua_code_analysis::LuaDeclId::new(file_id, local_name.get_position());
+
+        let CodeLensData::DeclId(actual_decl) = data.payload else {
+            panic!("expected declaration code lens");
+        };
+        assert_that!(actual_decl, eq(expected_decl));
     }
 }

--- a/crates/glua_ls/src/handlers/code_lens/resolve_code_lens.rs
+++ b/crates/glua_ls/src/handlers/code_lens/resolve_code_lens.rs
@@ -4,7 +4,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::{
     context::ClientId,
-    handlers::references::{search_decl_references, search_member_references},
+    handlers::references::{search_decl_usages, search_member_references},
 };
 
 use super::{CodeLensData, CodeLensResolveData};
@@ -50,14 +50,7 @@ pub fn resolve_code_lens(
             let file_id = decl_id.file_id;
             let semantic_model = compilation.get_semantic_model(file_id)?;
             let mut results = Vec::new();
-            search_decl_references(
-                &semantic_model,
-                compilation,
-                decl_id,
-                &mut results,
-                cancel_token,
-                true,
-            );
+            search_decl_usages(compilation, decl_id, &mut results, cancel_token);
             let ref_count = results.len();
             let uri = semantic_model.get_document().get_uri();
             let command = make_usage_command(uri, code_lens.range, ref_count, client_id, results);

--- a/crates/glua_ls/src/handlers/definition/goto_def_definition.rs
+++ b/crates/glua_ls/src/handlers/definition/goto_def_definition.rs
@@ -2,11 +2,12 @@ use std::str::FromStr;
 
 use glua_code_analysis::{
     LuaCompilation, LuaDeclId, LuaMemberId, LuaMemberInfo, LuaMemberKey, LuaMemberOwner,
-    LuaSemanticDeclId, LuaType, LuaTypeDeclId, SemanticDeclLevel, SemanticModel,
+    LuaSemanticDeclId, LuaSignatureId, LuaType, LuaTypeDeclId, SemanticDeclLevel, SemanticModel,
 };
 use glua_parser::{
-    LuaAstNode, LuaAstToken, LuaCallExpr, LuaExpr, LuaIndexExpr, LuaReturnStat, LuaStringToken,
-    LuaSyntaxKind, LuaSyntaxToken, LuaTableExpr, LuaTableField,
+    LuaAstNode, LuaAstToken, LuaCallExpr, LuaExpr, LuaFuncStat, LuaIndexExpr, LuaLocalFuncStat,
+    LuaReturnStat, LuaStringToken, LuaSyntaxKind, LuaSyntaxToken, LuaTableExpr, LuaTableField,
+    LuaVarExpr,
 };
 use itertools::Itertools;
 use lsp_types::{GotoDefinitionResponse, Location, Position, Range, Uri};
@@ -67,9 +68,23 @@ fn handle_decl_definition(
         find_function_call_origin(semantic_model, compilation, trigger_token, property_owner)
         && let LuaSemanticDeclId::LuaDecl(matched_decl_id) = match_semantic_decl
     {
+        if let Some(signature_id) = trigger_token_signature_id(semantic_model, trigger_token)
+            && signature_id.get_file_id() == decl_id.file_id
+            && let Some(location) = get_signature_definition_location(semantic_model, &signature_id)
+        {
+            return Some(GotoDefinitionResponse::Scalar(location));
+        }
+
         if let Some(location) = get_decl_location(semantic_model, &matched_decl_id) {
             return Some(GotoDefinitionResponse::Scalar(location));
         }
+    }
+
+    if let Some(signature_id) = trigger_token_signature_id(semantic_model, trigger_token)
+        && signature_id.get_file_id() == decl_id.file_id
+        && let Some(location) = get_signature_definition_location(semantic_model, &signature_id)
+    {
+        return Some(GotoDefinitionResponse::Scalar(location));
     }
 
     // 返回声明的位置
@@ -85,6 +100,54 @@ fn handle_decl_definition(
         && let Some(location) = get_decl_location(semantic_model, &decl_id)
     {
         return Some(GotoDefinitionResponse::Scalar(location));
+    }
+
+    None
+}
+
+fn trigger_token_signature_id(
+    semantic_model: &SemanticModel,
+    trigger_token: &LuaSyntaxToken,
+) -> Option<LuaSignatureId> {
+    match semantic_model
+        .get_semantic_info(trigger_token.clone().into())?
+        .typ
+    {
+        LuaType::Signature(signature_id) => Some(signature_id),
+        _ => None,
+    }
+}
+
+fn get_signature_definition_location(
+    semantic_model: &SemanticModel,
+    signature_id: &LuaSignatureId,
+) -> Option<Location> {
+    let root = semantic_model.get_root_by_file_id(signature_id.get_file_id())?;
+    let token = match root.syntax().token_at_offset(signature_id.get_position()) {
+        rowan::TokenAtOffset::Single(token) => token,
+        rowan::TokenAtOffset::Between(left, _) => left,
+        rowan::TokenAtOffset::None => return None,
+    };
+
+    for ancestor in token.parent_ancestors() {
+        if let Some(func_stat) = LuaFuncStat::cast(ancestor.clone()) {
+            let func_name = func_stat.get_func_name()?;
+            let range = match func_name {
+                LuaVarExpr::NameExpr(name_expr) => name_expr.get_name_token()?.get_range(),
+                LuaVarExpr::IndexExpr(index_expr) => index_expr
+                    .get_index_name_token()
+                    .map(|token| token.text_range())
+                    .unwrap_or_else(|| index_expr.get_range()),
+            };
+            let document = semantic_model.get_document_by_file_id(signature_id.get_file_id())?;
+            return document.to_lsp_location(range);
+        }
+
+        if let Some(local_func_stat) = LuaLocalFuncStat::cast(ancestor) {
+            let local_name = local_func_stat.get_local_name()?;
+            let document = semantic_model.get_document_by_file_id(signature_id.get_file_id())?;
+            return document.to_lsp_location(local_name.get_range());
+        }
     }
 
     None

--- a/crates/glua_ls/src/handlers/references/mod.rs
+++ b/crates/glua_ls/src/handlers/references/mod.rs
@@ -7,7 +7,9 @@ use lsp_types::{
     ClientCapabilities, Location, OneOf, Position, ReferenceParams, ServerCapabilities,
 };
 use reference_searcher::search_references;
-pub use reference_searcher::{search_decl_references, search_member_references};
+pub use reference_searcher::{
+    search_decl_references, search_decl_usages, search_member_references,
+};
 use rowan::TokenAtOffset;
 use tokio_util::sync::CancellationToken;
 

--- a/crates/glua_ls/src/handlers/references/reference_searcher.rs
+++ b/crates/glua_ls/src/handlers/references/reference_searcher.rs
@@ -25,6 +25,7 @@ struct ReferenceSearchContext {
     visited_module_exports: HashSet<FileId>,
     visited_semantic_ids: HashSet<LuaSemanticDeclId>,
     include_declaration: bool,
+    include_write_references: bool,
     /// Tracks whether we are still processing the starting symbol (vs secondary
     /// symbols enqueued from the worklist).  Used to honour LSP
     /// `includeDeclaration` semantics: only the starting symbol's own
@@ -111,6 +112,7 @@ pub fn search_decl_references_with_token(
 ) -> Option<()> {
     let mut ctx = ReferenceSearchContext {
         include_declaration,
+        include_write_references: true,
         is_starting_symbol: true,
         ..Default::default()
     };
@@ -157,6 +159,30 @@ pub fn search_decl_references(
 ) -> Option<()> {
     let mut ctx = ReferenceSearchContext {
         include_declaration,
+        include_write_references: true,
+        is_starting_symbol: true,
+        ..Default::default()
+    };
+    let mut semantic_cache = HashMap::new();
+    search_semantic_references_with_ctx(
+        &mut ctx,
+        compilation,
+        &mut semantic_cache,
+        LuaSemanticDeclId::LuaDecl(decl_id),
+        result,
+        cancel_token,
+    )
+}
+
+pub fn search_decl_usages(
+    compilation: &LuaCompilation,
+    decl_id: LuaDeclId,
+    result: &mut Vec<Location>,
+    cancel_token: &CancellationToken,
+) -> Option<()> {
+    let mut ctx = ReferenceSearchContext {
+        include_declaration: false,
+        include_write_references: false,
         is_starting_symbol: true,
         ..Default::default()
     };
@@ -191,8 +217,8 @@ fn search_decl_references_with_ctx<'a>(
             .get_decl_references(&decl_id.file_id, &decl_id)?;
         let document = semantic_model.get_document();
         // 加入自己 (only for the starting symbol when include_declaration is true,
-        // or always for secondary symbols from the worklist)
-        if ctx.include_declaration || !ctx.is_starting_symbol {
+        // or for secondary symbols when write/reference locations are requested)
+        if ctx.include_declaration || (!ctx.is_starting_symbol && ctx.include_write_references) {
             if let Some(location) = document.to_lsp_location(decl.get_range()) {
                 result.push(location);
             }
@@ -208,11 +234,14 @@ fn search_decl_references_with_ctx<'a>(
         );
 
         for decl_ref in &decl_refs.cells {
-            let location = document.to_lsp_location(decl_ref.range)?;
-            result.push(location);
             if should_follow_value_alias {
                 let _ = enqueue_value_alias_references(ctx, semantic_model, decl_ref, worklist);
             }
+            if !ctx.include_write_references && decl_ref.is_write {
+                continue;
+            }
+            let location = document.to_lsp_location(decl_ref.range)?;
+            result.push(location);
         }
 
         let _ = extend_module_return_value_references(
@@ -273,6 +302,7 @@ pub fn search_member_references(
 ) -> Option<()> {
     let mut ctx = ReferenceSearchContext {
         include_declaration,
+        include_write_references: true,
         is_starting_symbol: true,
         ..Default::default()
     };
@@ -372,7 +402,9 @@ fn search_member_references_with_ctx<'a>(
 
     // If include_declaration is true (or secondary symbol) and the declaration
     // was not found in the reference loop, add it now.
-    if !decl_found_in_loop && (ctx.include_declaration || !ctx.is_starting_symbol) {
+    if !decl_found_in_loop
+        && (ctx.include_declaration || (!ctx.is_starting_symbol && ctx.include_write_references))
+    {
         if let Some(loc) = decl_location {
             result.push(loc);
         }
@@ -399,9 +431,11 @@ fn search_member_secondary_references(
             let var = vars.get(idx)?;
             let decl_id = LuaDeclId::new(semantic_model.get_file_id(), var.get_position());
             enqueue_semantic_id(ctx, worklist, LuaSemanticDeclId::LuaDecl(decl_id));
-            let document = semantic_model.get_document();
-            let range = document.to_lsp_location(var.get_range())?;
-            result.push(range);
+            if ctx.include_write_references {
+                let document = semantic_model.get_document();
+                let range = document.to_lsp_location(var.get_range())?;
+                result.push(range);
+            }
         }
         LuaAst::LuaLocalStat(local_stat) => {
             let local_names = local_stat.get_local_name_list().collect::<Vec<_>>();
@@ -410,9 +444,11 @@ fn search_member_secondary_references(
             let name = local_names.get(idx)?;
             let decl_id = LuaDeclId::new(semantic_model.get_file_id(), name.get_position());
             enqueue_semantic_id(ctx, worklist, LuaSemanticDeclId::LuaDecl(decl_id));
-            let document = semantic_model.get_document();
-            let range = document.to_lsp_location(name.get_range())?;
-            result.push(range);
+            if ctx.include_write_references {
+                let document = semantic_model.get_document();
+                let range = document.to_lsp_location(name.get_range())?;
+                result.push(range);
+            }
         }
         _ => {}
     }
@@ -944,9 +980,9 @@ fn search_semantic_references_with_ctx<'a>(
             _ => Some(()),
         };
 
-        // After the first iteration, we are no longer processing the
-        // starting symbol, so secondary symbol declarations are always
-        // included regardless of include_declaration.
+        // After the first iteration, we are no longer processing the starting
+        // symbol. Broad reference searches include secondary declarations;
+        // usage searches still traverse them but omit declaration/write ranges.
         if ctx.is_starting_symbol {
             ctx.is_starting_symbol = false;
             start_ret = ret;

--- a/crates/glua_ls/src/handlers/test/definition_test.rs
+++ b/crates/glua_ls/src/handlers/test/definition_test.rs
@@ -389,6 +389,27 @@ mod tests {
     }
 
     #[gtest]
+    fn test_goto_forward_declared_function_call_prefers_function_definition() -> Result<()> {
+        let mut ws = ProviderVirtualWorkspace::new();
+        check!(ws.check_definition(
+            r#"
+                local create_initial_simplex4
+
+                function create_initial_simplex4(points, thread_yield)
+                    return { points, thread_yield }
+                end
+
+                local faces = create_initial_simplex4<??>({}, nil)
+            "#,
+            vec![Expected {
+                file: "".to_string(),
+                line: 3,
+            }]
+        ));
+        Ok(())
+    }
+
+    #[gtest]
     fn test_goto_export_function_2() -> Result<()> {
         let mut ws = ProviderVirtualWorkspace::new();
         ws.def_file(

--- a/crates/glua_ls/src/handlers/test/references_test.rs
+++ b/crates/glua_ls/src/handlers/test/references_test.rs
@@ -2,9 +2,10 @@
 mod tests {
     use std::collections::HashSet;
 
-    use crate::handlers::references::references;
+    use crate::handlers::references::{references, search_decl_usages};
     use crate::handlers::test_lib::{ProviderVirtualWorkspace, VirtualLocation, check};
-    use glua_code_analysis::Emmyrc;
+    use glua_code_analysis::{Emmyrc, LuaDeclId};
+    use glua_parser::{LuaAstNode, LuaLocalFuncStat, LuaLocalName};
     use googletest::prelude::*;
     use tokio_util::sync::CancellationToken;
 
@@ -109,6 +110,90 @@ mod tests {
                 },
             ]
         ));
+        Ok(())
+    }
+
+    #[gtest]
+    fn test_decl_usages_excludes_forward_declaration_and_function_definition() -> Result<()> {
+        let mut ws = ProviderVirtualWorkspace::new();
+        let file_id = ws.def(
+            r#"
+                local create_initial_simplex4
+
+                function create_initial_simplex4(points, thread_yield)
+                    return { points, thread_yield }
+                end
+
+                local faces = create_initial_simplex4({}, nil)
+            "#,
+        );
+        let semantic_model = check!(ws.analysis.compilation.get_semantic_model(file_id));
+        let local_name = check!(
+            semantic_model
+                .get_root()
+                .descendants::<LuaLocalName>()
+                .next()
+        );
+        let decl_id = LuaDeclId::new(file_id, local_name.get_position());
+
+        let mut results = Vec::new();
+        check!(search_decl_usages(
+            &ws.analysis.compilation,
+            decl_id,
+            &mut results,
+            &CancellationToken::new()
+        ));
+
+        assert_that!(results.len(), eq(1));
+        assert_that!(results[0].range.start.line, eq(7));
+        Ok(())
+    }
+
+    #[gtest]
+    fn test_decl_usages_traverses_module_alias_without_counting_alias_binding() -> Result<()> {
+        let mut ws = ProviderVirtualWorkspace::new();
+        let module_file_id = ws.def_file(
+            "a.lua",
+            r#"
+                local function init()
+                end
+
+                return init
+            "#,
+        );
+        ws.def_file(
+            "consumer.lua",
+            r#"
+                local init = require("a")
+                init()
+            "#,
+        );
+        let semantic_model = check!(ws.analysis.compilation.get_semantic_model(module_file_id));
+        let local_func = check!(
+            semantic_model
+                .get_root()
+                .descendants::<LuaLocalFuncStat>()
+                .next()
+        );
+        let local_name = check!(local_func.get_local_name());
+        let decl_id = LuaDeclId::new(module_file_id, local_name.get_position());
+
+        let mut results = Vec::new();
+        check!(search_decl_usages(
+            &ws.analysis.compilation,
+            decl_id,
+            &mut results,
+            &CancellationToken::new()
+        ));
+
+        let consumer_lines = results
+            .iter()
+            .filter(|location| location.uri.to_string().contains("consumer.lua"))
+            .map(|location| location.range.start.line)
+            .collect::<HashSet<_>>();
+
+        assert_that!(consumer_lines.contains(&2), eq(true));
+        assert_that!(consumer_lines.contains(&1), eq(false));
         Ok(())
     }
 


### PR DESCRIPTION
Fixes a bug where if a function was assigned to a previously defined variable, usage and definition would be broken.

Fixes:
- Fix functions definition signature binding to local variables rather than actual definition.
- Fix "goto definition" going to variable definition rather than function definition.
- Fix usages count showing all references rather than just function usages.