### PR TITLE
Fix multi-return arg type checking to use positional return types

### DIFF
--- a/crates/glua_code_analysis/src/diagnostic/checker/param_type_check.rs
+++ b/crates/glua_code_analysis/src/diagnostic/checker/param_type_check.rs
@@ -504,7 +504,9 @@ fn check_call_expr(
                 _ => arg_exprs.get(idx),
             };
             let result = arg_expr
-                .map(|arg_expr| semantic_model.type_check_expr_detail(&check_type, arg_expr))
+                .map(|arg_expr| {
+                    semantic_model.type_check_expr_detail_with_type(&check_type, arg_type, arg_expr)
+                })
                 .unwrap_or_else(|| semantic_model.type_check_detail(&check_type, arg_type));
             if result.is_err() {
                 // `never` and `SelfInfer` indicate type inference limitations, skip the diagnostic.

--- a/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -68,6 +68,85 @@ mod test {
     }
 
     #[test]
+    fn issue_47_multi_return_expansion_uses_positional_types() {
+        let mut ws = VirtualWorkspace::new_with_init_std_lib();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param ok boolean
+            ---@param msg string
+            local function take(ok, msg) return ok, msg end
+
+            ---@return boolean, string
+            local function producer() return true, "x" end
+
+            local direct = take(producer())
+            local protected = take(pcall(producer))
+            local ok, msg = producer()
+            local positional = take(ok, msg)
+            local truncated = take((producer()), "x")
+
+            ---@param prefix integer
+            ---@param ok boolean
+            ---@param msg string
+            local function take_three(prefix, ok, msg) return prefix, ok, msg end
+
+            local prefixed = take_three(1, producer())
+
+            ---@class Vector
+            ---@class Angle
+
+            ---@return Vector, Angle
+            local function local_to_world() end
+
+            ---@param value Vector
+            local function take_vector(value) return value end
+
+            local vector = take_vector(local_to_world())
+            "#,
+        ));
+    }
+
+    #[test]
+    fn issue_47_multi_return_expansion_reports_first_slot_mismatch() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param ok boolean
+            ---@param msg string
+            local function take(ok, msg) end
+
+            ---@return number, string
+            local function producer() return 1, "x" end
+
+            take(producer())
+            "#,
+        ));
+    }
+
+    #[test]
+    fn issue_47_multi_return_expansion_reports_later_slot_mismatch() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param ok boolean
+            ---@param msg string
+            local function take(ok, msg) end
+
+            ---@return boolean, table
+            local function producer() return true, {} end
+
+            take(producer())
+            "#,
+        ));
+    }
+
+    #[test]
     fn callback_with_fewer_params_and_compatible_return_is_accepted() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/semantic/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/mod.rs
@@ -366,14 +366,18 @@ impl<'a> SemanticModel<'a> {
         compact_expr: &LuaExpr,
     ) -> TypeCheckResult {
         let compact_fact = self.infer_expr_fact(compact_expr.clone());
+        self.type_check_expr_detail_with_type(source, compact_fact.typ(), compact_expr)
+    }
+
+    pub(crate) fn type_check_expr_detail_with_type(
+        &self,
+        source: &LuaType,
+        compact_type: &LuaType,
+        compact_expr: &LuaExpr,
+    ) -> TypeCheckResult {
         let mut member_facts = HashMap::new();
         self.collect_table_expr_member_facts(compact_expr, &mut member_facts);
-        check_type_compact_detail_with_member_facts(
-            self.db,
-            source,
-            compact_fact.typ(),
-            member_facts,
-        )
+        check_type_compact_detail_with_member_facts(self.db, source, compact_type, member_facts)
     }
 
     fn collect_table_expr_member_facts(


### PR DESCRIPTION
## Summary
- Fixed parameter type checking for call expressions to pass the expected argument type into expression checking, enabling correct positional matching for multi-return expansion.
- Added `SemanticModel::type_check_expr_detail_with_type` and refactored existing detail check path to support explicit compact type context.
- Added regression tests for issue-47 behavior across:
  - accepting valid multi-return positional expansion,
  - reporting mismatch on first return slot,
  - reporting mismatch on later return slots.

## Testing
- Not run in this draft.
- Added/updated tests in `crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs` covering producer/consumer multi-return patterns.
- Suggested verification: run `cargo test -p glua_code_analysis param_type_check_test::issue_47_multi_return_expansion_uses_positional_types` and the related `issue_47_*` tests.

Closes #47