### PR TITLE
Fix deferred closure flow narrowing for immutable return-cast guards

### DIFF
--- a/crates/glua_code_analysis/src/compilation/test/flow.rs
+++ b/crates/glua_code_analysis/src/compilation/test/flow.rs
@@ -26,6 +26,7 @@ mod test {
             ---@param value any
             ---@return TypeGuard<any>
             ---@return_cast value -NULL
+            ---@[valid_guard]
             function IsValid(value) end
             "#,
         );
@@ -1237,8 +1238,9 @@ end
     }
 
     #[test]
-    fn deferred_closure_drops_immutable_entity_isvalid_guard() {
+    fn deferred_closure_retains_immutable_entity_isvalid_guard() {
         let mut ws = VirtualWorkspace::new();
+        set_gmod_enabled(&mut ws);
         def_isvalid_guard(&mut ws);
 
         ws.def(
@@ -1253,12 +1255,12 @@ end
         );
 
         let captured = ws.expr_ty("isvalid_capture");
-        let expected = ws.ty("Entity|NULL");
+        let expected = ws.ty("Entity");
         assert_eq!(captured, expected);
     }
 
     #[test]
-    fn deferred_closure_drops_custom_type_guard() {
+    fn deferred_closure_retains_custom_type_guard() {
         let mut ws = VirtualWorkspace::new();
 
         ws.def(
@@ -1277,8 +1279,184 @@ end
         );
 
         let captured = ws.expr_ty("custom_guard_capture");
-        let expected = ws.ty("string|number");
+        let expected = ws.ty("string");
         assert_eq!(captured, expected);
+    }
+
+    #[test]
+    fn deferred_closure_retains_immutable_return_cast_self_guard() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Entity
+            ---@class Player: Entity
+
+            ---@return boolean
+            ---@return_cast self Player
+            function Entity:IsPlayer() end
+
+            ---@param ent Entity
+            local function make(ent)
+                if ent:IsPlayer() then
+                    direct_return_cast_capture = ent
+                    local callback = function()
+                        closure_return_cast_capture = ent
+                    end
+                end
+            end
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("direct_return_cast_capture"), ws.ty("Player"));
+        assert_eq!(ws.expr_ty("closure_return_cast_capture"), ws.ty("Player"));
+    }
+
+    #[test]
+    fn deferred_closure_retains_immutable_named_parameter_return_cast() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Entity
+            ---@class Player: Entity
+
+            ---@param value Entity
+            ---@return boolean
+            ---@return_cast value Player
+            local function isPlayer(value) end
+
+            ---@param ent Entity
+            local function make(ent)
+                if isPlayer(ent) then
+                    local callback = function()
+                        named_parameter_return_cast_capture = ent
+                    end
+                end
+            end
+            "#,
+        );
+
+        assert_eq!(
+            ws.expr_ty("named_parameter_return_cast_capture"),
+            ws.ty("Player")
+        );
+    }
+
+    #[test]
+    fn deferred_closure_retains_immutable_return_cast_false_branch() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Entity
+            ---@class Player: Entity
+            ---@class NPC: Entity
+
+            ---@return boolean
+            ---@return_cast self Player else NPC
+            function Entity:IsPlayer() end
+
+            ---@param ent Entity
+            local function make(ent)
+                if ent:IsPlayer() then
+                    return
+                end
+                local callback = function()
+                    return_cast_false_branch_capture = ent
+                end
+            end
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("return_cast_false_branch_capture"), ws.ty("NPC"));
+    }
+
+    #[test]
+    fn nested_deferred_closures_retain_immutable_return_cast_guard() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Entity
+            ---@class Player: Entity
+
+            ---@return boolean
+            ---@return_cast self Player
+            function Entity:IsPlayer() end
+
+            ---@param ent Entity
+            local function make(ent)
+                if ent:IsPlayer() then
+                    local outer = function()
+                        local inner = function()
+                            nested_return_cast_capture = ent
+                        end
+                    end
+                end
+            end
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("nested_return_cast_capture"), ws.ty("Player"));
+    }
+
+    #[test]
+    fn deferred_closure_drops_mutable_return_cast_guard() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class Entity
+            ---@class Player: Entity
+
+            ---@return boolean
+            ---@return_cast self Player
+            function Entity:IsPlayer() end
+
+            ---@param ent Entity
+            ---@param replacement Entity
+            local function make(ent, replacement)
+                if ent:IsPlayer() then
+                    local callback = function()
+                        mutable_return_cast_capture = ent
+                    end
+                end
+                ent = replacement
+            end
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("mutable_return_cast_capture"), ws.ty("Entity"));
+    }
+
+    #[test]
+    fn deferred_closure_drops_mutable_custom_type_guard() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@param value any
+            ---@return TypeGuard<string>
+            local function is_string(value) end
+
+            ---@param replacement string|number
+            local function make(replacement)
+                local value ---@type string|number
+                if is_string(value) then
+                    local callback = function()
+                        mutable_custom_guard_capture = value
+                    end
+                end
+                value = replacement
+            end
+            "#,
+        );
+
+        assert_eq!(
+            ws.expr_ty("mutable_custom_guard_capture"),
+            ws.ty("string|number")
+        );
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/compilation/test/unguarded_child_inference_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/unguarded_child_inference_test.rs
@@ -1636,6 +1636,186 @@ mod test {
     }
 
     #[test]
