### PR TITLE
Respect explicit annotation authority during inference cache refresh

### DIFF
--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/type_ref_tags.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/type_ref_tags.rs
@@ -245,6 +245,20 @@ pub fn analyze_param(analyzer: &mut DocAnalyzer, tag: LuaDocTagParam) -> Option<
         let idx = signature.find_param_idx(&name)?;
 
         signature.param_docs.insert(idx, param_info);
+        if let Some(param_token) = closure
+            .get_params_list()
+            .into_iter()
+            .flat_map(|params| params.get_params())
+            .filter_map(|param| param.get_name_token())
+            .find(|token| token.get_name_text() == name)
+        {
+            write_type_cache(
+                analyzer.db,
+                LuaDeclId::new(analyzer.file_id, param_token.get_position()).into(),
+                LuaTypeCache::DocType(type_ref),
+                TypeCacheWriteMode::ForceOverwrite,
+            );
+        }
     } else if let Some(LuaAst::LuaForRangeStat(for_range)) = analyzer.comment.get_owner() {
         // for in 支持 @param 语法
         for it_name_token in for_range.get_var_name_list() {

--- a/crates/glua_code_analysis/src/compilation/analyzer/mod.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/mod.rs
@@ -21,11 +21,13 @@ use std::{
 
 use crate::{
     AsyncState, FileId, GmodScopedClassInfo, InFiled, InferFailReason, LuaDeclId, LuaDefinitionId,
-    LuaFunctionType, LuaInferredGuardOwner, LuaMember, LuaMemberFeature, LuaMemberId, LuaMemberKey,
-    LuaSignatureId, LuaType, LuaTypeCache, LuaTypeDeclId, LuaTypeFact, LuaTypeOwner, WorkspaceId,
+    LuaFunctionType, LuaInferenceNodeId, LuaInferredGuardOwner, LuaMember, LuaMemberFeature,
+    LuaMemberId, LuaMemberKey, LuaSignatureId, LuaType, LuaTypeCache, LuaTypeDeclId, LuaTypeFact,
+    LuaTypeOwner, WorkspaceId,
     compilation::analyzer::common::{TypeCacheWriteMode, write_type_cache},
     db_index::{DbIndex, LuaMemberOwner},
     profile::Profile,
+    semantic::infer_expr_fact_with_cache,
 };
 use glua_parser::{
     LuaAstNode, LuaCallExpr, LuaChunk, LuaClosureExpr, LuaExpr, LuaNameExpr, LuaSyntaxId,
@@ -290,6 +292,12 @@ fn refresh_local_decl_initializer_caches(db: &mut DbIndex, context: &mut Analyze
                 continue;
             }
             let current_is_uninformative = type_cache_is_uninformative(current_cache.as_ref());
+            let current_fact = db.get_type_index().get_type_fact(&type_owner);
+            let target_node = LuaInferenceNodeId::TypeOwner(type_owner.clone());
+            let can_upgrade_authority = current_fact.as_ref().is_some_and(|fact| {
+                fact.base_provenance_kind()
+                    != Some(crate::LuaInferenceProvenanceKind::ExplicitAnnotation)
+            });
             let can_refine_nominal_type = !current_is_uninformative
                 && db.get_emmyrc().gmod.enabled
                 && current_cache
@@ -299,7 +307,7 @@ fn refresh_local_decl_initializer_caches(db: &mut DbIndex, context: &mut Analyze
                     .get_reference_index()
                     .get_decl_references(&decl_id.file_id, decl_id)
                     .is_none_or(|references| !references.mutable);
-            if !current_is_uninformative && !can_refine_nominal_type {
+            if !current_is_uninformative && !can_refine_nominal_type && !can_upgrade_authority {
                 continue;
             }
 
@@ -309,35 +317,49 @@ fn refresh_local_decl_initializer_caches(db: &mut DbIndex, context: &mut Analyze
             if !matches!(expr, LuaExpr::CallExpr(_) | LuaExpr::IndexExpr(_)) {
                 continue;
             }
-            let Ok(mut inferred_type) = crate::infer_expr(db, &mut infer_cache, expr) else {
+            let inferred_fact = select_result_fact(
+                infer_expr_fact_with_cache(db, &mut infer_cache, expr),
+                ret_idx,
+            );
+            let inferred_type = inferred_fact.typ().clone();
+            if type_is_uninformative(&inferred_type) {
                 continue;
-            };
-            if let LuaType::Variadic(variadic) = inferred_type {
-                inferred_type = variadic.get_type(ret_idx).cloned().unwrap_or(LuaType::Nil);
-            } else if ret_idx != 0 {
-                inferred_type = LuaType::Nil;
             }
-            if type_is_uninformative(&inferred_type)
-                || current_cache
-                    .as_ref()
-                    .is_some_and(|current| current.as_type() == &inferred_type)
+            if current_cache
+                .as_ref()
+                .is_some_and(|current| current.as_type() == &inferred_type)
             {
+                if current_fact.as_ref().is_some_and(|current| {
+                    inferred_fact.has_independently_stronger_authority_than(current, &target_node)
+                }) {
+                    result.updates.push(InitializerCacheUpdate::ReplaceFact {
+                        owner: type_owner,
+                        fact: inferred_fact,
+                    });
+                }
                 continue;
             }
 
+            let has_stronger_declared_authority = can_upgrade_authority
+                && current_fact.as_ref().is_some_and(|current| {
+                    inferred_fact.base_provenance_kind()
+                        == Some(crate::LuaInferenceProvenanceKind::ExplicitAnnotation)
+                        && inferred_fact
+                            .has_independently_stronger_authority_than(current, &target_node)
+                });
+            let is_nominal_refinement = can_refine_nominal_type
+                && current_cache.as_ref().is_some_and(|current| {
+                    is_strict_nominal_refinement(db, &inferred_type, current.as_type())
+                });
             if current_is_uninformative {
                 result.updates.push(InitializerCacheUpdate::Bind {
                     owner: type_owner,
-                    inferred_type,
+                    fact: inferred_fact,
                 });
-            } else if can_refine_nominal_type
-                && current_cache.as_ref().is_some_and(|current| {
-                    is_strict_nominal_refinement(db, &inferred_type, current.as_type())
-                })
-            {
+            } else if has_stronger_declared_authority || is_nominal_refinement {
                 result.updates.push(InitializerCacheUpdate::Overwrite {
                     owner: type_owner,
-                    inferred_type,
+                    fact: inferred_fact,
                 });
             }
         }
@@ -346,14 +368,16 @@ fn refresh_local_decl_initializer_caches(db: &mut DbIndex, context: &mut Analyze
         result
     });
 
+    let mut updates = Vec::new();
     for result in results {
         context.infer_manager.merge_inference_side_effects(
             result.file_id,
             result.pending_type_decls,
             result.guard_dependencies,
         );
-        apply_initializer_cache_updates(db, result.updates);
+        updates.extend(result.updates);
     }
+    apply_initializer_cache_updates(db, updates);
 }
 
 fn refresh_member_initializer_caches(db: &mut DbIndex, context: &mut AnalyzeContext) {
@@ -409,7 +433,7 @@ fn refresh_member_initializer_caches(db: &mut DbIndex, context: &mut AnalyzeCont
 
             result.updates.push(InitializerCacheUpdate::Overwrite {
                 owner: type_owner,
-                inferred_type,
+                fact: LuaTypeFact::certain(inferred_type),
             });
         }
         result.pending_type_decls = infer_cache.take_pending_str_tpl_type_decls();
@@ -417,14 +441,16 @@ fn refresh_member_initializer_caches(db: &mut DbIndex, context: &mut AnalyzeCont
         result
     });
 
+    let mut updates = Vec::new();
     for result in results {
         context.infer_manager.merge_inference_side_effects(
             result.file_id,
             result.pending_type_decls,
             result.guard_dependencies,
         );
-        apply_initializer_cache_updates(db, result.updates);
+        updates.extend(result.updates);
     }
+    apply_initializer_cache_updates(db, updates);
 }
 
 struct InitializerRefreshResult {
@@ -448,36 +474,55 @@ impl InitializerRefreshResult {
 enum InitializerCacheUpdate {
     Bind {
         owner: LuaTypeOwner,
-        inferred_type: LuaType,
+        fact: LuaTypeFact,
     },
     Overwrite {
         owner: LuaTypeOwner,
-        inferred_type: LuaType,
+        fact: LuaTypeFact,
+    },
+    ReplaceFact {
+        owner: LuaTypeOwner,
+        fact: LuaTypeFact,
     },
 }
 
 fn apply_initializer_cache_updates(db: &mut DbIndex, updates: Vec<InitializerCacheUpdate>) {
+    let mut fact_updates = Vec::with_capacity(updates.len());
     for update in updates {
         match update {
-            InitializerCacheUpdate::Bind {
-                owner,
-                inferred_type,
-            } => {
-                common::bind_resolved_type(db, owner, LuaTypeCache::InferType(inferred_type));
-            }
-            InitializerCacheUpdate::Overwrite {
-                owner,
-                inferred_type,
-            } => {
-                common::write_type_cache(
+            InitializerCacheUpdate::Bind { owner, fact } => {
+                common::bind_resolved_type(
                     db,
-                    owner,
-                    LuaTypeCache::InferType(inferred_type),
-                    common::TypeCacheWriteMode::ForceOverwrite,
+                    owner.clone(),
+                    LuaTypeCache::InferType(fact.typ().clone()),
                 );
+                if db
+                    .get_type_index()
+                    .get_type_cache(&owner)
+                    .is_some_and(|cache| cache.as_type() == fact.typ())
+                {
+                    fact_updates.push((LuaInferenceNodeId::TypeOwner(owner), fact));
+                }
+            }
+            InitializerCacheUpdate::Overwrite { owner, fact }
+            | InitializerCacheUpdate::ReplaceFact { owner, fact } => {
+                fact_updates.push((LuaInferenceNodeId::TypeOwner(owner), fact));
             }
         }
     }
+    db.publish_inference_facts(fact_updates);
+}
+
+fn select_result_fact(fact: LuaTypeFact, result_idx: usize) -> LuaTypeFact {
+    let typ = match fact.typ() {
+        LuaType::Variadic(variadic) => variadic
+            .get_type(result_idx)
+            .cloned()
+            .unwrap_or(LuaType::Nil),
+        typ if result_idx == 0 => typ.clone(),
+        _ => LuaType::Nil,
+    };
+    fact.with_runtime_type(typ)
 }
 
 fn member_initializer_expr(root: &LuaSyntaxNode, member_id: LuaMemberId) -> Option<LuaExpr> {
@@ -897,6 +942,9 @@ impl AnalyzeContext {
                 .push(definition);
         }
         self.infer_manager.clear();
+        let mut fact_updates = Vec::with_capacity(
+            consumers.len() + definition_refreshes.values().map(Vec::len).sum::<usize>(),
+        );
 
         for consumer in consumers {
             let (file_id, owner, expr, ret_idx) = match consumer {
@@ -920,23 +968,15 @@ impl AnalyzeContext {
                 _ => continue,
             };
             let cache = self.infer_manager.get_infer_cache(file_id);
-            let Ok(mut typ) = crate::infer_expr(db, cache, expr) else {
-                continue;
-            };
-            if let LuaType::Variadic(variadic) = typ {
-                typ = variadic.get_type(ret_idx).cloned().unwrap_or(LuaType::Nil);
-            } else if ret_idx != 0 {
-                typ = LuaType::Nil;
-            }
-            db.get_type_index_mut()
-                .force_bind_type(owner.clone(), LuaTypeCache::InferType(typ.clone()));
+            let fact = select_result_fact(infer_expr_fact_with_cache(db, cache, expr), ret_idx);
+            fact_updates.push((LuaInferenceNodeId::TypeOwner(owner.clone()), fact.clone()));
             if let Some(definitions) = definition_refreshes.get(&owner) {
                 for definition in definitions {
-                    db.get_type_index_mut()
-                        .bind_definition_fact(*definition, LuaTypeFact::certain(typ.clone()));
+                    fact_updates.push((LuaInferenceNodeId::Definition(*definition), fact.clone()));
                 }
             }
         }
+        db.publish_inference_facts(fact_updates);
         count
     }
 

--- a/crates/glua_code_analysis/src/db_index/type/inference_fact.rs
+++ b/crates/glua_code_analysis/src/db_index/type/inference_fact.rs
@@ -227,9 +227,26 @@ impl LuaTypeFact {
         target: &LuaInferenceNodeId,
     ) -> bool {
         self.authority_rank() > other.authority_rank()
+            && !other.is_unguarded_child_refinement_of(&self.typ, target)
             && self.provenance.iter().all(|step| {
-                &step.event.node != target && !step.support.iter().any(|support| support == target)
+                !same_fact_target(&step.event.node, target)
+                    && !step
+                        .support
+                        .iter()
+                        .any(|support| same_fact_target(support, target))
             })
+    }
+
+    fn is_unguarded_child_refinement_of(
+        &self,
+        base_type: &LuaType,
+        target: &LuaInferenceNodeId,
+    ) -> bool {
+        self.provenance.iter().any(|step| {
+            step.event.kind == LuaInferenceProvenanceKind::UnguardedChild
+                && same_fact_target(&step.event.node, target)
+                && step.found_type.as_deref() == Some(base_type)
+        })
     }
 
     fn authority_rank(&self) -> u8 {
@@ -265,6 +282,24 @@ impl LuaTypeFact {
             base_provenance_kind,
             provenance,
         }
+    }
+}
+
+fn same_fact_target(left: &LuaInferenceNodeId, right: &LuaInferenceNodeId) -> bool {
+    if left == right {
+        return true;
+    }
+
+    match (left, right) {
+        (
+            LuaInferenceNodeId::Definition(LuaDefinitionId::Declaration(left)),
+            LuaInferenceNodeId::TypeOwner(LuaTypeOwner::Decl(right)),
+        )
+        | (
+            LuaInferenceNodeId::TypeOwner(LuaTypeOwner::Decl(right)),
+            LuaInferenceNodeId::Definition(LuaDefinitionId::Declaration(left)),
+        ) => left == right,
+        _ => false,
     }
 }
 

--- a/crates/glua_code_analysis/src/db_index/type/inference_fact.rs
+++ b/crates/glua_code_analysis/src/db_index/type/inference_fact.rs
@@ -221,6 +221,38 @@ impl LuaTypeFact {
         self.provenance.iter().map(|step| &step.event)
     }
 
+    pub(crate) fn has_independently_stronger_authority_than(
+        &self,
+        other: &Self,
+        target: &LuaInferenceNodeId,
+    ) -> bool {
+        self.authority_rank() > other.authority_rank()
+            && self.provenance.iter().all(|step| {
+                &step.event.node != target && !step.support.iter().any(|support| support == target)
+            })
+    }
+
+    fn authority_rank(&self) -> u8 {
+        if self.base_provenance_kind == Some(LuaInferenceProvenanceKind::ExplicitAnnotation) {
+            return 4;
+        }
+        if self.confidence == LuaInferenceConfidence::Certain {
+            return 3;
+        }
+        if self.confidence == LuaInferenceConfidence::Anchored
+            || self
+                .provenance
+                .iter()
+                .any(|step| step.event.kind == LuaInferenceProvenanceKind::ContextualUnknown)
+        {
+            return 2;
+        }
+        if self.confidence == LuaInferenceConfidence::Heuristic {
+            return 1;
+        }
+        0
+    }
+
     pub(crate) fn from_normalized_parts(
         typ: LuaType,
         confidence: LuaInferenceConfidence,

--- a/crates/glua_code_analysis/src/db_index/type/mod.rs
+++ b/crates/glua_code_analysis/src/db_index/type/mod.rs
@@ -1028,7 +1028,7 @@ impl LuaTypeIndex {
                 continue;
             }
 
-            if type_references_any_file(cache.as_type(), file_ids) {
+            if self.type_references_any_file(cache.as_type(), file_ids, owner_file_id) {
                 dependent_files.insert(owner_file_id);
             }
         }
@@ -1043,58 +1043,88 @@ impl LuaTypeIndex {
         let mut dependent_files = HashSet::new();
         for (owner, cache) in &self.types {
             let owner_file_id = owner.get_file_id();
-            if type_references_other_file(cache.as_type(), file_ids, owner_file_id) {
+            if self.type_references_other_file(cache.as_type(), file_ids, owner_file_id) {
                 dependent_files.insert(owner_file_id);
             }
         }
 
         dependent_files
     }
-}
+    fn type_references_any_file(
+        &self,
+        typ: &LuaType,
+        file_ids: &HashSet<FileId>,
+        owner_file_id: FileId,
+    ) -> bool {
+        let mut references_file = false;
+        typ.visit_type(&mut |inner| {
+            if references_file {
+                return;
+            }
 
-fn type_references_any_file(typ: &LuaType, file_ids: &HashSet<FileId>) -> bool {
-    let mut references_file = false;
-    typ.visit_type(&mut |inner| {
-        if references_file {
-            return;
-        }
+            references_file = match inner {
+                LuaType::TableConst(range) => file_ids.contains(&range.file_id),
+                LuaType::Instance(instance) => file_ids.contains(&instance.get_range().file_id),
+                LuaType::Signature(signature_id) => file_ids.contains(&signature_id.get_file_id()),
+                LuaType::ModuleRef(file_id) => file_ids.contains(file_id),
+                LuaType::Ref(type_id) | LuaType::Def(type_id) => {
+                    self.get_type_decl(type_id).is_some_and(|decl| {
+                        let locations = decl.get_locations();
+                        !locations
+                            .iter()
+                            .any(|location| location.file_id == owner_file_id)
+                            && locations
+                                .iter()
+                                .any(|location| file_ids.contains(&location.file_id))
+                    })
+                }
+                _ => false,
+            };
+        });
 
-        references_file = match inner {
-            LuaType::TableConst(range) => file_ids.contains(&range.file_id),
-            LuaType::Instance(instance) => file_ids.contains(&instance.get_range().file_id),
-            LuaType::Signature(signature_id) => file_ids.contains(&signature_id.get_file_id()),
-            LuaType::ModuleRef(file_id) => file_ids.contains(file_id),
-            _ => false,
-        };
-    });
+        references_file
+    }
 
-    references_file
-}
+    fn type_references_other_file(
+        &self,
+        typ: &LuaType,
+        file_ids: &HashSet<FileId>,
+        owner_file_id: FileId,
+    ) -> bool {
+        let references_changed_file =
+            |file_id: FileId| file_id != owner_file_id && file_ids.contains(&file_id);
+        let mut references_file = false;
+        typ.visit_type(&mut |inner| {
+            if references_file {
+                return;
+            }
 
-fn type_references_other_file(
-    typ: &LuaType,
-    file_ids: &HashSet<FileId>,
-    owner_file_id: FileId,
-) -> bool {
-    let mut references_file = false;
-    typ.visit_type(&mut |inner| {
-        if references_file {
-            return;
-        }
+            references_file = match inner {
+                LuaType::TableConst(range) => references_changed_file(range.file_id),
+                LuaType::Instance(instance) => {
+                    references_changed_file(instance.get_range().file_id)
+                }
+                LuaType::Signature(signature_id) => {
+                    references_changed_file(signature_id.get_file_id())
+                }
+                LuaType::ModuleRef(file_id) => references_changed_file(*file_id),
+                LuaType::Ref(type_id) | LuaType::Def(type_id) => {
+                    self.get_type_decl(type_id).is_some_and(|decl| {
+                        let locations = decl.get_locations();
+                        !locations
+                            .iter()
+                            .any(|location| location.file_id == owner_file_id)
+                            && locations
+                                .iter()
+                                .any(|location| references_changed_file(location.file_id))
+                    })
+                }
+                _ => false,
+            };
+        });
 
-        let referenced_file_id = match inner {
-            LuaType::TableConst(range) => Some(range.file_id),
-            LuaType::Instance(instance) => Some(instance.get_range().file_id),
-            LuaType::Signature(signature_id) => Some(signature_id.get_file_id()),
-            LuaType::ModuleRef(file_id) => Some(*file_id),
-            _ => None,
-        };
-
-        references_file = referenced_file_id
-            .is_some_and(|file_id| file_id != owner_file_id && file_ids.contains(&file_id));
-    });
-
-    references_file
+        references_file
+    }
 }
 
 impl LuaIndex for LuaTypeIndex {

--- a/crates/glua_code_analysis/src/db_index/type/test.rs
+++ b/crates/glua_code_analysis/src/db_index/type/test.rs
@@ -9,10 +9,10 @@ mod test {
     use crate::db_index::r#type::LuaTypeIndex;
     use crate::db_index::{LuaDeclTypeKind, LuaTypeFlag};
     use crate::{
-        DbIndex, FileId, InFiled, LuaDeclId, LuaDefinitionId, LuaInferenceConfidence,
-        LuaInferenceEventId, LuaInferenceNodeId, LuaInferenceProvenanceKind, LuaInferenceStep,
-        LuaType, LuaTypeCache, LuaTypeDecl, LuaTypeDeclId, LuaTypeFact, LuaTypeFactMetadata,
-        LuaTypeOwner, resolve_alias_type,
+        DbIndex, FileId, InFiled, LuaDeclId, LuaDeclLocation, LuaDefinitionId,
+        LuaInferenceConfidence, LuaInferenceEventId, LuaInferenceNodeId,
+        LuaInferenceProvenanceKind, LuaInferenceStep, LuaType, LuaTypeCache, LuaTypeDecl,
+        LuaTypeDeclId, LuaTypeFact, LuaTypeFactMetadata, LuaTypeOwner, resolve_alias_type,
     };
 
     fn create_type_index() -> LuaTypeIndex {
@@ -178,6 +178,112 @@ mod test {
             Some(LuaInferenceProvenanceKind::ConcreteValue)
         );
         assert!(infer_fact.provenance().is_empty());
+    }
+
+    #[test]
+    fn inference_fact_authority_order_rejects_self_confirming_upgrades() {
+        let target = LuaInferenceNodeId::TypeOwner(owner());
+        let contextual = LuaTypeFact::new(
+            LuaType::Number,
+            LuaInferenceConfidence::Anchored,
+            anchored_metadata().provenance,
+        );
+        let concrete = LuaTypeFact::certain(LuaType::Number);
+        let explicit = LuaTypeFact::from_normalized_parts(
+            LuaType::Number,
+            LuaInferenceConfidence::Certain,
+            Some(LuaInferenceProvenanceKind::ExplicitAnnotation),
+            Arc::from([]),
+        );
+        let cyclic = LuaTypeFact::new(
+            LuaType::Number,
+            LuaInferenceConfidence::Certain,
+            Arc::from([LuaInferenceStep {
+                event: LuaInferenceEventId {
+                    node: target.clone(),
+                    kind: LuaInferenceProvenanceKind::ConcreteValue,
+                    source: source(30),
+                },
+                support: Arc::from([target.clone()]),
+                found_type: None,
+            }]),
+        );
+
+        assert!(concrete.has_independently_stronger_authority_than(&contextual, &target));
+        assert!(explicit.has_independently_stronger_authority_than(&concrete, &target));
+        assert!(!contextual.has_independently_stronger_authority_than(&concrete, &target));
+        assert!(!cyclic.has_independently_stronger_authority_than(&contextual, &target));
+    }
+
+    #[test]
+    fn ref_type_cache_tracks_the_declaring_file_as_an_incremental_dependency() {
+        let provider = FileId::new(1);
+        let consumer = FileId::new(2);
+        let type_id = LuaTypeDeclId::global("ProviderType");
+        let mut index = LuaTypeIndex::new();
+        index.add_type_decl(
+            provider,
+            LuaTypeDecl::new(
+                provider,
+                TextRange::new(0.into(), 1.into()),
+                "ProviderType".to_string(),
+                LuaDeclTypeKind::Class,
+                LuaTypeFlag::None.into(),
+                type_id.clone(),
+            ),
+        );
+        index.bind_type(
+            owner_in(consumer, 10),
+            LuaTypeCache::DocType(LuaType::Ref(type_id)),
+        );
+
+        assert_eq!(
+            index.files_with_type_caches_referencing_files(&HashSet::from([provider])),
+            HashSet::from([consumer])
+        );
+    }
+
+    #[test]
+    fn ref_type_dependency_excludes_files_that_contribute_to_the_same_type() {
+        let provider = FileId::new(1);
+        let contributor = FileId::new(2);
+        let consumer = FileId::new(3);
+        let type_id = LuaTypeDeclId::global("SharedType");
+        let mut index = LuaTypeIndex::new();
+        index.add_type_decl(
+            provider,
+            LuaTypeDecl::new(
+                provider,
+                TextRange::new(0.into(), 1.into()),
+                "SharedType".to_string(),
+                LuaDeclTypeKind::Class,
+                LuaTypeFlag::None.into(),
+                type_id.clone(),
+            ),
+        );
+        index.add_type_decl_location(
+            contributor,
+            &type_id,
+            LuaDeclLocation {
+                file_id: contributor,
+                range: TextRange::new(0.into(), 1.into()),
+                flag: LuaTypeFlag::None.into(),
+            },
+        );
+        index.bind_type(
+            owner_in(contributor, 10),
+            LuaTypeCache::DocType(LuaType::Ref(type_id.clone())),
+        );
+        index.bind_type(
+            owner_in(consumer, 10),
+            LuaTypeCache::DocType(LuaType::Ref(type_id)),
+        );
+
+        assert_eq!(
+            index
+                .files_with_cross_file_type_caches_referencing_files(&HashSet::from([contributor])),
+            HashSet::from([consumer])
+        );
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/db_index/type/test.rs
+++ b/crates/glua_code_analysis/src/db_index/type/test.rs
@@ -216,6 +216,70 @@ mod test {
     }
 
     #[test]
+    fn declared_base_does_not_replace_its_unguarded_child_runtime_refinement() {
+        let target = LuaInferenceNodeId::TypeOwner(owner());
+        let base_type = LuaType::Ref(LuaTypeDeclId::global("Entity"));
+        let refined_type = LuaType::Ref(LuaTypeDeclId::global("Player"));
+        let unguarded_child = LuaTypeFact::new(
+            refined_type,
+            LuaInferenceConfidence::Heuristic,
+            Arc::from([LuaInferenceStep {
+                event: LuaInferenceEventId {
+                    node: LuaInferenceNodeId::Definition(LuaDefinitionId::Declaration(
+                        LuaDeclId::new(file_id(), 10.into()),
+                    )),
+                    kind: LuaInferenceProvenanceKind::UnguardedChild,
+                    source: source(30),
+                },
+                support: Arc::from([]),
+                found_type: Some(Arc::new(base_type.clone())),
+            }]),
+        );
+        let declared_base = LuaTypeFact::from_normalized_parts(
+            base_type.clone(),
+            LuaInferenceConfidence::Certain,
+            Some(LuaInferenceProvenanceKind::ExplicitAnnotation),
+            Arc::from([]),
+        );
+        let changed_declaration = LuaTypeFact::from_normalized_parts(
+            LuaType::Number,
+            LuaInferenceConfidence::Certain,
+            Some(LuaInferenceProvenanceKind::ExplicitAnnotation),
+            Arc::from([]),
+        );
+
+        assert!(
+            !declared_base.has_independently_stronger_authority_than(&unguarded_child, &target)
+        );
+        assert!(
+            changed_declaration
+                .has_independently_stronger_authority_than(&unguarded_child, &target)
+        );
+
+        let inherited_receiver_provenance = LuaTypeFact::new(
+            LuaType::Ref(LuaTypeDeclId::global("Vector")),
+            LuaInferenceConfidence::Heuristic,
+            Arc::from([LuaInferenceStep {
+                event: LuaInferenceEventId {
+                    node: LuaInferenceNodeId::Definition(LuaDefinitionId::Declaration(
+                        LuaDeclId::new(file_id(), 20.into()),
+                    )),
+                    kind: LuaInferenceProvenanceKind::UnguardedChild,
+                    source: source(30),
+                },
+                support: Arc::from([]),
+                found_type: Some(Arc::new(base_type)),
+            }]),
+        );
+        assert!(
+            declared_base.has_independently_stronger_authority_than(
+                &inherited_receiver_provenance,
+                &target,
+            )
+        );
+    }
+
+    #[test]
     fn ref_type_cache_tracks_the_declaring_file_as_an_incremental_dependency() {
         let provider = FileId::new(1);
         let consumer = FileId::new(2);

--- a/crates/glua_code_analysis/src/diagnostic/test/inference_trust_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/inference_trust_test.rs
@@ -5,12 +5,12 @@ mod tests {
     use lsp_types::NumberOrString;
     use tokio_util::sync::CancellationToken;
 
-    use glua_parser::{LuaAstNode, LuaLocalName};
+    use glua_parser::{LuaAstNode, LuaAstToken, LuaCallExpr, LuaExpr, LuaLocalName};
 
     use crate::{
-        DiagnosticCode, Emmyrc, InFiled, LuaDefinitionId, LuaInferenceConfidence,
+        DiagnosticCode, Emmyrc, InFiled, LuaDefinitionId, LuaInferCache, LuaInferenceConfidence,
         LuaInferenceEventId, LuaInferenceNodeId, LuaInferenceProvenanceKind, LuaInferenceStep,
-        LuaType, LuaTypeFact, VirtualWorkspace,
+        LuaType, LuaTypeFact, LuaTypeOwner, VirtualWorkspace,
     };
 
     fn workspace() -> (VirtualWorkspace, crate::FileId) {
@@ -52,6 +52,66 @@ mod tests {
             .collect()
     }
 
+    fn gmod_workspace() -> VirtualWorkspace {
+        let mut ws = VirtualWorkspace::new();
+        let mut config = Emmyrc::default();
+        config.gmod.enabled = true;
+        ws.analysis.update_config(Arc::new(config));
+        ws.def_gmod_call_arg_builtins();
+        ws
+    }
+
+    fn file_id(ws: &VirtualWorkspace, file_name: &str) -> crate::FileId {
+        let uri = ws.virtual_url_generator.new_uri(file_name);
+        ws.analysis.get_file_id(&uri).expect("file id")
+    }
+
+    fn local_type(ws: &VirtualWorkspace, file_id: crate::FileId, name: &str) -> LuaType {
+        let local = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .expect("syntax tree")
+            .get_chunk_node()
+            .descendants::<LuaLocalName>()
+            .find(|local| local.get_text() == name)
+            .expect("local");
+        let model = ws
+            .analysis
+            .compilation
+            .get_semantic_model(file_id)
+            .expect("semantic model");
+        let token = local.get_name_token().expect("local name token");
+        model
+            .get_semantic_info(token.syntax().clone().into())
+            .expect("semantic info")
+            .display_typ()
+            .clone()
+    }
+
+    fn local_fact(ws: &VirtualWorkspace, file_id: crate::FileId, name: &str) -> LuaTypeFact {
+        let local = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .expect("syntax tree")
+            .get_chunk_node()
+            .descendants::<LuaLocalName>()
+            .find(|local| local.get_text() == name)
+            .expect("local");
+        let owner = LuaTypeOwner::Decl(crate::LuaDeclId::new(file_id, local.get_position()));
+        ws.analysis
+            .compilation
+            .get_db()
+            .get_type_index()
+            .get_type_fact(&owner)
+            .expect("local fact")
+    }
+
     #[test]
     fn infer_unknown_is_one_indexed_hint_at_the_anchor() {
         let (mut ws, file_id) = workspace();
@@ -77,6 +137,546 @@ mod tests {
         ws.analysis.update_config(Arc::new(config));
 
         assert!(diagnostics_for(&mut ws, file_id, DiagnosticCode::InferUnknown).is_empty());
+    }
+
+    #[test]
+    fn declared_cross_file_network_var_result_does_not_infer_from_usage_context() {
+        let mut ws = gmod_workspace();
+        ws.def_files(vec![
+            (
+                "lua/entities/probe_sent/shared.lua",
+                r#"
+                ---@class probe_sent : Entity
+                ENT.Type = "anim"
+                ENT.Base = "base_entity"
+
+                function ENT:SetupDataTables()
+                    self:NetworkVar("Float", 0, "ZFar")
+                end
+
+                ---@param zfar number
+                local function takesNumberSameFile(zfar) return zfar end
+
+                function ENT:ReadHere()
+                    local zfar = self:GetZFar()
+                    return takesNumberSameFile(zfar)
+                end
+                "#,
+            ),
+            (
+                "consumer.lua",
+                r#"
+                ---@param zfar number
+                local function takesNumber(zfar) return zfar end
+
+                ---@param ent probe_sent
+                local function read(ent)
+                    local zfar = ent:GetZFar()
+                    return takesNumber(zfar)
+                end
+
+                return read
+                "#,
+            ),
+        ]);
+        let provider_file_id = file_id(&ws, "lua/entities/probe_sent/shared.lua");
+        let consumer_file_id = file_id(&ws, "consumer.lua");
+
+        let consumer_found =
+            diagnostics_for(&mut ws, consumer_file_id, DiagnosticCode::InferUnknown);
+        let provider_found =
+            diagnostics_for(&mut ws, provider_file_id, DiagnosticCode::InferUnknown);
+
+        assert_eq!(
+            (
+                local_type(&ws, consumer_file_id, "zfar"),
+                consumer_found,
+                provider_found,
+            ),
+            (LuaType::Number, Vec::new(), Vec::new())
+        );
+    }
+
+    #[test]
+    fn declared_cross_file_return_does_not_infer_from_usage_context() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def_files(vec![
+            (
+                "annotations/producer.lua",
+                r#"
+                ---@class DeclaredProducer
+                local DeclaredProducer = {}
+
+                ---@return number
+                function DeclaredProducer:GetNumber() end
+                "#,
+            ),
+            (
+                "consumer.lua",
+                r#"
+                ---@param value number
+                local function takesNumber(value) return value end
+
+                ---@param producer DeclaredProducer
+                local function read(producer)
+                    local value = producer:GetNumber()
+                    return takesNumber(value)
+                end
+
+                return read
+                "#,
+            ),
+        ]);
+        let consumer_uri = ws.virtual_url_generator.new_uri("consumer.lua");
+        let consumer_file_id = ws
+            .analysis
+            .get_file_id(&consumer_uri)
+            .expect("consumer file id");
+
+        let found = diagnostics_for(&mut ws, consumer_file_id, DiagnosticCode::InferUnknown);
+
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    #[test]
+    fn declared_overload_return_does_not_infer_from_usage_context() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def_file(
+            "overload_return.lua",
+            r#"
+            ---@overload fun(name: "Count"): number
+            ---@param name string
+            local function resolve(name) end
+
+            ---@param value number
+            local function takesNumber(value) return value end
+
+            local value = resolve("Count")
+            return takesNumber(value)
+            "#,
+        );
+
+        let found = diagnostics_for(&mut ws, file_id, DiagnosticCode::InferUnknown);
+
+        assert_eq!(
+            (
+                local_type(&ws, file_id, "value"),
+                local_fact(&ws, file_id, "value").base_provenance_kind(),
+                found,
+            ),
+            (
+                LuaType::Number,
+                Some(LuaInferenceProvenanceKind::ExplicitAnnotation),
+                Vec::new(),
+            )
+        );
+    }
+
+    #[test]
+    fn declared_element_member_retains_contextual_receiver_provenance() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def_file(
+            "element_receiver.lua",
+            r#"
+            local declared = {}
+
+            ---@return number
+            function declared:GetNumber() end
+
+            local receiver = declared
+            local value = receiver:GetNumber()
+            "#,
+        );
+        let root = ws
+            .analysis
+            .compilation
+            .get_db()
+            .get_vfs()
+            .get_syntax_tree(&file_id)
+            .expect("syntax tree")
+            .get_chunk_node();
+        let receiver = root
+            .descendants::<LuaLocalName>()
+            .find(|local| local.get_text() == "receiver")
+            .expect("receiver local");
+        let receiver_node = LuaInferenceNodeId::TypeOwner(LuaTypeOwner::Decl(
+            crate::LuaDeclId::new(file_id, receiver.get_position()),
+        ));
+        let receiver_fact = local_fact(&ws, file_id, "receiver");
+        let receiver_event = LuaInferenceEventId {
+            node: receiver_node.clone(),
+            kind: LuaInferenceProvenanceKind::ContextualUnknown,
+            source: InFiled::new(file_id, receiver.get_syntax_id()),
+        };
+        ws.get_db_mut().publish_inference_facts(vec![(
+            receiver_node,
+            LuaTypeFact::new(
+                receiver_fact.typ().clone(),
+                LuaInferenceConfidence::Anchored,
+                vec![LuaInferenceStep {
+                    event: receiver_event.clone(),
+                    support: Vec::new().into(),
+                    found_type: None,
+                }]
+                .into(),
+            ),
+        )]);
+        let call = root
+            .descendants::<LuaCallExpr>()
+            .find(|call| {
+                call.syntax()
+                    .text()
+                    .to_string()
+                    .contains("receiver:GetNumber")
+            })
+            .expect("declared element-member call");
+        let mut cache = LuaInferCache::new(file_id, Default::default());
+
+        let fact = crate::semantic::infer_expr_fact_with_cache(
+            ws.analysis.compilation.get_db(),
+            &mut cache,
+            LuaExpr::CallExpr(call),
+        );
+
+        assert_eq!(
+            (
+                fact.typ(),
+                fact.confidence(),
+                fact.base_provenance_kind(),
+                fact.provenance()
+                    .iter()
+                    .map(|step| &step.event)
+                    .collect::<Vec<_>>(),
+            ),
+            (
+                &LuaType::Number,
+                LuaInferenceConfidence::Anchored,
+                None,
+                vec![&receiver_event],
+            )
+        );
+    }
+
+    #[test]
+    fn inferred_return_does_not_gain_declared_authority() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def_file(
+            "annotations/inferred-return.lua",
+            r#"
+            ---@return unknown
+            function unknown_source() end
+            "#,
+        );
+        let file_id = ws.def_file(
+            "inferred-return.lua",
+            r#"
+            local function inferredSource()
+                return unknown_source()
+            end
+
+            ---@param value number
+            local function takesNumber(value) return value end
+
+            local value = inferredSource()
+            return takesNumber(value)
+            "#,
+        );
+
+        let found = diagnostics_for(&mut ws, file_id, DiagnosticCode::InferUnknown);
+
+        assert_eq!(found.len(), 1, "{found:?}");
+    }
+
+    #[test]
+    fn unmatched_overload_base_return_does_not_gain_declared_authority() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def_file(
+            "annotations/unmatched-overload.lua",
+            r#"
+            ---@return unknown
+            function unknown_source() end
+            "#,
+        );
+        let file_id = ws.def_file(
+            "unmatched-overload.lua",
+            r#"
+            ---@overload fun(name: "Count"): number
+            ---@param name string
+            local function resolve(name)
+                return unknown_source()
+            end
+
+            ---@param value number
+            local function takesNumber(value) return value end
+
+            local value = resolve("Other")
+            return takesNumber(value)
+            "#,
+        );
+
+        let found = diagnostics_for(&mut ws, file_id, DiagnosticCode::InferUnknown);
+
+        assert_eq!(found.len(), 1, "{found:?}");
+    }
+
+    #[test]
+    fn declared_cross_file_field_does_not_infer_from_usage_context() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def_files(vec![
+            (
+                "annotations/holder.lua",
+                r#"
+                ---@class DeclaredHolder
+                ---@field count number
+                local DeclaredHolder = {}
+                "#,
+            ),
+            (
+                "consumer.lua",
+                r#"
+                ---@param value number
+                local function takesNumber(value) return value end
+
+                ---@param holder DeclaredHolder
+                local function read(holder)
+                    local value = holder.count
+                    return takesNumber(value)
+                end
+
+                return read
+                "#,
+            ),
+        ]);
+        let consumer_file_id = file_id(&ws, "consumer.lua");
+
+        let found = diagnostics_for(&mut ws, consumer_file_id, DiagnosticCode::InferUnknown);
+
+        assert_eq!(
+            (local_type(&ws, consumer_file_id, "value"), found),
+            (LuaType::Number, Vec::new())
+        );
+    }
+
+    #[test]
+    fn declared_cross_file_accessor_func_result_does_not_infer_from_usage_context() {
+        let mut ws = gmod_workspace();
+        ws.def_files(vec![
+            (
+                "lua/entities/accessor_probe/shared.lua",
+                r#"
+                ---@class accessor_probe : Entity
+                ENT.Type = "anim"
+                ENT.Base = "base_entity"
+                AccessorFunc(ENT, "m_bEnabled", "Enabled", true)
+                "#,
+            ),
+            (
+                "consumer.lua",
+                r#"
+                ---@param value boolean
+                local function takesBoolean(value) return value end
+
+                ---@param ent accessor_probe
+                local function read(ent)
+                    local value = ent:GetEnabled()
+                    return takesBoolean(value)
+                end
+
+                return read
+                "#,
+            ),
+        ]);
+        let consumer_uri = ws.virtual_url_generator.new_uri("consumer.lua");
+        let consumer_file_id = ws
+            .analysis
+            .get_file_id(&consumer_uri)
+            .expect("consumer file id");
+
+        let found = diagnostics_for(&mut ws, consumer_file_id, DiagnosticCode::InferUnknown);
+
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    #[test]
+    fn declared_cross_file_network_var_element_result_does_not_infer_from_usage_context() {
+        let mut ws = gmod_workspace();
+        ws.def_files(vec![
+            (
+                "lua/entities/element_probe/shared.lua",
+                r#"
+                ---@class element_probe : Entity
+                ENT.Type = "anim"
+                ENT.Base = "base_entity"
+
+                function ENT:SetupDataTables()
+                    self:NetworkVarElement("Vector", 0, "x", "OffsetX")
+                end
+                "#,
+            ),
+            (
+                "consumer.lua",
+                r#"
+                ---@param value number
+                local function takesNumber(value) return value end
+
+                ---@param ent element_probe
+                local function read(ent)
+                    local value = ent:GetOffsetX()
+                    return takesNumber(value)
+                end
+
+                return read
+                "#,
+            ),
+        ]);
+        let consumer_uri = ws.virtual_url_generator.new_uri("consumer.lua");
+        let consumer_file_id = ws
+            .analysis
+            .get_file_id(&consumer_uri)
+            .expect("consumer file id");
+
+        let found = diagnostics_for(&mut ws, consumer_file_id, DiagnosticCode::InferUnknown);
+
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    #[test]
+    fn declared_hook_callback_parameter_does_not_infer_from_usage_context() {
+        let mut ws = gmod_workspace();
+        let callback_file_id = ws.def_file(
+            "lua/autorun/server/hook_callback.lua",
+            r#"
+            ---@class GM
+            GM = {}
+
+            ---@hook AcceptInput
+            ---@param ent Entity
+            function GM:AcceptInput(ent) end
+
+            ---@param ent Entity
+            local function takesEntity(ent) return ent end
+
+            hook.Add("AcceptInput", "provenance", function(ent)
+                return takesEntity(ent)
+            end)
+            "#,
+        );
+
+        let found = diagnostics_for(&mut ws, callback_file_id, DiagnosticCode::InferUnknown);
+
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    #[test]
+    fn declared_overload_callback_parameter_does_not_infer_from_usage_context() {
+        let mut ws = VirtualWorkspace::new();
+        let file_id = ws.def_file(
+            "callback.lua",
+            r#"
+            ---@overload fun(name: "Count", callback: fun(value: number))
+            ---@param name string
+            ---@param callback function
+            local function addHook(name, callback) end
+
+            ---@param value number
+            local function takesNumber(value) return value end
+
+            addHook("Count", function(value)
+                return takesNumber(value)
+            end)
+            "#,
+        );
+
+        let found = diagnostics_for(&mut ws, file_id, DiagnosticCode::InferUnknown);
+
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    #[test]
+    fn cross_file_declared_result_reconciles_after_incremental_changes() {
+        const WITHOUT_NETWORK_VAR: &str = r#"
+            ---@class incremental_probe : Entity
+            ENT.Type = "anim"
+            ENT.Base = "base_entity"
+        "#;
+        const WITH_FLOAT_NETWORK_VAR: &str = r#"
+            ---@class incremental_probe : Entity
+            ENT.Type = "anim"
+            ENT.Base = "base_entity"
+
+            function ENT:SetupDataTables()
+                self:NetworkVar("Float", 0, "Value")
+            end
+        "#;
+        const WITH_BOOL_NETWORK_VAR: &str = r#"
+            ---@class incremental_probe : Entity
+            ENT.Type = "anim"
+            ENT.Base = "base_entity"
+
+            function ENT:SetupDataTables()
+                self:NetworkVar("Bool", 0, "Value")
+            end
+        "#;
+        const CONSUMER: &str = r#"
+            ---@param value number
+            local function takesNumber(value) return value end
+
+            ---@param ent incremental_probe
+            local function read(ent)
+                local value = ent:GetValue()
+                return takesNumber(value)
+            end
+
+            return read
+        "#;
+
+        let mut ws = gmod_workspace();
+        ws.def_files(vec![
+            (
+                "lua/entities/incremental_probe/shared.lua",
+                WITHOUT_NETWORK_VAR,
+            ),
+            ("consumer.lua", CONSUMER),
+        ]);
+        let provider_uri = ws
+            .virtual_url_generator
+            .new_uri("lua/entities/incremental_probe/shared.lua");
+        let consumer_file_id = file_id(&ws, "consumer.lua");
+
+        assert_eq!(
+            diagnostics_for(&mut ws, consumer_file_id, DiagnosticCode::InferUnknown).len(),
+            1
+        );
+
+        ws.analysis
+            .update_file_by_uri(&provider_uri, Some(WITH_FLOAT_NETWORK_VAR.to_string()));
+        assert_eq!(
+            (
+                local_type(&ws, consumer_file_id, "value"),
+                diagnostics_for(&mut ws, consumer_file_id, DiagnosticCode::InferUnknown),
+            ),
+            (LuaType::Number, Vec::new())
+        );
+
+        ws.analysis
+            .update_file_by_uri(&provider_uri, Some(WITH_BOOL_NETWORK_VAR.to_string()));
+        assert_eq!(local_type(&ws, consumer_file_id, "value"), LuaType::Boolean);
+
+        ws.analysis.update_file_by_uri(&provider_uri, None);
+        assert_eq!(
+            diagnostics_for(&mut ws, consumer_file_id, DiagnosticCode::InferUnknown).len(),
+            1
+        );
+
+        ws.analysis
+            .update_file_by_uri(&provider_uri, Some(WITH_FLOAT_NETWORK_VAR.to_string()));
+        assert_eq!(
+            (
+                local_type(&ws, consumer_file_id, "value"),
+                diagnostics_for(&mut ws, consumer_file_id, DiagnosticCode::InferUnknown),
+            ),
+            (LuaType::Number, Vec::new())
+        );
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_call/mod.rs
@@ -1009,6 +1009,37 @@ fn infer_signature_doc_function(
     }
 }
 
+pub(crate) fn signature_call_selects_declared_overload(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    signature_id: LuaSignatureId,
+    call_expr: LuaCallExpr,
+) -> bool {
+    let Some(signature) = db.get_signature_index().get(&signature_id) else {
+        return false;
+    };
+    if signature.overloads.is_empty() || !signature.is_resolve_return() {
+        return false;
+    }
+    let is_generic = signature_is_generic(db, cache, signature, &call_expr).unwrap_or(false);
+    let declared_overload_count = signature.overloads.len();
+    let mut candidates = signature.overloads.clone();
+    candidates.push(Arc::new(
+        LuaFunctionType::new(
+            signature.async_state,
+            signature.is_colon_define,
+            signature.is_vararg,
+            signature.get_type_params(),
+            signature.get_return_type(),
+        )
+        .with_optional_params(signature.get_param_optional_flags()),
+    ));
+    crate::semantic::overload_resolve::resolve_signature_with_index(
+        db, cache, candidates, call_expr, is_generic, None,
+    )
+    .is_ok_and(|(_, selected_idx)| selected_idx < declared_overload_count)
+}
+
 fn specialize_class_name_param_return_alias_for_call(
     db: &DbIndex,
     cache: &mut LuaInferCache,

--- a/crates/glua_code_analysis/src/semantic/infer/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/mod.rs
@@ -19,6 +19,7 @@ use infer_binary::infer_binary_expr;
 pub(crate) use infer_call::get_prefix_expr_signature_id;
 use infer_call::infer_call_expr;
 pub use infer_call::infer_call_expr_func;
+pub(crate) use infer_call::signature_call_selects_declared_overload;
 pub use infer_doc_type::{DocTypeInferContext, infer_doc_type};
 pub use infer_fail_reason::InferFailReason;
 pub(crate) use infer_index::check_iter_var_range;

--- a/crates/glua_code_analysis/src/semantic/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/mod.rs
@@ -71,7 +71,8 @@ use crate::semantic::type_check::{
     check_type_compact_detail, check_type_compact_detail_with_member_facts,
 };
 use crate::{
-    Emmyrc, LuaDocument, LuaSemanticDeclId, LuaTypeFact, ModuleInfo, db_index::LuaTypeDeclId,
+    Emmyrc, LuaDocument, LuaInferenceConfidence, LuaInferenceProvenanceKind, LuaMemberOwner,
+    LuaSemanticDeclId, LuaTypeFact, ModuleInfo, db_index::LuaTypeDeclId,
 };
 use crate::{
     FileId,
@@ -107,6 +108,117 @@ pub(crate) fn unwrap_paren_to_name_expr(expr: &LuaExpr) -> Option<LuaNameExpr> {
         LuaExpr::NameExpr(name_expr) => Some(name_expr.clone()),
         LuaExpr::ParenExpr(paren_expr) => unwrap_paren_to_name_expr(&paren_expr.get_expr()?),
         _ => None,
+    }
+}
+
+pub(crate) fn infer_expr_fact_with_cache(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    expr: LuaExpr,
+) -> LuaTypeFact {
+    let call_contract_authority = declared_call_contract_authority(db, cache, &expr);
+    let semantic_decl = infer_expr_semantic_decl(
+        db,
+        cache,
+        expr.clone(),
+        SemanticDeclGuard::default(),
+        SemanticDeclLevel::NoTrace,
+    );
+    let fact = infer_expr_semantic_info(db, cache, expr, semantic_decl)
+        .inference_fact()
+        .clone();
+    match call_contract_authority {
+        DeclaredCallContractAuthority::Independent => LuaTypeFact::from_normalized_parts(
+            fact.typ().clone(),
+            LuaInferenceConfidence::Certain,
+            Some(LuaInferenceProvenanceKind::ExplicitAnnotation),
+            Arc::from([]),
+        ),
+        DeclaredCallContractAuthority::ReceiverDependent(receiver_fact) => {
+            LuaTypeFact::from_normalized_parts(
+                fact.typ().clone(),
+                LuaInferenceConfidence::Anchored,
+                None,
+                receiver_fact.provenance().into(),
+            )
+        }
+        DeclaredCallContractAuthority::NotDeclared => fact,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DeclaredCallContractAuthority {
+    Independent,
+    ReceiverDependent(LuaTypeFact),
+    NotDeclared,
+}
+
+fn declared_call_contract_authority(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    expr: &LuaExpr,
+) -> DeclaredCallContractAuthority {
+    let LuaExpr::CallExpr(call) = expr else {
+        return DeclaredCallContractAuthority::NotDeclared;
+    };
+    let Some(prefix) = call.get_prefix_expr() else {
+        return DeclaredCallContractAuthority::NotDeclared;
+    };
+    let Ok(prefix_type) = infer::infer_expr(db, cache, prefix.clone()) else {
+        return DeclaredCallContractAuthority::NotDeclared;
+    };
+    let is_declared = match &prefix_type {
+        LuaType::DocFunction(_) => true,
+        LuaType::Signature(signature_id) => {
+            db.get_signature_index()
+                .get(signature_id)
+                .is_some_and(|signature| {
+                    signature.resolve_return == crate::SignatureReturnStatus::DocResolve
+                        && !signature.return_docs.is_empty()
+                })
+                || infer::signature_call_selects_declared_overload(
+                    db,
+                    cache,
+                    *signature_id,
+                    call.clone(),
+                )
+        }
+        _ => false,
+    };
+    if !is_declared {
+        return DeclaredCallContractAuthority::NotDeclared;
+    }
+
+    let LuaExpr::IndexExpr(index) = prefix else {
+        return DeclaredCallContractAuthority::Independent;
+    };
+    let Some(LuaSemanticDeclId::Member(member_id)) = infer_expr_semantic_decl(
+        db,
+        cache,
+        LuaExpr::IndexExpr(index.clone()),
+        SemanticDeclGuard::default(),
+        SemanticDeclLevel::NoTrace,
+    ) else {
+        return DeclaredCallContractAuthority::Independent;
+    };
+    let Some(member_owner) = db.get_member_index().get_member_owner(&member_id) else {
+        return DeclaredCallContractAuthority::Independent;
+    };
+    let expected_receiver_type = match member_owner {
+        LuaMemberOwner::Type(owner_id) => LuaType::Ref(owner_id.clone()),
+        LuaMemberOwner::Element(range) => LuaType::TableConst(range.clone()),
+        _ => return DeclaredCallContractAuthority::Independent,
+    };
+    let Some(receiver) = index.get_prefix_expr() else {
+        return DeclaredCallContractAuthority::Independent;
+    };
+    let receiver_fact = infer_expr_fact_with_cache(db, cache, receiver);
+    if receiver_fact.confidence() >= LuaInferenceConfidence::Certain
+        && check_type_compact(db, receiver_fact.typ(), &expected_receiver_type).is_ok()
+    {
+        DeclaredCallContractAuthority::Independent
+    } else {
+        DeclaredCallContractAuthority::ReceiverDependent(receiver_fact)
     }
 }
 

--- a/crates/glua_code_analysis/src/semantic/overload_resolve/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/overload_resolve/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use glua_parser::LuaCallExpr;
 
-use crate::db_index::{DbIndex, LuaFunctionType, LuaType};
+use crate::db_index::{DbIndex, LuaFunctionType};
 
 use super::{
     LuaInferCache,
@@ -22,6 +22,18 @@ pub fn resolve_signature(
     is_generic: bool,
     arg_count: Option<usize>,
 ) -> InferCallFuncResult {
+    resolve_signature_with_index(db, cache, overloads, call_expr, is_generic, arg_count)
+        .map(|(func, _)| func)
+}
+
+pub(crate) fn resolve_signature_with_index(
+    db: &DbIndex,
+    cache: &mut LuaInferCache,
+    overloads: Vec<Arc<LuaFunctionType>>,
+    call_expr: LuaCallExpr,
+    is_generic: bool,
+    arg_count: Option<usize>,
+) -> Result<(Arc<LuaFunctionType>, usize), InferFailReason> {
     if call_expr.get_args_list().is_none() {
         return Err(InferFailReason::None);
     }
@@ -29,37 +41,35 @@ pub fn resolve_signature(
         .into_iter()
         .map(|(typ, _)| typ)
         .collect::<Vec<_>>();
-    if is_generic {
-        resolve_signature_by_generic(db, cache, overloads, call_expr, expr_types, arg_count)
+    let candidates = if is_generic {
+        instantiate_signatures(db, cache, overloads, call_expr.clone())?
     } else {
-        resolve_signature_by_args(
-            db,
-            &overloads,
-            &expr_types,
-            call_expr.is_colon_call(),
-            arg_count,
-        )
-    }
+        overloads
+    };
+    let resolved = resolve_signature_by_args(
+        db,
+        &candidates,
+        &expr_types,
+        call_expr.is_colon_call(),
+        arg_count,
+    )?;
+    let selected_idx = candidates
+        .iter()
+        .position(|candidate| Arc::ptr_eq(candidate, &resolved))
+        .ok_or(InferFailReason::None)?;
+    Ok((resolved, selected_idx))
 }
 
-fn resolve_signature_by_generic(
+fn instantiate_signatures(
     db: &DbIndex,
     cache: &mut LuaInferCache,
     overloads: Vec<Arc<LuaFunctionType>>,
     call_expr: LuaCallExpr,
-    expr_types: Vec<LuaType>,
-    arg_count: Option<usize>,
-) -> InferCallFuncResult {
+) -> Result<Vec<Arc<LuaFunctionType>>, InferFailReason> {
     let mut instantiate_funcs = Vec::new();
     for func in overloads {
         let instantiate_func = instantiate_func_generic(db, cache, &func, call_expr.clone())?;
         instantiate_funcs.push(Arc::new(instantiate_func));
     }
-    resolve_signature_by_args(
-        db,
-        &instantiate_funcs,
-        &expr_types,
-        call_expr.is_colon_call(),
-        arg_count,
-    )
+    Ok(instantiate_funcs)
 }


### PR DESCRIPTION
## Summary
- Prevented weaker or contextual inference from overwriting higher-authority explicit annotations when refreshing local declaration and member initializer caches.
- Added authority-aware type fact comparison in `LuaTypeFact` (`has_independently_stronger_authority_than`) and threaded full fact propagation through inference refresh paths.
- Switched several cache-refresh/inference update paths to publish full `LuaTypeFact` updates (including provenance/confidence) instead of only raw types.
- Improved cross-file type dependency tracking to account for `Ref/Def` declarations by declaring-file contribution and avoid false dependency attribution.
- Added/expanded tests in inference trust and type-index suites for authority ordering, cross-file declared types, overload/annotation behavior, and declared-call usage scenarios to prevent contextual inference from upgrading declared facts.

## Testing
- Added unit/integration coverage in:
  - `crates/glua_code_analysis/src/db_index/type/test.rs`
  - `crates/glua_code_analysis/src/diagnostic/test/inference_trust_test.rs`
- Not run: full `cargo test` suite (no execution requested).

Closes #46