### PR TITLE
Add deterministic library collision precedence and warning reporting

### DIFF
--- a/crates/glua_check/src/lib.rs
+++ b/crates/glua_check/src/lib.rs
@@ -60,6 +60,9 @@ pub async fn run_check(cmd_args: CmdArgs) -> Result<(), Box<dyn Error + Sync + S
             return Err("Failed to load workspace".into());
         }
     };
+    for collision in analysis.library_definition_collisions() {
+        log::warn!("{}", collision.warning_message());
+    }
 
     let db = analysis.compilation.get_db();
     let ignore_dirs: Vec<PathBuf> = analysis

--- a/crates/glua_code_analysis/src/compilation/test/library_collision_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/library_collision_test.rs
@@ -1,0 +1,354 @@
+#[cfg(test)]
+mod tests {
+    use crate::{DiagnosticCode, VirtualWorkspace};
+    use lsp_types::NumberOrString;
+    use tokio_util::sync::CancellationToken;
+
+    const DUPLICATE_ANNOTATIONS: &str = r#"
+        ---@meta
+
+        ---@class Critter
+        local Critter = {}
+
+        ---@class Bird : Critter
+        ---@field song string
+        local Bird = {}
+
+        ---@return boolean
+        ---@return_cast self Bird
+        function Critter:IsBird() end
+    "#;
+
+    const PROBE: &str = r#"
+        ---@param c Critter
+        local function guarded(c)
+            if c:IsBird() then
+                return c.song
+            end
+        end
+        return guarded
+    "#;
+
+    fn workspace_with_libraries(libraries: &[&str]) -> VirtualWorkspace {
+        let mut workspace = VirtualWorkspace::new();
+        for library in libraries {
+            workspace
+                .analysis
+                .add_library_workspace(workspace.virtual_url_generator.new_path(library));
+        }
+        workspace
+    }
+
+    fn diagnostic_count(
+        workspace: &mut VirtualWorkspace,
+        file_id: crate::FileId,
+        code: DiagnosticCode,
+    ) -> usize {
+        workspace.analysis.diagnostic.enable_only(code);
+        workspace
+            .analysis
+            .diagnose_file(file_id, CancellationToken::new())
+            .unwrap_or_default()
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.code == Some(NumberOrString::String(code.get_name().to_string()))
+            })
+            .count()
+    }
+
+    fn define_duplicate_reproduction(workspace: &mut VirtualWorkspace) -> crate::FileId {
+        workspace.def_file("lib_a/annotations.lua", DUPLICATE_ANNOTATIONS);
+        workspace.def_file("lib_b/annotations.lua", DUPLICATE_ANNOTATIONS);
+        workspace.def_file("probe.lua", PROBE)
+    }
+
+    #[test]
+    fn duplicate_library_return_cast_uses_first_library_signature() {
+        let mut workspace = workspace_with_libraries(&["lib_a", "lib_b"]);
+        let probe_file = define_duplicate_reproduction(&mut workspace);
+
+        assert_eq!(
+            diagnostic_count(
+                &mut workspace,
+                probe_file,
+                DiagnosticCode::InferUnguardedChild
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn single_library_return_cast_control_remains_clean() {
+        let mut workspace = workspace_with_libraries(&["lib_a"]);
+        workspace.def_file("lib_a/annotations.lua", DUPLICATE_ANNOTATIONS);
+        let probe_file = workspace.def_file("probe.lua", PROBE);
+
+        assert_eq!(
+            diagnostic_count(
+                &mut workspace,
+                probe_file,
+                DiagnosticCode::InferUnguardedChild
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn conflicting_return_cast_follows_library_registration_order() {
+        const FIRST: &str = r#"
+            ---@meta
+            ---@class Critter
+            local Critter = {}
+            ---@class SingingBird : Critter
+            ---@field song string
+            local SingingBird = {}
+            ---@return boolean
+            ---@return_cast self SingingBird
+            function Critter:IsKind() end
+        "#;
+        const SECOND: &str = r#"
+            ---@meta
+            ---@class Critter
+            local Critter = {}
+            ---@class QuietBird : Critter
+            ---@field silence boolean
+            local QuietBird = {}
+            ---@return boolean
+            ---@return_cast self QuietBird
+            function Critter:IsKind() end
+        "#;
+        const CONSUMER: &str = r#"
+            ---@param c Critter
+            local function guarded(c)
+                if c:IsKind() then
+                    return c.song
+                end
+            end
+            return guarded
+        "#;
+
+        let mut first_wins = workspace_with_libraries(&["lib_a", "lib_b"]);
+        first_wins.def_file("lib_a/annotations.lua", FIRST);
+        first_wins.def_file("lib_b/annotations.lua", SECOND);
+        let first_probe = first_wins.def_file("probe.lua", CONSUMER);
+
+        let mut second_wins = workspace_with_libraries(&["lib_b", "lib_a"]);
+        second_wins.def_file("lib_a/annotations.lua", FIRST);
+        second_wins.def_file("lib_b/annotations.lua", SECOND);
+        let second_probe = second_wins.def_file("probe.lua", CONSUMER);
+
+        assert_eq!(
+            diagnostic_count(
+                &mut first_wins,
+                first_probe,
+                DiagnosticCode::InferUnguardedChild
+            ),
+            0
+        );
+        assert_eq!(
+            diagnostic_count(
+                &mut second_wins,
+                second_probe,
+                DiagnosticCode::UndefinedField
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn later_library_still_contributes_unique_members() {
+        let mut workspace = workspace_with_libraries(&["lib_a", "lib_b"]);
+        workspace.def_file("lib_a/annotations.lua", DUPLICATE_ANNOTATIONS);
+        workspace.def_file(
+            "lib_b/extension.lua",
+            r#"
+            ---@meta
+            ---@class (partial) Critter
+            ---@field age integer
+            "#,
+        );
+        let probe_file = workspace.def_file(
+            "probe.lua",
+            r#"
+            ---@param c Critter
+            local function read(c)
+                return c.age
+            end
+            return read
+            "#,
+        );
+
+        assert_eq!(
+            diagnostic_count(&mut workspace, probe_file, DiagnosticCode::UndefinedField),
+            0
+        );
+    }
+
+    #[test]
+    fn collision_report_is_grouped_readable_and_deterministic() {
+        let mut workspace = workspace_with_libraries(&["lib_a", "lib_b"]);
+        define_duplicate_reproduction(&mut workspace);
+
+        let collisions = workspace.analysis.library_definition_collisions();
+
+        assert_eq!(collisions.len(), 1);
+        assert_eq!(collisions[0].type_collisions, 2);
+        assert_eq!(collisions[0].member_collisions, 2);
+        assert_eq!(
+            collisions[0].examples,
+            vec![
+                "Bird".to_string(),
+                "Bird.song".to_string(),
+                "Critter".to_string(),
+                "Critter:IsBird".to_string(),
+            ]
+        );
+        assert!(collisions[0].preferred_root.ends_with("lib_a"));
+        assert!(collisions[0].shadowed_root.ends_with("lib_b"));
+    }
+
+    #[test]
+    fn disjoint_partial_library_extensions_do_not_report_collisions() {
+        let mut workspace = workspace_with_libraries(&["lib_a", "lib_b"]);
+        workspace.def_file(
+            "lib_a/extension.lua",
+            r#"
+            ---@meta
+            ---@class (partial) SharedType
+            ---@field first string
+            "#,
+        );
+        workspace.def_file(
+            "lib_b/extension.lua",
+            r#"
+            ---@meta
+            ---@class (partial) SharedType
+            ---@field second integer
+            "#,
+        );
+
+        assert!(
+            workspace
+                .analysis
+                .library_definition_collisions()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn collision_report_updates_after_delete_and_reopen() {
+        let mut workspace = workspace_with_libraries(&["lib_a", "lib_b"]);
+        let preferred_uri = workspace
+            .virtual_url_generator
+            .new_uri("lib_a/annotations.lua");
+        let probe_file = define_duplicate_reproduction(&mut workspace);
+        assert_eq!(workspace.analysis.library_definition_collisions().len(), 1);
+
+        workspace
+            .analysis
+            .remove_file_by_uri(&preferred_uri)
+            .expect("preferred library file should exist");
+        assert!(
+            workspace
+                .analysis
+                .library_definition_collisions()
+                .is_empty()
+        );
+        assert_eq!(
+            diagnostic_count(
+                &mut workspace,
+                probe_file,
+                DiagnosticCode::InferUnguardedChild
+            ),
+            0
+        );
+
+        workspace
+            .analysis
+            .update_file_by_uri(&preferred_uri, Some(DUPLICATE_ANNOTATIONS.to_string()))
+            .expect("preferred library file should reopen");
+        assert_eq!(workspace.analysis.library_definition_collisions().len(), 1);
+        assert_eq!(
+            diagnostic_count(
+                &mut workspace,
+                probe_file,
+                DiagnosticCode::InferUnguardedChild
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn collision_report_counts_aliases_attributes_fields_and_methods() {
+        const DEFINITIONS: &str = r#"
+            ---@meta
+            ---@alias SharedAlias string
+            ---@attribute shared_attribute(value: string)
+
+            ---@class SharedClass
+            ---@field value string
+            local SharedClass = {}
+
+            function SharedClass:Read() end
+        "#;
+        let mut workspace = workspace_with_libraries(&["lib_a", "lib_b"]);
+        workspace.def_file("lib_a/annotations.lua", DEFINITIONS);
+        workspace.def_file("lib_b/annotations.lua", DEFINITIONS);
+
+        let collisions = workspace.analysis.library_definition_collisions();
+
+        assert_eq!(collisions.len(), 1);
+        assert_eq!(collisions[0].type_collisions, 3);
+        assert_eq!(collisions[0].member_collisions, 2);
+        assert!(collisions[0].examples.contains(&"SharedAlias".to_string()));
+        assert!(
+            collisions[0]
+                .examples
+                .contains(&"shared_attribute".to_string())
+        );
+        assert!(
+            collisions[0]
+                .examples
+                .contains(&"SharedClass.value".to_string())
+        );
+        assert!(
+            collisions[0]
+                .examples
+                .contains(&"SharedClass:Read".to_string())
+        );
+    }
+
+    #[test]
+    fn duplicate_registration_of_one_normalized_root_is_not_a_collision() {
+        let mut workspace = VirtualWorkspace::new();
+        let root = workspace.virtual_url_generator.new_path("lib_a");
+        workspace.analysis.add_library_workspace(root.clone());
+        workspace.analysis.add_library_workspace(root);
+        workspace.def_file("lib_a/annotations.lua", DUPLICATE_ANNOTATIONS);
+
+        assert!(
+            workspace
+                .analysis
+                .library_definition_collisions()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn warning_message_contains_precedence_counts_and_examples() {
+        let mut workspace = workspace_with_libraries(&["lib_a", "lib_b"]);
+        define_duplicate_reproduction(&mut workspace);
+        let collision = workspace
+            .analysis
+            .library_definition_collisions()
+            .into_iter()
+            .next()
+            .expect("collision");
+
+        let warning = collision.warning_message();
+
+        assert!(warning.contains("earlier workspace.library entry takes precedence"));
+        assert!(warning.contains("2 types, 2 members"));
+        assert!(warning.contains("Critter:IsBird"));
+    }
+}

--- a/crates/glua_code_analysis/src/compilation/test/mod.rs
+++ b/crates/glua_code_analysis/src/compilation/test/mod.rs
@@ -21,6 +21,7 @@ mod gmod_scripted_class_test;
 mod infer_str_tpl_test;
 mod inherit_type;
 mod legacy_module_test;
+mod library_collision_test;
 mod mathlib_test;
 mod member_infer_test;
 mod metatable_test;

--- a/crates/glua_code_analysis/src/db_index/member/lua_member_feature.rs
+++ b/crates/glua_code_analysis/src/db_index/member/lua_member_feature.rs
@@ -32,6 +32,13 @@ impl LuaMemberFeature {
         )
     }
 
+    pub fn is_method_decl(&self) -> bool {
+        matches!(
+            self,
+            LuaMemberFeature::FileMethodDecl | LuaMemberFeature::MetaMethodDecl
+        )
+    }
+
     pub fn is_decl(&self) -> bool {
         matches!(
             self,

--- a/crates/glua_code_analysis/src/db_index/member/lua_member_item.rs
+++ b/crates/glua_code_analysis/src/db_index/member/lua_member_item.rs
@@ -5,7 +5,8 @@ use std::{
 
 use crate::{
     DbIndex, FileId, InferFailReason, LuaFunctionType, LuaSemanticDeclId, LuaType, TypeOps,
-    db_index::gmod_infer::GmodRealm, is_table_assignment_merge_type, widen_file_define_member_type,
+    db_index::{WorkspaceKind, WorkspaceResolutionKey, gmod_infer::GmodRealm},
+    is_table_assignment_merge_type, widen_file_define_member_type,
 };
 use glua_parser::{BinaryOperator, LuaAssignStat, LuaAstNode, LuaExpr, PathTrait};
 use rowan::TextSize;
@@ -858,10 +859,13 @@ fn get_member_id_priority_tiers(
     db: &DbIndex,
     caller_file_id: &FileId,
     member_ids: &[LuaMemberId],
-) -> Vec<(u8, Vec<LuaMemberId>)> {
+) -> Vec<(WorkspaceResolutionKey, Vec<LuaMemberId>)> {
     let module_index = db.get_module_index();
     let Some(caller_workspace_id) = module_index.get_workspace_id(*caller_file_id) else {
-        return vec![(0, member_ids.to_vec())];
+        return vec![(
+            WorkspaceResolutionKey::new(0, 0, crate::WorkspaceId { id: 0 }),
+            member_ids.to_vec(),
+        )];
     };
 
     let mut priority_tiers = BTreeMap::new();
@@ -870,7 +874,7 @@ fn get_member_id_priority_tiers(
             .get_workspace_id(member_id.file_id)
             .unwrap_or(crate::WorkspaceId::MAIN);
         let Some(priority) =
-            module_index.workspace_resolution_priority(caller_workspace_id, candidate_workspace_id)
+            module_index.workspace_resolution_key(caller_workspace_id, candidate_workspace_id)
         else {
             continue;
         };
@@ -886,8 +890,8 @@ fn get_member_id_priority_tiers(
 
 fn select_member_ids_by_workspace_and_realm(
     db: &DbIndex,
-    _caller_file_id: &FileId,
-    priority_tiers: Vec<(u8, Vec<LuaMemberId>)>,
+    caller_file_id: &FileId,
+    priority_tiers: Vec<(WorkspaceResolutionKey, Vec<LuaMemberId>)>,
     caller_realm: GmodRealm,
 ) -> Vec<LuaMemberId> {
     if !db.get_emmyrc().gmod.enabled {
@@ -912,12 +916,19 @@ fn select_member_ids_by_workspace_and_realm(
 
     let member_index = db.get_member_index();
     let infer_index = db.get_gmod_infer_index();
+    let caller_is_main = db
+        .get_module_index()
+        .get_workspace_id(*caller_file_id)
+        .is_some_and(|workspace_id| {
+            db.get_module_index().get_workspace_kind(workspace_id) == WorkspaceKind::Main
+        });
 
     let mut result = Vec::new();
     let mut found_first_compatible = false;
     let mut all_seen_are_non_meta = true;
+    let mut can_supplement_from_library = false;
 
-    for (_, tier_member_ids) in priority_tiers {
+    for (priority, tier_member_ids) in priority_tiers {
         let compatible_member_ids = tier_member_ids
             .into_iter()
             .filter(|member_id| {
@@ -940,7 +951,9 @@ fn select_member_ids_by_workspace_and_realm(
             result.extend(compatible_member_ids);
             found_first_compatible = true;
             all_seen_are_non_meta = !has_meta;
-        } else if all_seen_are_non_meta {
+            can_supplement_from_library =
+                caller_is_main && priority.broad_tier() == 0 && all_seen_are_non_meta;
+        } else if can_supplement_from_library && all_seen_are_non_meta {
             // We have only non-meta members so far. Supplement with any
             // meta (annotated) members from this lower-priority tier so that
             // resolve_member_type can prefer them via meta_override_file_define.
@@ -1262,7 +1275,7 @@ mod tests {
 
     use crate::{
         DbIndex, Emmyrc, FileId, GmodRealm, GmodRealmFileMetadata, GmodRealmRange, InFiled,
-        LuaSemanticDeclId, LuaType, LuaTypeDeclId, WorkspaceId,
+        LuaSemanticDeclId, LuaType, LuaTypeDeclId, WorkspaceId, WorkspaceResolutionKey,
         db_index::{
             LuaMember, LuaMemberFeature, LuaMemberId, LuaMemberKey, LuaMemberOwner, WorkspaceKind,
         },
@@ -1282,6 +1295,10 @@ mod tests {
     fn make_member_id_with_kind(file_id: FileId, start: u32, kind: LuaSyntaxKind) -> LuaMemberId {
         let range = TextRange::new(TextSize::new(start), TextSize::new(start + 1));
         LuaMemberId::new(LuaSyntaxId::new(kind.into(), range), file_id)
+    }
+
+    fn priority(tier: u8) -> WorkspaceResolutionKey {
+        WorkspaceResolutionKey::new(tier, 0, WorkspaceId { id: 0 })
     }
 
     fn table_const(start: u32, end: u32) -> LuaType {
@@ -1392,8 +1409,14 @@ mod tests {
         );
 
         assert_eq!(tiers.len(), 2);
-        assert_eq!(tiers[0], (1, vec![library_member]));
-        assert_eq!(tiers[1], (2, vec![std_member]));
+        assert_eq!(
+            tiers[0],
+            (
+                WorkspaceResolutionKey::new(1, 2, library_workspace),
+                vec![library_member]
+            )
+        );
+        assert_eq!(tiers[1], (priority(2), vec![std_member]));
     }
 
     #[test]
@@ -1432,7 +1455,96 @@ mod tests {
             get_member_id_priority_tiers(&db, &caller_file, &[caller_member, other_main_member]);
 
         assert_eq!(tiers.len(), 1);
-        assert_eq!(tiers[0], (0, vec![caller_member, other_main_member]));
+        assert_eq!(
+            tiers[0],
+            (priority(0), vec![caller_member, other_main_member])
+        );
+    }
+
+    #[test]
+    fn member_id_priority_tiers_split_library_roots_in_registration_order() {
+        let mut db = make_db();
+        let module_index = db.get_module_index_mut();
+        let first_library = WorkspaceId { id: 3 };
+        let second_library = WorkspaceId { id: 4 };
+
+        module_index.add_workspace_root_with_kind(
+            Path::new("C:/Project").into(),
+            WorkspaceId::MAIN,
+            WorkspaceKind::Main,
+        );
+        module_index.add_workspace_root_with_kind(
+            Path::new("C:/Libraries/first").into(),
+            first_library,
+            WorkspaceKind::Library,
+        );
+        module_index.add_workspace_root_with_kind(
+            Path::new("C:/Libraries/second").into(),
+            second_library,
+            WorkspaceKind::Library,
+        );
+
+        let caller_file = FileId::new(1);
+        let first_file = FileId::new(2);
+        let second_file = FileId::new(3);
+        module_index.add_module_by_path(caller_file, "C:/Project/init.lua");
+        module_index.add_module_by_path(first_file, "C:/Libraries/first/api.lua");
+        module_index.add_module_by_path(second_file, "C:/Libraries/second/api.lua");
+        let first_member = make_member_id(first_file, 1);
+        let second_member = make_member_id(second_file, 1);
+
+        let tiers = get_member_id_priority_tiers(&db, &caller_file, &[second_member, first_member]);
+
+        assert_eq!(
+            tiers,
+            vec![
+                (
+                    WorkspaceResolutionKey::new(1, 1, first_library),
+                    vec![first_member]
+                ),
+                (
+                    WorkspaceResolutionKey::new(1, 2, second_library),
+                    vec![second_member]
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn member_id_priority_tiers_keep_same_library_declarations_together() {
+        let mut db = make_db();
+        let module_index = db.get_module_index_mut();
+        let library = WorkspaceId { id: 3 };
+
+        module_index.add_workspace_root_with_kind(
+            Path::new("C:/Project").into(),
+            WorkspaceId::MAIN,
+            WorkspaceKind::Main,
+        );
+        module_index.add_workspace_root_with_kind(
+            Path::new("C:/Libraries/annotations").into(),
+            library,
+            WorkspaceKind::Library,
+        );
+
+        let caller_file = FileId::new(1);
+        let first_file = FileId::new(2);
+        let second_file = FileId::new(3);
+        module_index.add_module_by_path(caller_file, "C:/Project/init.lua");
+        module_index.add_module_by_path(first_file, "C:/Libraries/annotations/first.lua");
+        module_index.add_module_by_path(second_file, "C:/Libraries/annotations/second.lua");
+        let first_member = make_member_id(first_file, 1);
+        let second_member = make_member_id(second_file, 1);
+
+        let tiers = get_member_id_priority_tiers(&db, &caller_file, &[second_member, first_member]);
+
+        assert_eq!(
+            tiers,
+            vec![(
+                WorkspaceResolutionKey::new(1, 1, library),
+                vec![second_member, first_member]
+            )]
+        );
     }
 
     #[test]
@@ -1452,7 +1564,10 @@ mod tests {
         let selected = select_member_ids_by_workspace_and_realm(
             &db,
             &FileId::new(100),
-            vec![(0, vec![tier_one_member]), (1, vec![tier_two_member])],
+            vec![
+                (priority(0), vec![tier_one_member]),
+                (priority(1), vec![tier_two_member]),
+            ],
             GmodRealm::Client,
         );
 
@@ -1476,11 +1591,47 @@ mod tests {
         let selected = select_member_ids_by_workspace_and_realm(
             &db,
             &FileId::new(101),
-            vec![(0, vec![server_member]), (1, vec![unknown_member])],
+            vec![
+                (priority(0), vec![server_member]),
+                (priority(1), vec![unknown_member]),
+            ],
             GmodRealm::Client,
         );
 
         assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn select_member_ids_by_workspace_and_realm_uses_next_realm_compatible_library() {
+        let mut db = make_db();
+        let first_library_member = make_member_id(FileId::new(20), 1);
+        let second_library_member = make_member_id(FileId::new(21), 2);
+
+        set_file_realms(
+            &mut db,
+            &[
+                (first_library_member.file_id, GmodRealm::Server),
+                (second_library_member.file_id, GmodRealm::Client),
+            ],
+        );
+
+        let selected = select_member_ids_by_workspace_and_realm(
+            &db,
+            &FileId::new(101),
+            vec![
+                (
+                    WorkspaceResolutionKey::new(1, 1, WorkspaceId { id: 3 }),
+                    vec![first_library_member],
+                ),
+                (
+                    WorkspaceResolutionKey::new(1, 2, WorkspaceId { id: 4 }),
+                    vec![second_library_member],
+                ),
+            ],
+            GmodRealm::Client,
+        );
+
+        assert_eq!(selected, vec![second_library_member]);
     }
 
     #[test]
@@ -1502,7 +1653,7 @@ mod tests {
         let selected = select_member_ids_by_workspace_and_realm(
             &db,
             &caller_file,
-            vec![(0, vec![other_file_member, same_file_member])],
+            vec![(priority(0), vec![other_file_member, same_file_member])],
             GmodRealm::Server,
         );
 
@@ -1521,13 +1672,13 @@ mod tests {
         let selected_forward = select_member_ids_by_workspace_and_realm(
             &db,
             &caller_file,
-            vec![(0, vec![first_member, second_member])],
+            vec![(priority(0), vec![first_member, second_member])],
             GmodRealm::Server,
         );
         let selected_reversed = select_member_ids_by_workspace_and_realm(
             &db,
             &caller_file,
-            vec![(0, vec![second_member, first_member])],
+            vec![(priority(0), vec![second_member, first_member])],
             GmodRealm::Server,
         );
 
@@ -2173,7 +2324,10 @@ mod tests {
         let selected = select_member_ids_by_workspace_and_realm(
             &db,
             &caller_file,
-            vec![(0, vec![override_member]), (1, vec![library_member])],
+            vec![
+                (priority(0), vec![override_member]),
+                (priority(1), vec![library_member]),
+            ],
             GmodRealm::Shared,
         );
 

--- a/crates/glua_code_analysis/src/db_index/member/lua_member_item.rs
+++ b/crates/glua_code_analysis/src/db_index/member/lua_member_item.rs
@@ -967,8 +967,11 @@ fn select_member_ids_by_workspace_and_realm(
                 .collect();
             if !meta_members.is_empty() {
                 result.extend(meta_members);
-                all_seen_are_non_meta = false;
             }
+            // Each library root has its own tier. Once the first compatible
+            // lower tier is examined, later libraries must not supply
+            // metadata for the same member.
+            break;
         }
     }
 
@@ -2343,5 +2346,83 @@ mod tests {
             selected.contains(&override_member),
             "main-workspace FileMethodDecl override should still be included"
         );
+    }
+
+    #[test]
+    fn select_member_ids_does_not_skip_first_compatible_library_for_metadata() {
+        let mut db = make_db();
+        let module_index = db.get_module_index_mut();
+        let first_library = WorkspaceId { id: 3 };
+        let second_library = WorkspaceId { id: 4 };
+
+        module_index.add_workspace_root_with_kind(
+            Path::new("C:/Project").into(),
+            WorkspaceId::MAIN,
+            WorkspaceKind::Main,
+        );
+        module_index.add_workspace_root_with_kind(
+            Path::new("C:/Libraries/first").into(),
+            first_library,
+            WorkspaceKind::Library,
+        );
+        module_index.add_workspace_root_with_kind(
+            Path::new("C:/Libraries/second").into(),
+            second_library,
+            WorkspaceKind::Library,
+        );
+
+        let caller_file = FileId::new(1);
+        let main_file = FileId::new(2);
+        let first_library_file = FileId::new(3);
+        let second_library_file = FileId::new(4);
+        module_index.add_module_by_path(caller_file, "C:/Project/init.lua");
+        module_index.add_module_by_path(main_file, "C:/Project/override.lua");
+        module_index.add_module_by_path(first_library_file, "C:/Libraries/first/api.lua");
+        module_index.add_module_by_path(second_library_file, "C:/Libraries/second/api.lua");
+
+        let main_member = make_member_id(main_file, 1);
+        let first_library_member = make_member_id(first_library_file, 2);
+        let second_library_member = make_member_id(second_library_file, 3);
+        let owner = LuaMemberOwner::Type(LuaTypeDeclId::global("Example"));
+        let key = LuaMemberKey::Name("Read".into());
+
+        for (member_id, feature) in [
+            (main_member, LuaMemberFeature::FileMethodDecl),
+            (first_library_member, LuaMemberFeature::FileMethodDecl),
+            (second_library_member, LuaMemberFeature::MetaMethodDecl),
+        ] {
+            db.get_member_index_mut().add_member(
+                owner.clone(),
+                LuaMember::new(member_id, key.clone(), feature, None),
+            );
+        }
+        set_file_realms(
+            &mut db,
+            &[
+                (caller_file, GmodRealm::Shared),
+                (main_file, GmodRealm::Shared),
+                (first_library_file, GmodRealm::Shared),
+                (second_library_file, GmodRealm::Shared),
+            ],
+        );
+
+        let selected = select_member_ids_by_workspace_and_realm(
+            &db,
+            &caller_file,
+            vec![
+                (priority(0), vec![main_member]),
+                (
+                    WorkspaceResolutionKey::new(1, 1, first_library),
+                    vec![first_library_member],
+                ),
+                (
+                    WorkspaceResolutionKey::new(1, 2, second_library),
+                    vec![second_library_member],
+                ),
+            ],
+            GmodRealm::Shared,
+        );
+
+        assert_eq!(selected, vec![main_member]);
     }
 }

--- a/crates/glua_code_analysis/src/db_index/member/mod.rs
+++ b/crates/glua_code_analysis/src/db_index/member/mod.rs
@@ -698,6 +698,14 @@ impl LuaMemberIndex {
             .collect()
     }
 
+    pub(crate) fn iter_current_owner_keys(
+        &self,
+    ) -> impl Iterator<Item = (&LuaMemberOwner, &LuaMemberKey)> {
+        self.member_owner_key_index
+            .iter()
+            .flat_map(|(owner, members_by_key)| members_by_key.keys().map(move |key| (owner, key)))
+    }
+
     pub fn add_function_scope_range(&mut self, file_id: FileId, range: TextRange) {
         let ranges = self.function_scope_ranges.entry(file_id).or_default();
         match ranges.binary_search_by_key(&range.start(), |range| range.start()) {

--- a/crates/glua_code_analysis/src/db_index/module/mod.rs
+++ b/crates/glua_code_analysis/src/db_index/module/mod.rs
@@ -11,6 +11,7 @@ pub use module_info::ModuleInfo;
 pub use module_node::{ModuleNode, ModuleNodeId};
 use regex::Regex;
 use rowan::TextSize;
+pub(crate) use workspace::WorkspaceResolutionKey;
 pub use workspace::{Workspace, WorkspaceId, WorkspaceKind};
 
 use super::traits::LuaIndex;
@@ -725,6 +726,50 @@ impl LuaModuleIndex {
                 WorkspaceKind::Main => None,
             },
         }
+    }
+
+    /// Extends the broad workspace-kind priority with configured library order.
+    ///
+    /// For colliding definitions, earlier `workspace.library` entries are
+    /// authoritative. The workspace ID is only a stable final fallback.
+    pub(crate) fn workspace_resolution_key(
+        &self,
+        current_workspace_id: WorkspaceId,
+        candidate_workspace_id: WorkspaceId,
+    ) -> Option<WorkspaceResolutionKey> {
+        let tier =
+            self.workspace_resolution_priority(current_workspace_id, candidate_workspace_id)?;
+        let candidate_kind = self.get_workspace_kind(candidate_workspace_id);
+        let library_order = if candidate_kind == WorkspaceKind::Library {
+            self.workspace_registration_order(candidate_workspace_id)
+                .unwrap_or(usize::MAX)
+        } else {
+            0
+        };
+        let stable_workspace_id = if candidate_kind == WorkspaceKind::Library {
+            candidate_workspace_id
+        } else {
+            WorkspaceId { id: 0 }
+        };
+
+        Some(WorkspaceResolutionKey::new(
+            tier,
+            library_order,
+            stable_workspace_id,
+        ))
+    }
+
+    pub(crate) fn workspace_registration_order(&self, workspace_id: WorkspaceId) -> Option<usize> {
+        self.workspaces
+            .iter()
+            .position(|workspace| workspace.id == workspace_id)
+    }
+
+    pub(crate) fn get_workspace_root(&self, workspace_id: WorkspaceId) -> Option<&Path> {
+        self.workspaces
+            .iter()
+            .find(|workspace| workspace.id == workspace_id)
+            .map(|workspace| workspace.root.as_path())
     }
 
     pub fn extract_module_path(&self, path: &str) -> Option<(String, WorkspaceId)> {

--- a/crates/glua_code_analysis/src/db_index/module/workspace.rs
+++ b/crates/glua_code_analysis/src/db_index/module/workspace.rs
@@ -26,6 +26,27 @@ pub struct WorkspaceId {
     pub id: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct WorkspaceResolutionKey {
+    tier: u8,
+    library_order: usize,
+    workspace_id: u32,
+}
+
+impl WorkspaceResolutionKey {
+    pub(crate) fn new(tier: u8, library_order: usize, workspace_id: WorkspaceId) -> Self {
+        Self {
+            tier,
+            library_order,
+            workspace_id: workspace_id.id,
+        }
+    }
+
+    pub(crate) fn broad_tier(self) -> u8 {
+        self.tier
+    }
+}
+
 #[allow(unused)]
 impl WorkspaceId {
     pub const STD: WorkspaceId = WorkspaceId { id: 0 };

--- a/crates/glua_code_analysis/src/db_index/type/type_decl.rs
+++ b/crates/glua_code_analysis/src/db_index/type/type_decl.rs
@@ -288,6 +288,10 @@ impl LuaTypeDeclId {
         self.id.as_ref()
     }
 
+    pub(crate) fn is_global(&self) -> bool {
+        matches!(self.id.as_ref(), LuaTypeIdentifier::Global(_))
+    }
+
     pub fn get_name(&self) -> &str {
         match self.id.as_ref() {
             LuaTypeIdentifier::Global(name) => name.as_ref(),

--- a/crates/glua_code_analysis/src/lib.rs
+++ b/crates/glua_code_analysis/src/lib.rs
@@ -14,6 +14,7 @@ mod config;
 mod db_index;
 mod diagnostic;
 mod gamemode_base;
+mod library_collision;
 mod profile;
 mod resources;
 mod semantic;
@@ -30,6 +31,7 @@ use glua_parser::{
     LineIndex, LuaAstNode, LuaCallExpr, LuaExpr, LuaIndexKey, LuaLocalStat, LuaNameExpr,
     LuaParenExpr, LuaParser, LuaSyntaxTree,
 };
+pub use library_collision::LibraryDefinitionCollision;
 use lsp_types::Uri;
 pub use profile::Profile;
 use resources::load_resource_std;

--- a/crates/glua_code_analysis/src/library_collision.rs
+++ b/crates/glua_code_analysis/src/library_collision.rs
@@ -1,0 +1,222 @@
+use std::{
+    collections::{BTreeSet, HashMap},
+    path::PathBuf,
+};
+
+use crate::{
+    EmmyLuaAnalysis, FileId, LuaMember, LuaMemberKey, LuaMemberOwner, LuaTypeFlag, WorkspaceId,
+    WorkspaceKind,
+};
+
+const MAX_COLLISION_EXAMPLES: usize = 5;
+
+/// Describes definitions shadowed by an earlier configured library root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LibraryDefinitionCollision {
+    /// The earlier, authoritative library root.
+    pub preferred_root: PathBuf,
+    /// The later library root whose colliding definitions are shadowed.
+    pub shadowed_root: PathBuf,
+    /// The number of colliding global type definitions.
+    pub type_collisions: usize,
+    /// The number of colliding stable member definitions.
+    pub member_collisions: usize,
+    /// Up to five deterministically sorted, readable symbol names.
+    pub examples: Vec<String>,
+}
+
+impl LibraryDefinitionCollision {
+    /// Formats the deterministic warning shared by the CLI and language server.
+    pub fn warning_message(&self) -> String {
+        let examples = if self.examples.is_empty() {
+            String::new()
+        } else {
+            format!("; examples: {}", self.examples.join(", "))
+        };
+        format!(
+            "Library '{}' overlaps definitions from earlier library '{}'; the earlier \
+             workspace.library entry takes precedence ({} types, {} members{}).",
+            self.shadowed_root.display(),
+            self.preferred_root.display(),
+            self.type_collisions,
+            self.member_collisions,
+            examples,
+        )
+    }
+}
+
+#[derive(Debug, Default)]
+struct CollisionAccumulator {
+    type_collisions: usize,
+    member_collisions: usize,
+    examples: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct LibraryLocation {
+    workspace_id: WorkspaceId,
+    order: usize,
+}
+
+impl EmmyLuaAnalysis {
+    /// Returns cross-library definition collisions in configured precedence order.
+    pub fn library_definition_collisions(&self) -> Vec<LibraryDefinitionCollision> {
+        let db = self.compilation.get_db();
+        let module_index = db.get_module_index();
+        let mut collisions = HashMap::<(WorkspaceId, WorkspaceId), CollisionAccumulator>::new();
+
+        for type_decl in db.get_type_index().get_all_types() {
+            if !type_decl.get_id().is_global() {
+                continue;
+            }
+
+            let locations = type_decl.get_locations();
+            if locations
+                .iter()
+                .all(|location| location.flag.contains(LuaTypeFlag::Partial))
+            {
+                continue;
+            }
+
+            let library_locations = collect_library_locations(
+                module_index,
+                locations.iter().map(|location| location.file_id),
+            );
+            record_collision(
+                &mut collisions,
+                &library_locations,
+                type_decl.get_full_name(),
+                CollisionKind::Type,
+            );
+        }
+
+        let member_index = db.get_member_index();
+        for (owner, key) in member_index.iter_current_owner_keys() {
+            if !matches!(key, LuaMemberKey::Name(_) | LuaMemberKey::Integer(_)) {
+                continue;
+            }
+            let members = member_index.get_members_for_owner_key(owner, key);
+            let library_locations = collect_library_locations(
+                module_index,
+                members.iter().map(|member| member.get_file_id()),
+            );
+            let Some(example) = format_member_example(owner, key, &members) else {
+                continue;
+            };
+            record_collision(
+                &mut collisions,
+                &library_locations,
+                &example,
+                CollisionKind::Member,
+            );
+        }
+
+        let mut result = collisions
+            .into_iter()
+            .filter_map(|((preferred_id, shadowed_id), collision)| {
+                let preferred_root = module_index.get_workspace_root(preferred_id)?.to_path_buf();
+                let shadowed_root = module_index.get_workspace_root(shadowed_id)?.to_path_buf();
+                Some(LibraryDefinitionCollision {
+                    preferred_root,
+                    shadowed_root,
+                    type_collisions: collision.type_collisions,
+                    member_collisions: collision.member_collisions,
+                    examples: collision
+                        .examples
+                        .into_iter()
+                        .take(MAX_COLLISION_EXAMPLES)
+                        .collect(),
+                })
+            })
+            .collect::<Vec<_>>();
+        result.sort_by(|left, right| {
+            left.preferred_root
+                .cmp(&right.preferred_root)
+                .then_with(|| left.shadowed_root.cmp(&right.shadowed_root))
+        });
+        result
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CollisionKind {
+    Type,
+    Member,
+}
+
+fn collect_library_locations(
+    module_index: &crate::LuaModuleIndex,
+    file_ids: impl Iterator<Item = FileId>,
+) -> Vec<LibraryLocation> {
+    let mut by_workspace = HashMap::<WorkspaceId, LibraryLocation>::new();
+    for file_id in file_ids {
+        let Some(workspace_id) = module_index.get_workspace_id(file_id) else {
+            continue;
+        };
+        if module_index.get_workspace_kind(workspace_id) != WorkspaceKind::Library {
+            continue;
+        }
+        let Some(order) = module_index.workspace_registration_order(workspace_id) else {
+            continue;
+        };
+        by_workspace.entry(workspace_id).or_insert(LibraryLocation {
+            workspace_id,
+            order,
+        });
+    }
+
+    let mut locations = by_workspace.into_values().collect::<Vec<_>>();
+    locations.sort_by_key(|location| (location.order, location.workspace_id.id));
+    locations
+}
+
+fn record_collision(
+    collisions: &mut HashMap<(WorkspaceId, WorkspaceId), CollisionAccumulator>,
+    locations: &[LibraryLocation],
+    example: &str,
+    kind: CollisionKind,
+) {
+    let Some(preferred) = locations.first() else {
+        return;
+    };
+    for shadowed in &locations[1..] {
+        let collision = collisions
+            .entry((preferred.workspace_id, shadowed.workspace_id))
+            .or_default();
+        match kind {
+            CollisionKind::Type => collision.type_collisions += 1,
+            CollisionKind::Member => collision.member_collisions += 1,
+        }
+        collision.examples.insert(example.to_string());
+    }
+}
+
+fn format_member_example(
+    owner: &LuaMemberOwner,
+    key: &LuaMemberKey,
+    members: &[&LuaMember],
+) -> Option<String> {
+    let owner_name = match owner {
+        LuaMemberOwner::Type(type_id) => type_id.get_name(),
+        LuaMemberOwner::GlobalPath(global_id) => global_id.get_name(),
+        LuaMemberOwner::LocalUnresolve | LuaMemberOwner::Element(_) => return None,
+    };
+    let key_name = match key {
+        LuaMemberKey::Name(name) => name.to_string(),
+        LuaMemberKey::Integer(index) => format!("[{index}]"),
+        LuaMemberKey::None | LuaMemberKey::ExprType(_) => return None,
+    };
+    let separator = if matches!(owner, LuaMemberOwner::Type(_))
+        && members
+            .iter()
+            .any(|member| member.get_feature().is_method_decl())
+    {
+        ":"
+    } else if matches!(key, LuaMemberKey::Integer(_)) {
+        ""
+    } else {
+        "."
+    };
+
+    Some(format!("{owner_name}{separator}{key_name}"))
+}

--- a/crates/glua_ls/src/handlers/initialized/mod.rs
+++ b/crates/glua_ls/src/handlers/initialized/mod.rs
@@ -367,6 +367,7 @@ pub async fn init_analysis(
     } else {
         Vec::new()
     };
+    let library_collisions = mut_analysis.library_definition_collisions();
 
     file_diagnostic.invalidate_shared_diagnostic_data();
     drop(mut_analysis);
@@ -378,6 +379,21 @@ pub async fn init_analysis(
         watchdog_status.describe(),
     );
     log::info!("workspace index ready");
+
+    for collision in &library_collisions {
+        log::warn!("{}", collision.warning_message());
+    }
+    if !library_collisions.is_empty() {
+        client.show_message(ShowMessageParams {
+            typ: MessageType::WARNING,
+            message: format!(
+                "GLuaLS found overlapping definitions in {} library-root pair(s). Earlier \
+                 workspace.library entries take precedence. See the GLuaLS output log for roots \
+                 and examples.",
+                library_collisions.len()
+            ),
+        });
+    }
 
     if !schema_urls.is_empty() {
         watchdog_status.set_progress("Fetching JSON schemas", 0, schema_urls.len());


### PR DESCRIPTION
## Summary
- Introduced library collision detection in `glua_code_analysis` to compute cross-library definition overlaps (types + members), determine a preferred earlier-library winner, and provide deterministic, bounded examples.
- Added a `WorkspaceResolutionKey` and updated member/type resolution to preserve same-tier grouping while deterministically splitting library declarations by configured `workspace.library` registration order.
- Updated resolver logic so main workspace callers keep using the first compatible non-meta declaration tier and can still supplement with lower-tier metadata methods/fields when appropriate.
- Added library-collision-focused test coverage in `crates/glua_code_analysis/src/compilation/test/library_collision_test.rs` for precedence, partial extensions, collision reporting stability, reload behavior, and message contents.
- Wired collision warnings into user-facing outputs in `glua_check` and initialization path of `glua_ls`.

## Testing
- Added and exercised unit tests in `crates/glua_code_analysis/src/compilation/test/library_collision_test.rs` and existing `lua_member_item` resolution tests for new key ordering/supplementation behavior.
- Not run: full `cargo test`/CI suite (no explicit request to execute).
- Not run: manual `glua_check`/LSP runtime smoke test for warning output in CLI/extension startup (not requested).

Closes #48