+    fn immutable_return_cast_guard_suppresses_closure_child_diagnostic() {
+        let mut ws = VirtualWorkspace::new();
+        enable_gmod(&mut ws);
+        let file_id = ws.def(
+            r#"
+            ---@class Entity
+            ---@class Player: Entity
+            ---@field GetPlayerColor fun(self: Player): number
+
+            ---@return boolean
+            ---@return_cast self Player
+            function Entity:IsPlayer() end
+
+            ---@param ent Entity
+            local function make(ent)
+                if ent:IsPlayer() then
+                    local direct = ent:GetPlayerColor()
+                    local callback = function()
+                        return ent:GetPlayerColor()
+                    end
+                    return direct, callback
+                end
+            end
+            "#,
+        );
+
+        assert_eq!(
+            diagnostic_count(&mut ws, file_id, DiagnosticCode::InferUnguardedChild),
+            0
+        );
+    }
+
+    #[test]
+    fn mutable_return_cast_guard_reports_only_closure_child_access() {
+        let mut ws = VirtualWorkspace::new();
+        enable_gmod(&mut ws);
+        let file_id = ws.def(
+            r#"
+            ---@class Entity
+            ---@class Player: Entity
+            ---@field GetPlayerColor fun(self: Player): number
+
+            ---@return boolean
+            ---@return_cast self Player
+            function Entity:IsPlayer() end
+
+            ---@param ent Entity
+            ---@param replacement Entity
+            local function make(ent, replacement)
+                if ent:IsPlayer() then
+                    local direct = ent:GetPlayerColor()
+                    local callback = function()
+                        return ent:GetPlayerColor()
+                    end
+                    ent = replacement
+                    return direct, callback
+                end
+            end
+            "#,
+        );
+
+        let diagnostics = diagnostics_for(&mut ws, file_id, DiagnosticCode::InferUnguardedChild);
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+        assert_eq!(diagnostics[0].range.start.line, 15);
+        assert_eq!(
+            diagnostics[0].message,
+            "expected `Player` but found `Entity`. Add a guard to narrow the parent to `Player`."
+        );
+    }
+
+    #[test]
+    fn return_cast_closure_capture_tracks_incremental_mutability_and_reopen() {
+        const IMMUTABLE_SOURCE: &str = r#"
+            ---@class Entity
+            ---@class Player: Entity
+            ---@field GetPlayerColor fun(self: Player): number
+
+            ---@return boolean
+            ---@return_cast self Player
+            function Entity:IsPlayer() end
+
+            ---@param ent Entity
+            ---@param replacement Entity
+            local function make(ent, replacement)
+                if ent:IsPlayer() then
+                    local callback = function()
+                        return ent:GetPlayerColor()
+                    end
+                    return callback
+                end
+            end
+        "#;
+        const MUTABLE_SOURCE: &str = r#"
+            ---@class Entity
+            ---@class Player: Entity
+            ---@field GetPlayerColor fun(self: Player): number
+
+            ---@return boolean
+            ---@return_cast self Player
+            function Entity:IsPlayer() end
+
+            ---@param ent Entity
+            ---@param replacement Entity
+            local function make(ent, replacement)
+                if ent:IsPlayer() then
+                    local callback = function()
+                        return ent:GetPlayerColor()
+                    end
+                    ent = replacement
+                    return callback
+                end
+            end
+        "#;
+
+        let fresh_diagnostic_count = |source: &str| {
+            let mut fresh = VirtualWorkspace::new();
+            enable_gmod(&mut fresh);
+            let file_id = fresh.def(source);
+            diagnostic_count(&mut fresh, file_id, DiagnosticCode::InferUnguardedChild)
+        };
+
+        let mut ws = VirtualWorkspace::new();
+        enable_gmod(&mut ws);
+        let uri = ws
+            .virtual_url_generator
+            .new_uri("lua/autorun/shared/issue_49_incremental.lua");
+        let file_id = ws
+            .analysis
+            .update_file_by_uri(&uri, Some(IMMUTABLE_SOURCE.to_string()))
+            .expect("initial immutable file");
+        assert_eq!(
+            diagnostic_count(&mut ws, file_id, DiagnosticCode::InferUnguardedChild),
+            fresh_diagnostic_count(IMMUTABLE_SOURCE)
+        );
+
+        let updated_file_id = ws
+            .analysis
+            .update_file_by_uri(&uri, Some(MUTABLE_SOURCE.to_string()))
+            .expect("mutable update");
+        assert_eq!(updated_file_id, file_id);
+        assert_eq!(
+            diagnostic_count(
+                &mut ws,
+                updated_file_id,
+                DiagnosticCode::InferUnguardedChild
+            ),
+            fresh_diagnostic_count(MUTABLE_SOURCE)
+        );
+
+        let restored_file_id = ws
+            .analysis
+            .update_file_by_uri(&uri, Some(IMMUTABLE_SOURCE.to_string()))
+            .expect("restored immutable update");
+        assert_eq!(
+            diagnostic_count(
+                &mut ws,
+                restored_file_id,
+                DiagnosticCode::InferUnguardedChild
+            ),
+            fresh_diagnostic_count(IMMUTABLE_SOURCE)
+        );
+
+        ws.analysis
+            .remove_file_by_uri(&uri)
+            .expect("removed incremental file");
+        let reopened_file_id = ws
+            .analysis
+            .update_file_by_uri(&uri, Some(IMMUTABLE_SOURCE.to_string()))
+            .expect("reopened immutable file");
+        assert_eq!(
+            diagnostic_count(
+                &mut ws,
+                reopened_file_id,
+                DiagnosticCode::InferUnguardedChild
+            ),
+            fresh_diagnostic_count(IMMUTABLE_SOURCE)
+        );
+    }
+
+    #[test]
     fn unguarded_child_reports_once_and_keeps_unknown_diagnostic_separate() {
         let mut ws = VirtualWorkspace::new();
         enable_gmod(&mut ws);

--- a/crates/glua_code_analysis/src/diagnostic/test/need_check_nil_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/need_check_nil_test.rs
@@ -14339,7 +14339,7 @@ mod test {
     }
 
     #[gtest]
-    fn test_deferred_timer_immutable_entity_isvalid_guard_needs_check_nil() {
+    fn test_deferred_timer_immutable_entity_isvalid_guard_has_no_need_check_nil() {
         let mut ws = VirtualWorkspace::new();
         def_isvalid_type_guard(&mut ws);
         let diagnostics = diagnostics_for_code(
@@ -14361,6 +14361,36 @@ mod test {
                     captured:GetClass()
                 end)
             end
+            "#,
+        );
+
+        assert_that!(diagnostics, is_empty());
+    }
+
+    #[gtest]
+    fn test_deferred_timer_mutable_entity_isvalid_guard_needs_check_nil() {
+        let mut ws = VirtualWorkspace::new();
+        def_isvalid_type_guard(&mut ws);
+        let diagnostics = diagnostics_for_code(
+            &mut ws,
+            DiagnosticCode::NeedCheckNil,
+            r#"
+            ---@class Entity
+            ---@field GetClass fun(self: Entity): string
+
+            timer = {}
+            ---@param delay number
+            ---@param callback fun()
+            function timer.Simple(delay, callback) end
+
+            local entity ---@type Entity?
+            if IsValid(entity) then
+                timer.Simple(0, function()
+                    local captured = entity
+                    captured:GetClass()
+                end)
+            end
+            entity = nil
             "#,
         );
 

--- a/crates/glua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/narrow/get_type_at_flow.rs
@@ -293,6 +293,20 @@ fn get_type_at_immutable_closure_condition(
             };
             Ok(Some(narrowed))
         }
+        LuaExpr::CallExpr(call_expr) => match get_type_at_condition_flow(
+            db,
+            tree,
+            cache,
+            root,
+            var_ref_id,
+            flow_node,
+            LuaExpr::CallExpr(call_expr),
+            condition_flow,
+            policy,
+        )? {
+            ResultTypeOrContinue::Result(condition_type) => Ok(Some(condition_type)),
+            ResultTypeOrContinue::Continue => Ok(None),
+        },
         _ => Ok(None),
     }
 }


