### PR TITLE
fix: type-check defaulted structural fields

### DIFF
--- a/crates/glua_code_analysis/src/compilation/analyzer/mod.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/mod.rs
@@ -37,6 +37,35 @@ use infer_cache_manager::InferCacheManager;
 use lua::LuaReturnPoint;
 use unresolve::{UnResolve, UnResolveReturn};
 
+pub(crate) fn infer_closure_body_function_type(
+    db: &DbIndex,
+    cache: &mut crate::LuaInferCache,
+    closure: &LuaClosureExpr,
+) -> Option<LuaType> {
+    let signature_id = LuaSignatureId::from_closure(cache.get_file_id(), closure);
+    let signature = db.get_signature_index().get(&signature_id)?;
+    if signature.resolve_return != crate::SignatureReturnStatus::DocResolve {
+        return None;
+    }
+
+    let return_points = lua::func_body::analyze_func_body_returns(closure.get_block()?);
+    let return_type = lua::analyze_return_point(db, cache, &return_points)
+        .ok()?
+        .into_iter()
+        .next()?
+        .type_ref;
+    let function_type = LuaFunctionType::new(
+        signature.async_state,
+        signature.is_colon_define,
+        signature.is_vararg,
+        signature.get_type_params(),
+        return_type,
+    )
+    .with_optional_params(signature.get_param_optional_flags());
+
+    Some(LuaType::DocFunction(function_type.into()))
+}
+
 pub fn analyze(db: &mut DbIndex, need_analyzed_files: Vec<InFiled<LuaChunk>>) {
     if need_analyzed_files.is_empty() {
         return;

--- a/crates/glua_code_analysis/src/compilation/analyzer/mod.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/mod.rs
@@ -44,7 +44,9 @@ pub(crate) fn infer_closure_body_function_type(
 ) -> Option<LuaType> {
     let signature_id = LuaSignatureId::from_closure(cache.get_file_id(), closure);
     let signature = db.get_signature_index().get(&signature_id)?;
-    if signature.resolve_return != crate::SignatureReturnStatus::DocResolve {
+    if signature.resolve_return != crate::SignatureReturnStatus::DocResolve
+        || !signature.overloads.is_empty()
+    {
         return None;
     }
 

--- a/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -726,6 +726,44 @@ mod test {
     }
 
     #[test]
+    fn issue_54_default_after_type_is_checked_when_present() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::AssignTypeMismatch,
+            r#"
+            ---@class DefaultAfterType
+            ---@field force number=1000
+            ---@field other string
+
+            ---@param value DefaultAfterType
+            local function takes_default(value) end
+
+            takes_default({ force = "wrong", other = "ok" })
+            "#
+        ));
+    }
+
+    #[test]
+    fn issue_54_default_before_type_is_checked_when_present() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::AssignTypeMismatch,
+            r#"
+            ---@class DefaultBeforeType
+            ---@field force=1000 number
+            ---@field other string
+
+            ---@param value DefaultBeforeType
+            local function takes_default(value) end
+
+            takes_default({ force = "wrong", other = "ok" })
+            "#
+        ));
+    }
+
+    #[test]
     fn stable_table_field_expression_overrides_stale_aggregate_member_cache() {
         let mut ws = VirtualWorkspace::new();
         let file_id = ws.def(

--- a/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -1324,6 +1324,28 @@ mod test {
     }
 
     #[test]
+    fn overloaded_inline_callback_uses_matching_overload() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param callback fun(value: number): boolean
+            local function register(callback) end
+
+            register(
+                ---@overload fun(value: number): boolean
+                ---@param value string
+                ---@return string
+                function(value)
+                    return value
+                end
+            )
+            "#,
+        ));
+    }
+
+    #[test]
     fn test_function_field_return_type_is_checked_when_present() {
         let mut ws = VirtualWorkspace::new();
 
@@ -1341,6 +1363,32 @@ mod test {
                 handler = function()
                     return "not a boolean"
                 end,
+            })
+            "#,
+        ));
+    }
+
+    #[test]
+    fn overloaded_function_field_uses_matching_overload() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@class HandlerContract
+            ---@field handler fun(value: number): boolean
+
+            ---@param contract HandlerContract
+            local function register(contract) end
+
+            register({
+                handler =
+                    ---@overload fun(value: number): boolean
+                    ---@param value string
+                    ---@return string
+                    function(value)
+                        return value
+                    end,
             })
             "#,
         ));

--- a/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -1290,6 +1290,86 @@ mod test {
     }
 
     #[test]
