### PR TITLE
Preserve declared element types for empty table assignments

### DIFF
--- a/crates/glua_code_analysis/src/compilation/analyzer/lua/member_write_policy/collection.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/lua/member_write_policy/collection.rs
@@ -283,7 +283,7 @@ pub(in crate::compilation::analyzer::lua) fn direct_local_table_prefix_member_ow
     prefix_expr: &LuaExpr,
 ) -> Option<LuaMemberOwner> {
     let decl_id = direct_local_prefix_decl_id(analyzer, prefix_expr)?;
-    if local_decl_binds_class_type(analyzer, decl_id) {
+    if local_decl_has_declared_type(analyzer, decl_id) {
         return None;
     }
 
@@ -302,6 +302,14 @@ pub(in crate::compilation::analyzer::lua) fn direct_local_table_prefix_member_ow
     owner
 }
 
+pub(in crate::compilation::analyzer::lua) fn direct_local_prefix_has_declared_type(
+    analyzer: &LuaAnalyzer,
+    prefix_expr: &LuaExpr,
+) -> bool {
+    direct_local_prefix_decl_id(analyzer, prefix_expr)
+        .is_some_and(|decl_id| local_decl_has_declared_type(analyzer, decl_id))
+}
+
 fn direct_local_prefix_decl_id(analyzer: &LuaAnalyzer, prefix_expr: &LuaExpr) -> Option<LuaDeclId> {
     let LuaExpr::NameExpr(name_expr) = prefix_expr else {
         return None;
@@ -313,20 +321,12 @@ fn direct_local_prefix_decl_id(analyzer: &LuaAnalyzer, prefix_expr: &LuaExpr) ->
         .and_then(|file_ref| file_ref.get_decl_id(&name_expr.get_range()))
 }
 
-fn local_decl_binds_class_type(analyzer: &LuaAnalyzer, decl_id: LuaDeclId) -> bool {
-    let Some(type_cache) = analyzer.db.get_type_index().get_type_cache(&decl_id.into()) else {
-        return false;
-    };
-    let type_id = match type_cache.as_type() {
-        LuaType::Ref(type_id) | LuaType::Def(type_id) => type_id,
-        _ => return false,
-    };
-
+fn local_decl_has_declared_type(analyzer: &LuaAnalyzer, decl_id: LuaDeclId) -> bool {
     analyzer
         .db
         .get_type_index()
-        .get_type_decl(type_id)
-        .is_some_and(|decl| decl.is_class())
+        .get_type_cache(&decl_id.into())
+        .is_some_and(LuaTypeCache::is_doc)
 }
 
 fn resolve_direct_local_table_prefix_member_owner(

--- a/crates/glua_code_analysis/src/compilation/analyzer/lua/member_write_policy/mod.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/lua/member_write_policy/mod.rs
@@ -10,7 +10,7 @@ pub(in crate::compilation::analyzer::lua) use cache::{
 };
 pub(in crate::compilation::analyzer) use collection::resolve_index_expr_member_owner_for_file;
 pub(in crate::compilation::analyzer::lua) use collection::{
-    direct_local_table_prefix_member_owner,
+    direct_local_prefix_has_declared_type, direct_local_table_prefix_member_owner,
     flush_pending_dynamic_key_collection_widening_for_members,
     get_widened_member_assignment_collection_type, is_collection_append_write,
     is_member_realm_compatible, record_member_collection_assignment_widening_cache,

--- a/crates/glua_code_analysis/src/compilation/analyzer/lua/stats.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/lua/stats.rs
@@ -26,7 +26,7 @@ use super::{
     member_write_policy::{
         MemberAssignmentWideningCacheKey, MemberAssignmentWideningDecision,
         MemberAssignmentWideningState, WideningCacheLookup, decide_member_assignment_widening,
-        direct_local_table_prefix_member_owner,
+        direct_local_prefix_has_declared_type, direct_local_table_prefix_member_owner,
         flush_pending_dynamic_key_collection_widening_for_members,
         get_widened_member_assignment_collection_type, is_collection_append_write,
         is_member_realm_compatible, lookup_widening_cache, member_assignment_state_mask,
@@ -814,9 +814,13 @@ pub fn analyze_assign_stat(analyzer: &mut LuaAnalyzer, assign_stat: LuaAssignSta
             continue;
         }
 
+        let declared_empty_table_type = declared_empty_table_assignment_type(analyzer, &var, expr);
         set_index_expr_owner(analyzer, var.clone());
 
-        let expr_type = match analyzer.infer_expr(expr) {
+        let expr_type = match declared_empty_table_type
+            .map(Ok)
+            .unwrap_or_else(|| analyzer.infer_expr(expr))
+        {
             Ok(mut expr_type) => {
                 if let LuaType::Variadic(multi) = expr_type {
                     expr_type = multi.get_type(0)?.clone();
@@ -979,6 +983,92 @@ pub fn analyze_assign_stat(analyzer: &mut LuaAnalyzer, assign_stat: LuaAssignSta
     }
 
     Some(())
+}
+
+fn declared_empty_table_assignment_type(
+    analyzer: &mut LuaAnalyzer,
+    var: &LuaVarExpr,
+    expr: &LuaExpr,
+) -> Option<LuaType> {
+    let LuaExpr::TableExpr(table_expr) = expr else {
+        return None;
+    };
+    if table_expr.get_fields().next().is_some() {
+        return None;
+    }
+
+    let LuaVarExpr::IndexExpr(index_expr) = var else {
+        return None;
+    };
+    let prefix_expr = index_expr.get_prefix_expr()?;
+    if !direct_local_prefix_has_declared_type(analyzer, &prefix_expr) {
+        return None;
+    }
+
+    let cache = analyzer
+        .context
+        .infer_manager
+        .get_infer_cache(analyzer.file_id);
+    let declared_type =
+        crate::infer_index_expr(analyzer.db, cache, index_expr.clone(), false).ok()?;
+    let table_value_type = declared_table_assignment_type(analyzer.db, &declared_type)?;
+
+    write_type_cache(
+        analyzer.db,
+        LuaTypeOwner::SyntaxId(InFiled::new(analyzer.file_id, table_expr.get_syntax_id())),
+        LuaTypeCache::InferType(table_value_type.clone()),
+        TypeCacheWriteMode::InsertOnly,
+    );
+
+    Some(table_value_type)
+}
+
+fn declared_table_assignment_type(db: &crate::DbIndex, declared_type: &LuaType) -> Option<LuaType> {
+    match declared_type {
+        typ if typ.is_table() => Some(typ.clone()),
+        LuaType::Ref(type_id) | LuaType::Def(type_id)
+            if db
+                .get_type_index()
+                .get_type_decl(type_id)
+                .is_some_and(|decl| decl.is_class()) =>
+        {
+            Some(declared_type.clone())
+        }
+        LuaType::Instance(instance)
+            if declared_table_assignment_type(db, instance.get_base()).is_some() =>
+        {
+            Some(declared_type.clone())
+        }
+        LuaType::TypeGuard(inner) => declared_table_assignment_type(db, inner),
+        LuaType::Union(union) => union
+            .types()
+            .filter_map(|typ| declared_table_assignment_type(db, typ))
+            .fold(None, |result, typ| {
+                Some(match result {
+                    Some(current) => TypeOps::Union.apply(db, &current, &typ),
+                    None => typ,
+                })
+            }),
+        LuaType::Intersection(intersection)
+            if intersection
+                .get_types()
+                .iter()
+                .any(|typ| declared_table_assignment_type(db, typ).is_some()) =>
+        {
+            Some(declared_type.clone())
+        }
+        LuaType::MultiLineUnion(union) => union
+            .get_unions()
+            .iter()
+            .filter_map(|(typ, _)| declared_table_assignment_type(db, typ))
+            .fold(None, |result, typ| {
+                Some(match result {
+                    Some(current) => TypeOps::Union.apply(db, &current, &typ),
+                    None => typ,
+                })
+            }),
+        _ => None,
+    }
 }
 
 fn type_contains_nominal_reference(typ: &LuaType) -> bool {

--- a/crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs
@@ -2927,3 +2927,152 @@ fn repeated_initialized_index_member_assignments_diagnose_quick_smoke() {
         "unexpected assign-type diagnostics: {diagnostics:#?}"
     );
 }
+
+#[test]
+fn declared_array_empty_initializer_keeps_declared_owner_on_append() {
+    let mut ws = crate::VirtualWorkspace::new();
+    assert!(ws.check_code_for(
+        crate::DiagnosticCode::AssignTypeMismatch,
+        r#"
+        ---@class Thing
+        ---@field icon string
+        local _Thing = {}
+
+        ---@type Thing[]
+        local values = {}
+        values[#values + 1] = { icon = "" }
+        "#
+    ));
+}
+
+#[test]
+fn declared_map_empty_slot_keeps_declared_collection_type() {
+    let mut ws = crate::VirtualWorkspace::new();
+    assert!(ws.check_code_for(
+        crate::DiagnosticCode::AssignTypeMismatch,
+        r#"
+        ---@class Thing
+
+        ---@type table<Thing, Thing[]|false>
+        local cache = {}
+
+        ---@param owner Thing
+        ---@param member Thing
+        local function add(owner, member)
+            if not cache[owner] then cache[owner] = {} end
+            local group = cache[owner]
+            if group then group[#group + 1] = member end
+            cache[owner] = false
+        end
+        "#
+    ));
+}
+
+#[test]
+fn declared_nested_container_empty_slot_preserves_all_value_arms() {
+    let mut ws = crate::VirtualWorkspace::new();
+    assert!(ws.check_code_for(
+        crate::DiagnosticCode::AssignTypeMismatch,
+        r#"
+        ---@class Ent
+        ---@class Portal
+
+        ---@type table<Portal, table<Ent, Ent[]|false>>
+        local cache = {}
+
+        ---@param key Ent
+        ---@param portal Portal
+        ---@param group Ent[]?
+        local function store(key, portal, group)
+            if not cache[portal] then cache[portal] = {} end
+            local portalCache = cache[portal]
+            if group then
+                portalCache[key] = group
+            else
+                portalCache[key] = false
+            end
+        end
+        "#
+    ));
+}
+
+#[test]
+fn declared_index_signature_empty_slot_keeps_named_field_type() {
+    let mut ws = crate::VirtualWorkspace::new();
+    assert!(ws.check_code_for(
+        crate::DiagnosticCode::AssignTypeMismatch,
+        r#"
+        ---@class cat
+        ---@field icon string?
+        ---@field [string] { icon: string, real: string }
+
+        ---@type table<string, cat>
+        local cats = {}
+
+        ---@param category string
+        ---@param displayName string
+        ---@param surfaceId string
+        ---@param categoryIcon string?
+        local function add(category, displayName, surfaceId, categoryIcon)
+            if not cats[category] then cats[category] = {} end
+            local entry = cats[category]
+            entry.icon = categoryIcon or entry.icon or ""
+            entry[displayName] = { icon = entry.icon or "", real = surfaceId }
+        end
+        "#
+    ));
+}
+
+#[test]
+fn declared_array_invalid_append_still_reports() {
+    let mut ws = crate::VirtualWorkspace::new();
+    assert!(!ws.check_code_for(
+        crate::DiagnosticCode::AssignTypeMismatch,
+        r#"
+        ---@class Thing
+
+        ---@type Thing[]
+        local values = {}
+        values[#values + 1] = "not a Thing"
+        "#
+    ));
+}
+
+#[test]
+fn declared_empty_container_controls_remain_clean() {
+    let mut ws = crate::VirtualWorkspace::new_with_init_std_lib();
+    assert!(ws.check_code_for(
+        crate::DiagnosticCode::AssignTypeMismatch,
+        r#"
+        ---@class Ent
+        ---@class Portal
+
+        ---@type Ent[]
+        local viaInsert = {}
+        table.insert(viaInsert, {})
+
+        ---@type Ent[]
+        local neverFilled = {}
+
+        ---@type table<Ent, Ent[]|false>
+        local seed = {}
+
+        ---@type table<Portal, table<Ent, Ent[]|false>>
+        local cache = {}
+
+        ---@param key Ent
+        ---@param portal Portal
+        ---@param group Ent[]
+        local function controls(key, portal, group)
+            if not cache[portal] then cache[portal] = seed end
+            local typed = cache[portal]
+            typed[key] = group
+            typed[key] = false
+
+            if not cache[portal] then cache[portal] = {} end
+            local singleWrite = cache[portal]
+            singleWrite[key] = group
+        end
+        "#
+    ));
+}


### PR DESCRIPTION
## Summary
- Changed local table member-write policy to skip inferred-owner fallback when the base local has an explicit declared type, preventing accidental loss of declared collection intent.
- Added `declared_empty_table_assignment_type` in `stats.rs` to infer and cache an appropriate table value type from annotated empties during assignment analysis.
- Updated member-write policy helpers to use declared-type checks via `local_decl_has_declared_type` and exposed `direct_local_prefix_has_declared_type` for consistent behavior.
- Added regression tests in `assign_type_mismatch_test.rs` for empty declared containers (arrays/maps/nested containers/index signatures) to ensure typed empty initializers keep declared types on later writes, while invalid assignments still report diagnostics.

## Testing
- Not run (no test execution was performed in this pass).
- Added/updated tests are expected in `crates/glua_code_analysis/src/diagnostic/test/assign_type_mismatch_test.rs` covering:
  - `declared_array_empty_initializer_keeps_declared_owner_on_append`
  - `declared_map_empty_slot_keeps_declared_collection_type`
  - `declared_nested_container_empty_slot_preserves_all_value_arms`
  - `declared_index_signature_empty_slot_keeps_named_field_type`
  - `declared_array_invalid_append_still_reports`
  - `declared_empty_container_controls_remain_clean`

Closes #50