### PR DESCRIPTION
## Summary
- Update flow narrowing to propagate `return_cast` types through closure conditions by delegating call-expression conditions to `get_type_at_condition_flow` in `get_type_at_immutable_closure_condition`.
- Add regression coverage in flow inference tests for deferred closures retaining immutable `return_cast` guards (self and named-parameter forms), handling false-branch captures, and nested closures.
- Add mutable-guard regressions to ensure inferred `return_cast` narrowing is dropped when captured variables are reassigned, including incremental edit/reopen scenarios.
- Update unguarded-child diagnostics tests to assert closure capture behavior changes for immutable vs mutable guarded values.
- Adjust nil-check diagnostics: immutable deferred `IsValid` captures now have no `NeedCheckNil`, while mutable deferred captures still require it.

## Testing
- Added/updated unit tests in:
  - `crates/glua_code_analysis/src/compilation/test/flow.rs`
  - `crates/glua_code_analysis/src/compilation/test/unguarded_child_inference_test.rs`
  - `crates/glua_code_analysis/src/diagnostic/test/need_check_nil_test.rs`
- New incremental/reopen test validates cached flow behavior after mutable/immutable source updates for `InferUnguardedChild`.
- Not run: full `cargo test` suite in this PR message (tests are described by added coverage).

Closes #49