+    fn inline_callback_return_type_mismatch_is_reported() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param callback fun(): boolean
+            local function register(callback) end
+
+            register(function()
+                return "not a boolean"
+            end)
+            "#
+        ));
+    }
+
+    #[test]
+    fn compatible_inline_callback_return_type_is_accepted() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@param callback fun(value: string): string
+            local function register(callback) end
+
+            register(function(value)
+                return value
+            end)
+            "#
+        ));
+    }
+
+    #[test]
+    fn test_function_field_return_type_is_checked_when_present() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@class HandlerContract
+            ---@field handler fun(): boolean
+
+            ---@param contract HandlerContract
+            local function register(contract)
+            end
+
+            register({
+                handler = function()
+                    return "not a boolean"
+                end,
+            })
+            "#,
+        ));
+    }
+
+    #[test]
+    fn test_compatible_function_field_return_type_is_accepted() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@class HandlerContract
+            ---@field handler fun(): boolean
+
+            ---@param contract HandlerContract
+            local function register(contract)
+            end
+
+            register({
+                handler = function()
+                    return true
+                end,
+            })
+            "#,
+        ));
+    }
+
+    #[test]
     fn test_issue_135() {
         let mut ws = VirtualWorkspace::new();
 
@@ -3632,16 +3712,16 @@ mod test {
             r#"
             ---@class Entity
             ---@field Activate function
-            
+
             ---@class BaseEntity : Entity
             ---@field baseField number
-            
-            ---@class MyEntity : BaseEntity  
+
+            ---@class MyEntity : BaseEntity
             ---@field myField number
-            
+
             ---@param filter Entity|Entity[]|function
             local function testFunc(filter) end
-            
+
             local myInstance = {} ---@type MyEntity
             -- This should work - MyEntity inherits from Entity through BaseEntity
             testFunc({myInstance})
@@ -3658,7 +3738,7 @@ mod test {
             r#"
             ---@param x number
             local function test(x) end
-            
+
             test("string")
         "#
         ));
@@ -3673,10 +3753,10 @@ mod test {
             DiagnosticCode::ParamTypeMismatch,
             r#"
             ---@class Entity
-            
+
             ---@param filter Entity|Entity[]|function
             local function testFunc(filter) end
-            
+
             -- This should report an error - number is not compatible with Entity
             testFunc({123})
         "#

--- a/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -1347,6 +1347,33 @@ mod test {
     }
 
     #[test]
+    fn intersection_function_field_return_type_is_checked_when_present() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(!ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@class HasHandler
+            ---@field handler fun(): boolean
+
+            ---@class Tagged
+            ---@field tag string
+
+            ---@param contract HasHandler & Tagged
+            local function register(contract)
+            end
+
+            register({
+                handler = function()
+                    return "not a boolean"
+                end,
+                tag = "test",
+            })
+            "#,
+        ));
+    }
+
+    #[test]
     fn test_compatible_function_field_return_type_is_accepted() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/param_type_check_test.rs
@@ -1213,6 +1213,61 @@ mod test {
     }
 
     #[test]
+    fn test_method_members_are_not_type_checked_when_present_in_table_literals() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def_file(
+            "libraries/sh_cami_present.lua",
+            r#"
+            CAMI_PRESENT = {}
+
+            ---@class CAMI_PRESENT_PRIVILEGE
+            ---@field Name string
+            local CAMI_PRESENT_PRIVILEGE = {}
+
+            function CAMI_PRESENT_PRIVILEGE:HasAccess(actor, target)
+                return true
+            end
+
+            ---@param privilege CAMI_PRESENT_PRIVILEGE
+            function CAMI_PRESENT.RegisterPrivilege(privilege)
+            end
+            "#,
+        );
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::AssignTypeMismatch,
+            r#"
+            CAMI_PRESENT.RegisterPrivilege{
+                Name = "DarkRP_SetLicense",
+                HasAccess = function(actor, target) return false end,
+            }
+            "#
+        ));
+    }
+
+    #[test]
+    fn test_subclass_documented_default_overrides_parent_required_field() {
+        let mut ws = VirtualWorkspace::new();
+
+        assert!(ws.check_code_for(
+            DiagnosticCode::ParamTypeMismatch,
+            r#"
+            ---@class ProbeDParent
+            ---@field force number
+            ---@field other string
+
+            ---@class ProbeDChild : ProbeDParent
+            ---@field force number=1000
+
+            ---@param d ProbeDChild
+            local function takes_child(d) end
+
+            takes_child({ other = "ok" })
+            "#
+        ));
+    }
+
+    #[test]
     fn test_function_fields_still_cause_param_type_mismatch_when_missing() {
         let mut ws = VirtualWorkspace::new();
 

--- a/crates/glua_code_analysis/src/semantic/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/mod.rs
@@ -18,9 +18,9 @@ use std::sync::{Arc, Mutex, MutexGuard};
 pub use cache::{CacheEntry, CacheOptions, LuaAnalysisPhase, LuaInferCache, PendingStrTplTypeDecl};
 pub use decl::{enum_variable_is_param, parse_require_module_info};
 use glua_parser::{
-    LuaAssignStat, LuaAstNode, LuaAstToken, LuaCallExpr, LuaChunk, LuaDocType, LuaExpr,
-    LuaIndexExpr, LuaIndexKey, LuaIndexMemberExpr, LuaNameExpr, LuaParseError, LuaSyntaxKind,
-    LuaSyntaxNode, LuaSyntaxToken, LuaTableExpr, LuaTokenKind, LuaVarExpr,
+    LuaAssignStat, LuaAstNode, LuaAstToken, LuaCallExpr, LuaChunk, LuaClosureExpr, LuaDocType,
+    LuaExpr, LuaIndexExpr, LuaIndexKey, LuaIndexMemberExpr, LuaNameExpr, LuaParseError,
+    LuaSyntaxKind, LuaSyntaxNode, LuaSyntaxToken, LuaTableExpr, LuaTokenKind, LuaVarExpr,
 };
 pub(crate) use gmod_vgui_context::{
     resolve_registered_vgui_method_context, resolve_registered_vgui_method_context_for_func,
@@ -493,7 +493,22 @@ impl<'a> SemanticModel<'a> {
     ) -> TypeCheckResult {
         let mut member_facts = HashMap::new();
         self.collect_table_expr_member_facts(compact_expr, &mut member_facts);
-        check_type_compact_detail_with_member_facts(self.db, source, compact_type, member_facts)
+        let runtime_compact_type = self.infer_closure_body_type_for_check(compact_expr);
+        check_type_compact_detail_with_member_facts(
+            self.db,
+            source,
+            runtime_compact_type.as_ref().unwrap_or(compact_type),
+            member_facts,
+        )
+    }
+
+    fn infer_closure_body_type_for_check(&self, expr: &LuaExpr) -> Option<LuaType> {
+        let closure = LuaClosureExpr::cast(expr.syntax().clone())?;
+        crate::compilation::analyzer::infer_closure_body_function_type(
+            self.db,
+            &mut self.infer_cache.borrow_mut(),
+            &closure,
+        )
     }
 
     fn collect_table_expr_member_facts(
@@ -510,7 +525,12 @@ impl<'a> SemanticModel<'a> {
                 continue;
             };
             let member_id = LuaMemberId::new(field.get_syntax_id(), self.file_id);
-            member_facts.insert(member_id, self.infer_expr_fact(value_expr.clone()));
+            let fact = self.infer_expr_fact(value_expr.clone());
+            let fact = match self.infer_closure_body_type_for_check(&value_expr) {
+                Some(typ) => fact.with_runtime_type(typ),
+                None => fact,
+            };
+            member_facts.insert(member_id, fact);
             self.collect_table_expr_member_facts(&value_expr, member_facts);
         }
     }

--- a/crates/glua_code_analysis/src/semantic/type_check/complex_type/intersection_type_check.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/complex_type/intersection_type_check.rs
@@ -37,10 +37,8 @@ pub fn check_intersection_type_compact(
         LuaType::Object(_) => {
             // 检查对象是否满足交叉类型的所有组成部分
             for intersection_component in source_intersection.get_types() {
-                // Use a fresh context so branch-local checking state cannot leak across
-                // intersection components.
-                let mut component_context =
-                    TypeCheckContext::new(context.db, context.detail, context.level.clone());
+                // Keep expression-specific member facts while isolating mutable branch state.
+                let mut component_context = context.clone();
                 check_general_type_compact(
                     &mut component_context,
                     intersection_component,
@@ -63,9 +61,7 @@ pub fn check_intersection_type_compact(
         _ => {
             // 对于其他类型，检查是否至少满足一个组成部分
             for intersection_component in source_intersection.get_types() {
-                // NOTE: Use a fresh TypeCheckContext per component to avoid leaking check state.
-                let mut component_context =
-                    TypeCheckContext::new(context.db, context.detail, context.level.clone());
+                let mut component_context = context.clone();
                 if check_general_type_compact(
                     &mut component_context,
                     intersection_component,
@@ -90,9 +86,7 @@ fn check_intersection_type_compact_table(
 ) -> TypeCheckResult {
     // 交叉类型要求 TableConst 必须满足所有组成部分
     for intersection_component in source_intersection.get_types() {
-        // NOTE: Use a fresh TypeCheckContext per component to avoid leaking check state.
-        let mut component_context =
-            TypeCheckContext::new(context.db, context.detail, context.level.clone());
+        let mut component_context = context.clone();
         check_general_type_compact(
             &mut component_context,
             intersection_component,

--- a/crates/glua_code_analysis/src/semantic/type_check/complex_type/intersection_type_check.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/complex_type/intersection_type_check.rs
@@ -37,9 +37,8 @@ pub fn check_intersection_type_compact(
         LuaType::Object(_) => {
             // 检查对象是否满足交叉类型的所有组成部分
             for intersection_component in source_intersection.get_types() {
-                // NOTE: Use a fresh TypeCheckContext per component so `table_member_checked` (and
-                // similar state) doesn't leak across components. Otherwise `A & B` may check `A`
-                // first and then skip `B`'s same-key checks.
+                // Use a fresh context so branch-local checking state cannot leak across
+                // intersection components.
                 let mut component_context =
                     TypeCheckContext::new(context.db, context.detail, context.level.clone());
                 check_general_type_compact(

--- a/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
@@ -157,14 +157,8 @@ fn check_generic_type_compact_table(
     let next_guard = check_guard.next_level()?;
 
     for source_member in source_type_members {
-        if !is_required_structural_member(
-            context.db,
-            source_member.feature,
-            source_member.property_owner_id.as_ref(),
-            Some(&source_member.typ),
-        ) {
-            continue;
-        }
+        let source_member_feature = source_member.feature;
+        let property_owner_id = source_member.property_owner_id;
         let source_member_type = source_member.typ;
         let key = source_member.key;
 
@@ -200,7 +194,14 @@ fn check_generic_type_compact_table(
                     ));
                 }
             }
-            None if !source_member_type.is_optional() => {
+            None if !source_member_type.is_optional()
+                && is_required_structural_member(
+                    context.db,
+                    source_member_feature,
+                    property_owner_id.as_ref(),
+                    Some(&source_member_type),
+                ) =>
+            {
                 if !context.detail {
                     return Err(TypeCheckFailReason::TypeNotMatch);
                 }

--- a/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
@@ -164,6 +164,9 @@ fn check_generic_type_compact_table(
         let property_owner_id = source_member.property_owner_id;
         let source_member_type = source_member.typ;
         let key = source_member.key;
+        if context.is_key_checked(&key) {
+            continue;
+        }
 
         match table_member_map.get(&key) {
             Some(table_member_id) => {
@@ -214,6 +217,8 @@ fn check_generic_type_compact_table(
             }
             _ => {} // 可选成员未找到，继续检查
         }
+
+        context.mark_key_checked(key);
     }
 
     // 检查超类型

--- a/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
@@ -7,8 +7,9 @@ use crate::{
 };
 
 use super::{
-    TypeCheckResult, check_general_type_compact, is_required_structural_member,
-    type_check_fail_reason::TypeCheckFailReason, type_check_guard::TypeCheckGuard,
+    TypeCheckResult, check_general_type_compact, is_structural_method_member,
+    member_has_documented_default, type_check_fail_reason::TypeCheckFailReason,
+    type_check_guard::TypeCheckGuard,
 };
 
 pub fn check_generic_type_compact(
@@ -157,7 +158,9 @@ fn check_generic_type_compact_table(
     let next_guard = check_guard.next_level()?;
 
     for source_member in source_type_members {
-        let source_member_feature = source_member.feature;
+        if is_structural_method_member(source_member.feature) {
+            continue;
+        }
         let property_owner_id = source_member.property_owner_id;
         let source_member_type = source_member.typ;
         let key = source_member.key;
@@ -195,9 +198,8 @@ fn check_generic_type_compact_table(
                 }
             }
             None if !source_member_type.is_optional()
-                && is_required_structural_member(
+                && !member_has_documented_default(
                     context.db,
-                    source_member_feature,
                     property_owner_id.as_ref(),
                     Some(&source_member_type),
                 ) =>

--- a/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/generic_type.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use crate::{
     LuaGenericType, LuaMemberOwner, LuaType, LuaTypeDeclId, RenderLevel, TypeSubstitutor,
@@ -156,17 +159,18 @@ fn check_generic_type_compact_table(
 
     // 提前计算下一级检查守卫
     let next_guard = check_guard.next_level()?;
+    let mut checked_keys = HashSet::new();
 
     for source_member in source_type_members {
+        let key = source_member.key;
+        if !checked_keys.insert(key.clone()) {
+            continue;
+        }
         if is_structural_method_member(source_member.feature) {
             continue;
         }
         let property_owner_id = source_member.property_owner_id;
         let source_member_type = source_member.typ;
-        let key = source_member.key;
-        if context.is_key_checked(&key) {
-            continue;
-        }
 
         match table_member_map.get(&key) {
             Some(table_member_id) => {
@@ -216,21 +220,6 @@ fn check_generic_type_compact_table(
                 ));
             }
             _ => {} // 可选成员未找到，继续检查
-        }
-
-        context.mark_key_checked(key);
-    }
-
-    // 检查超类型
-    let source_base_id = source_generic.get_base_type_id();
-    if let Some(supers) = context.db.get_type_index().get_super_types(&source_base_id) {
-        let element_range = table_owner
-            .get_element_range()
-            .ok_or(TypeCheckFailReason::TypeNotMatch)?;
-        let table_type = LuaType::TableConst(element_range.clone());
-
-        for super_type in supers {
-            check_general_type_compact(context, &super_type, &table_type, next_guard)?;
         }
     }
 

--- a/crates/glua_code_analysis/src/semantic/type_check/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/mod.rs
@@ -29,22 +29,13 @@ pub use sub_type::is_sub_type_of;
 pub type TypeCheckResult = Result<(), TypeCheckFailReason>;
 pub use type_check_context::TypeCheckCheckLevel;
 
-fn is_required_structural_member(
-    db: &DbIndex,
-    feature: Option<LuaMemberFeature>,
-    property_owner_id: Option<&LuaSemanticDeclId>,
-    member_type: Option<&LuaType>,
-) -> bool {
-    if matches!(
-        feature,
-        Some(LuaMemberFeature::FileMethodDecl | LuaMemberFeature::MetaMethodDecl)
-    ) {
-        return false;
-    }
-
-    !member_has_documented_default(db, property_owner_id, member_type)
+// Method declarations are exempt from structural comparison because their inferred
+// types can include body-specific literal returns and, for colon methods, `self`.
+fn is_structural_method_member(feature: Option<LuaMemberFeature>) -> bool {
+    feature.is_some_and(|feature| feature.is_method_decl())
 }
 
+// A documented default makes a member optional for presence only.
 fn member_has_documented_default(
     db: &DbIndex,
     property_owner_id: Option<&LuaSemanticDeclId>,

--- a/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     LuaMemberKey, LuaMemberOwner, LuaObjectType, LuaSemanticDeclId, LuaTupleType, LuaType,
-    LuaTypeCache, LuaTypeDecl, LuaTypeDeclId, RenderLevel, humanize_type,
+    LuaTypeDecl, LuaTypeDeclId, RenderLevel, humanize_type,
     semantic::{
         member::find_members,
         type_check::{
@@ -330,25 +330,28 @@ fn check_ref_type_compact_table(
         })
         .unwrap_or_default();
 
-    let source_owner = LuaMemberOwner::Type(source_type_id.clone());
-    let source_type_members = member_index.get_members(&source_owner);
+    let source_type = LuaType::Ref(source_type_id.clone());
+    let source_type_members = find_members(context.db, &source_type);
     let Some(source_type_members) = source_type_members else {
         return Ok(()); // empty member donot need check
     };
 
-    let mut resolved_duplicate_types = HashMap::new();
+    let mut checked_keys = HashSet::new();
 
     for source_member in source_type_members {
-        let raw_source_member_type = context
-            .db
-            .get_type_index()
-            .get_type_cache(&source_member.get_id().into())
-            .unwrap_or(&LuaTypeCache::InferType(LuaType::Any))
-            .as_type();
-        let key = source_member.get_key();
-        if let std::collections::hash_map::Entry::Vacant(entry) =
-            resolved_duplicate_types.entry(key.clone())
-            && let Some(item) = member_index.get_member_item(&source_owner, key)
+        let key = source_member.key;
+        if !checked_keys.insert(key.clone()) {
+            continue;
+        }
+        if is_structural_method_member(source_member.feature) {
+            continue;
+        }
+
+        let mut source_member_type = source_member.typ;
+        if let Some(LuaSemanticDeclId::Member(source_member_id)) =
+            source_member.property_owner_id.as_ref()
+            && let Some(source_owner) = member_index.get_current_owner(source_member_id)
+            && let Some(item) = member_index.get_member_item(source_owner, &key)
             && !item.is_one()
             && item.get_member_ids().iter().all(|member_id| {
                 member_index.get_member(member_id).is_some_and(|member| {
@@ -357,22 +360,10 @@ fn check_ref_type_compact_table(
             })
             && let Ok(typ) = context.resolve_member_item_type(item)
         {
-            entry.insert(typ);
-        }
-        let source_member_type = resolved_duplicate_types
-            .get(key)
-            .unwrap_or(raw_source_member_type);
-        let property_owner_id = LuaSemanticDeclId::Member(source_member.get_id());
-        if is_structural_method_member(Some(source_member.get_feature())) {
-            continue;
-        }
-        let key = source_member.get_key();
-
-        if context.is_key_checked(key) {
-            continue;
+            source_member_type = typ;
         }
 
-        match table_member_map.get(key) {
+        match table_member_map.get(&key) {
             Some(table_member_id) => {
                 let table_member = member_index
                     .get_member(table_member_id)
@@ -383,7 +374,7 @@ fn check_ref_type_compact_table(
 
                 if let Err(err) = check_general_type_compact(
                     context,
-                    source_member_type,
+                    &source_member_type,
                     &table_member_type,
                     check_guard.next_level()?,
                 ) && err.is_type_not_match()
@@ -397,7 +388,7 @@ fn check_ref_type_compact_table(
                             "member {name} type not match, expect {expect}, got {got}",
                             name = key.to_path(),
                             expect =
-                                humanize_type(context.db, source_member_type, RenderLevel::Simple),
+                                humanize_type(context.db, &source_member_type, RenderLevel::Simple),
                             got =
                                 humanize_type(context.db, &table_member_type, RenderLevel::Simple)
                         )
@@ -408,8 +399,8 @@ fn check_ref_type_compact_table(
             None if !source_member_type.is_optional()
                 && !member_has_documented_default(
                     context.db,
-                    Some(&property_owner_id),
-                    Some(source_member_type),
+                    source_member.property_owner_id.as_ref(),
+                    Some(&source_member_type),
                 ) =>
             {
                 if !context.detail {
@@ -421,26 +412,6 @@ fn check_ref_type_compact_table(
                 ));
             }
             _ => {} // Optional member not found, continue
-        }
-
-        context.mark_key_checked(key.clone());
-    }
-
-    // 检查超类型
-    if let Some(supers) = context.db.get_type_index().get_super_types(source_type_id) {
-        let table_type = LuaType::TableConst(
-            table_owner
-                .get_element_range()
-                .ok_or(TypeCheckFailReason::TypeNotMatch)?
-                .clone(),
-        );
-        for super_type in supers {
-            check_general_type_compact(
-                context,
-                &super_type,
-                &table_type,
-                check_guard.next_level()?,
-            )?;
         }
     }
 
@@ -459,16 +430,17 @@ fn check_ref_type_compact_object(
         return Ok(());
     };
 
+    let mut checked_keys = HashSet::new();
     for source_member in source_type_members {
+        let key = source_member.key;
+        if !checked_keys.insert(key.clone()) {
+            continue;
+        }
         if is_structural_method_member(source_member.feature) {
             continue;
         }
         let property_owner_id = source_member.property_owner_id;
         let source_member_type = source_member.typ;
-        let key = source_member.key;
-        if context.is_key_checked(&key) {
-            continue;
-        }
 
         match get_object_field_type(object_type, &key) {
             Some(field_type) => {
@@ -511,8 +483,6 @@ fn check_ref_type_compact_object(
             }
             _ => {} // Optional member not found, continue
         }
-
-        context.mark_key_checked(key);
     }
 
     Ok(())
@@ -546,9 +516,10 @@ fn check_ref_type_compact_tuple(
     };
 
     let tuple_types = tuple_type.get_types();
+    let mut checked_keys = HashSet::new();
     for member in source_type_members {
         let key = member.key;
-        if context.is_key_checked(&key) {
+        if !checked_keys.insert(key.clone()) {
             continue;
         }
         match &key {
@@ -584,8 +555,6 @@ fn check_ref_type_compact_tuple(
                 return Err(TypeCheckFailReason::TypeNotMatch);
             }
         }
-
-        context.mark_key_checked(key);
     }
 
     Ok(())

--- a/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
@@ -12,9 +12,9 @@ use crate::{
 };
 
 use super::{
-    TypeCheckResult, check_general_type_compact, is_required_structural_member, is_sub_type_of,
-    sub_type::get_base_type_id, type_check_fail_reason::TypeCheckFailReason,
-    type_check_guard::TypeCheckGuard,
+    TypeCheckResult, check_general_type_compact, is_structural_method_member, is_sub_type_of,
+    member_has_documented_default, sub_type::get_base_type_id,
+    type_check_fail_reason::TypeCheckFailReason, type_check_guard::TypeCheckGuard,
 };
 
 const GMOD_NULL_TYPE_NAME: &str = "NULL";
@@ -363,6 +363,9 @@ fn check_ref_type_compact_table(
             .get(key)
             .unwrap_or(raw_source_member_type);
         let property_owner_id = LuaSemanticDeclId::Member(source_member.get_id());
+        if is_structural_method_member(Some(source_member.get_feature())) {
+            continue;
+        }
         let key = source_member.get_key();
 
         if context.is_key_checked(key) {
@@ -403,9 +406,8 @@ fn check_ref_type_compact_table(
                 }
             }
             None if !source_member_type.is_optional()
-                && is_required_structural_member(
+                && !member_has_documented_default(
                     context.db,
-                    Some(source_member.get_feature()),
                     Some(&property_owner_id),
                     Some(source_member_type),
                 ) =>
@@ -458,7 +460,9 @@ fn check_ref_type_compact_object(
     };
 
     for source_member in source_type_members {
-        let source_member_feature = source_member.feature;
+        if is_structural_method_member(source_member.feature) {
+            continue;
+        }
         let property_owner_id = source_member.property_owner_id;
         let source_member_type = source_member.typ;
         let key = source_member.key;
@@ -492,9 +496,8 @@ fn check_ref_type_compact_object(
                 }
             }
             None if !source_member_type.is_optional()
-                && is_required_structural_member(
+                && !member_has_documented_default(
                     context.db,
-                    source_member_feature,
                     property_owner_id.as_ref(),
                     Some(&source_member_type),
                 ) =>

--- a/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/ref_type.rs
@@ -363,14 +363,6 @@ fn check_ref_type_compact_table(
             .get(key)
             .unwrap_or(raw_source_member_type);
         let property_owner_id = LuaSemanticDeclId::Member(source_member.get_id());
-        if !is_required_structural_member(
-            context.db,
-            Some(source_member.get_feature()),
-            Some(&property_owner_id),
-            Some(source_member_type),
-        ) {
-            continue;
-        }
         let key = source_member.get_key();
 
         if context.is_key_checked(key) {
@@ -410,7 +402,14 @@ fn check_ref_type_compact_table(
                     ));
                 }
             }
-            None if !source_member_type.is_optional() => {
+            None if !source_member_type.is_optional()
+                && is_required_structural_member(
+                    context.db,
+                    Some(source_member.get_feature()),
+                    Some(&property_owner_id),
+                    Some(source_member_type),
+                ) =>
+            {
                 if !context.detail {
                     return Err(TypeCheckFailReason::TypeNotMatch);
                 }
@@ -459,14 +458,8 @@ fn check_ref_type_compact_object(
     };
 
     for source_member in source_type_members {
-        if !is_required_structural_member(
-            context.db,
-            source_member.feature,
-            source_member.property_owner_id.as_ref(),
-            Some(&source_member.typ),
-        ) {
-            continue;
-        }
+        let source_member_feature = source_member.feature;
+        let property_owner_id = source_member.property_owner_id;
         let source_member_type = source_member.typ;
         let key = source_member.key;
         if context.is_key_checked(&key) {
@@ -498,7 +491,14 @@ fn check_ref_type_compact_object(
                     ));
                 }
             }
-            None if !source_member_type.is_optional() => {
+            None if !source_member_type.is_optional()
+                && is_required_structural_member(
+                    context.db,
+                    source_member_feature,
+                    property_owner_id.as_ref(),
+                    Some(&source_member_type),
+                ) =>
+            {
                 if !context.detail {
                     return Err(TypeCheckFailReason::TypeNotMatch);
                 }

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -569,6 +569,26 @@ mod test {
     }
 
     #[test]
+    fn generic_child_default_suppresses_parent_required_field() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class GenericParent<T>
+            ---@field force T
+            ---@field other string
+
+            ---@class GenericChild<T> : GenericParent<T>
+            ---@field force T=1
+            "#,
+        );
+
+        let target_ty = ws.ty("GenericChild<number>");
+        let table_ty = ws.expr_ty(r#"{ other = "ok" }"#);
+
+        assert!(ws.check_type(&target_ty, &table_ty));
+    }
+
+    #[test]
     fn generic_method_member_is_not_checked_when_present() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -589,6 +589,46 @@ mod test {
     }
 
     #[test]
+    fn nested_generic_fields_do_not_share_checked_keys() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Inner<T>
+            ---@field value T
+
+            ---@class Outer<T>
+            ---@field inner Inner<T>
+            ---@field value string
+            "#,
+        );
+
+        let target_ty = ws.ty("Outer<number>");
+        let table_ty = ws.expr_ty(r#"{ inner = { value = 1 }, value = 1 }"#);
+
+        assert!(!ws.check_type(&target_ty, &table_ty));
+    }
+
+    #[test]
+    fn nested_class_fields_do_not_share_checked_keys() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class Inner
+            ---@field value number
+
+            ---@class Outer
+            ---@field inner Inner
+            ---@field value string
+            "#,
+        );
+
+        let target_ty = ws.ty("Outer");
+        let table_ty = ws.expr_ty(r#"{ inner = { value = 1 }, value = 1 }"#);
+
+        assert!(!ws.check_type(&target_ty, &table_ty));
+    }
+
+    #[test]
     fn generic_method_member_is_not_checked_when_present() {
         let mut ws = VirtualWorkspace::new();
         ws.def(

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -491,6 +491,50 @@ mod test {
     }
 
     #[test]
+    fn method_member_is_not_checked_in_object_type() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class WithMethod
+            ---@field other string
+            local WithMethod = {}
+
+            function WithMethod:check()
+                return true
+            end
+            "#,
+        );
+
+        let target_ty = ws.ty("WithMethod");
+        let object_ty = ws.ty("{ check: number, other: string }");
+
+        assert!(ws.check_type(&target_ty, &object_ty));
+    }
+
+    #[test]
+    fn inherited_method_member_is_not_checked_when_present() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class MethodParent
+            local MethodParent = {}
+
+            function MethodParent:check()
+                return true
+            end
+
+            ---@class MethodChild : MethodParent
+            ---@field other string
+            "#,
+        );
+
+        let target_ty = ws.ty("MethodChild");
+        let table_ty = ws.expr_ty(r#"{ check = 1, other = "ok" }"#);
+
+        assert!(ws.check_type(&target_ty, &table_ty));
+    }
+
+    #[test]
     fn test_defaulted_generic_field_is_not_required_for_table_compatibility() {
         let mut ws = VirtualWorkspace::new();
         ws.def(
@@ -522,5 +566,26 @@ mod test {
         let table_ty = ws.expr_ty(r#"{ Value = 1, Hit = "wrong" }"#);
 
         assert!(!ws.check_type(&target_ty, &table_ty));
+    }
+
+    #[test]
+    fn generic_method_member_is_not_checked_when_present() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class GenericWithMethod<T>
+            ---@field value T
+            local GenericWithMethod = {}
+
+            function GenericWithMethod:check()
+                return true
+            end
+            "#,
+        );
+
+        let target_ty = ws.ty("GenericWithMethod<number>");
+        let table_ty = ws.expr_ty("{ value = 1, check = 1 }");
+
+        assert!(ws.check_type(&target_ty, &table_ty));
     }
 }

--- a/crates/glua_code_analysis/src/semantic/type_check/test.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/test.rs
@@ -457,6 +457,40 @@ mod test {
     }
 
     #[test]
+    fn issue_54_defaulted_class_field_is_checked_when_present() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class WithDefault
+            ---@field force number=1000
+            ---@field other string
+            "#,
+        );
+
+        let target_ty = ws.ty("WithDefault");
+        let table_ty = ws.expr_ty(r#"{ force = "wrong", other = "ok" }"#);
+
+        assert!(!ws.check_type(&target_ty, &table_ty));
+    }
+
+    #[test]
+    fn issue_54_defaulted_class_field_is_checked_in_object_type() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class WithDefault
+            ---@field force number=1000
+            ---@field other string
+            "#,
+        );
+
+        let target_ty = ws.ty("WithDefault");
+        let object_ty = ws.ty("{ force: string, other: string }");
+
+        assert!(!ws.check_type(&target_ty, &object_ty));
+    }
+
+    #[test]
     fn test_defaulted_generic_field_is_not_required_for_table_compatibility() {
         let mut ws = VirtualWorkspace::new();
         ws.def(
@@ -471,5 +505,22 @@ mod test {
         let table_ty = ws.expr_ty("{ Value = 1 }");
 
         assert!(ws.check_type(&target_ty, &table_ty));
+    }
+
+    #[test]
+    fn issue_54_defaulted_generic_field_is_checked_when_present() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class TraceBox<T>
+            ---@field Value T
+            ---@field Hit boolean=false
+            "#,
+        );
+
+        let target_ty = ws.ty("TraceBox<number>");
+        let table_ty = ws.expr_ty(r#"{ Value = 1, Hit = "wrong" }"#);
+
+        assert!(!ws.check_type(&target_ty, &table_ty));
     }
 }

--- a/crates/glua_code_analysis/src/semantic/type_check/type_check_context.rs
+++ b/crates/glua_code_analysis/src/semantic/type_check/type_check_context.rs
@@ -1,8 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
-use crate::{
-    DbIndex, InferFailReason, LuaMemberId, LuaMemberIndexItem, LuaMemberKey, LuaType, LuaTypeFact,
-};
+use crate::{DbIndex, InferFailReason, LuaMemberId, LuaMemberIndexItem, LuaType, LuaTypeFact};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeCheckCheckLevel {
@@ -15,7 +13,6 @@ pub struct TypeCheckContext<'db> {
     pub detail: bool,
     pub db: &'db DbIndex,
     pub level: TypeCheckCheckLevel,
-    pub table_member_checked: Option<HashSet<LuaMemberKey>>,
     member_facts: HashMap<LuaMemberId, LuaTypeFact>,
 }
 
@@ -25,7 +22,6 @@ impl<'db> TypeCheckContext<'db> {
             detail,
             db,
             level,
-            table_member_checked: None,
             member_facts: HashMap::new(),
         }
     }
@@ -54,22 +50,5 @@ impl<'db> TypeCheckContext<'db> {
         }
 
         member_item.resolve_type(self.db)
-    }
-
-    pub fn is_key_checked(&self, key: &LuaMemberKey) -> bool {
-        if let Some(checked) = &self.table_member_checked {
-            checked.contains(key)
-        } else {
-            false
-        }
-    }
-
-    pub fn mark_key_checked(&mut self, key: LuaMemberKey) {
-        if self.table_member_checked.is_none() {
-            self.table_member_checked = Some(HashSet::new());
-        }
-        if let Some(checked) = &mut self.table_member_checked {
-            checked.insert(key);
-        }
     }
 }


### PR DESCRIPTION
## Summary

- type-check supplied structural fields even when their annotations define defaults
- keep defaulted fields optional when omitted and preserve child overrides and method exemptions
- validate inline callback body returns, including nested and intersection table shapes
- isolate inherited field traversal so nested structures cannot suppress outer mismatches

## Root cause

Default metadata was treated as a reason to skip the entire member check instead of only the missing-member requirement. Contextual callback types and shared inheritance traversal state could also hide incompatible supplied values.

## Validation

- cargo test --workspace --all-targets --all-features (2,970 analyzer tests passed; 5 intentionally ignored; all workspace crates passed)
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- changed-file pre-commit hooks
- independent merge-readiness review

Closes #54