### PR TITLE
fix: stabilize scripted child inference and tools

### DIFF
--- a/crates/glua_code_analysis/src/compilation/analyzer/doc/type_def_tags.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/doc/type_def_tags.rs
@@ -46,6 +46,7 @@ pub fn analyze_class(analyzer: &mut DocAnalyzer, tag: LuaDocTagClass) -> Option<
 
     if let Some(supers) = tag.get_supers() {
         for super_doc_type in supers.get_types() {
+            let source_range = super_doc_type.get_range();
             let super_type = infer_type(analyzer, super_doc_type);
             if super_type.is_unknown() {
                 continue;
@@ -54,6 +55,7 @@ pub fn analyze_class(analyzer: &mut DocAnalyzer, tag: LuaDocTagClass) -> Option<
             analyzer.db.get_type_index_mut().add_super_type(
                 class_decl_id.clone(),
                 file_id,
+                source_range,
                 super_type,
             );
         }

--- a/crates/glua_code_analysis/src/compilation/analyzer/gmod/mod.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/gmod/mod.rs
@@ -2992,6 +2992,7 @@ fn ensure_scoped_class_type_decl(
         db.get_type_index_mut().add_super_type_if_missing(
             class_decl_id.clone(),
             file_id,
+            range,
             super_type,
         );
     }
@@ -4953,14 +4954,15 @@ fn synthesize_scripted_ent_registration(
     db.get_type_index_mut()
         .replace_table_const_type(&table_range, &class_type);
 
-    let base_name =
+    let base =
         resolve_registered_scripted_ent_base(table_expr.clone(), metadata, register_position);
-    if let Some(base_name) = base_name {
+    if let Some((base_name, source_range)) = base {
         let super_type = LuaType::Ref(LuaTypeDeclId::global(&base_name));
         if super_type != class_type {
             db.get_type_index_mut().add_super_type_if_missing(
                 class_decl_id.clone(),
                 file_id,
+                source_range,
                 super_type,
             );
         }
@@ -4973,7 +4975,7 @@ fn synthesize_scripted_ent_registration(
     // injection). Without this, `self:StartActivity()` on a `base_nextbot`
     // entity produces false-positive `undefined-field` diagnostics because
     // the synthesized `base_nextbot` class doesn't inherit from `NextBot`.
-    if let Some(type_name) = resolve_registered_scripted_ent_type(&table_expr)
+    if let Some((type_name, source_range)) = resolve_registered_scripted_ent_type(&table_expr)
         && let Some(super_name) = super_type_for_entity_type(&type_name)
     {
         let super_type = LuaType::Ref(LuaTypeDeclId::global(&super_name));
@@ -4981,6 +4983,7 @@ fn synthesize_scripted_ent_registration(
             db.get_type_index_mut().add_super_type_if_missing(
                 class_decl_id.clone(),
                 file_id,
+                source_range,
                 super_type,
             );
         }
@@ -5000,12 +5003,12 @@ fn resolve_registered_scripted_ent_base(
     table_expr: LuaTableExpr,
     metadata: &GmodScriptedClassFileMetadata,
     register_position: TextSize,
-) -> Option<String> {
+) -> Option<(String, TextRange)> {
     if let Some(field) = find_table_field_by_name(&table_expr, "Base")
         && let Some(value_expr) = field.get_value_expr()
         && let Some(base_name) = extract_scoped_base_name(&value_expr)
     {
-        return Some(base_name);
+        return Some((base_name, field.get_range()));
     }
 
     metadata
@@ -5016,7 +5019,7 @@ fn resolve_registered_scripted_ent_base(
         .and_then(
             |call| match call.literal_args.get(call.inheritance_name_arg_idx()) {
                 Some(Some(GmodClassCallLiteral::String(name))) if !name.is_empty() => {
-                    Some(name.clone())
+                    Some((name.clone(), call.syntax_id.get_range()))
                 }
                 _ => None,
             },
@@ -5025,10 +5028,10 @@ fn resolve_registered_scripted_ent_base(
 
 /// Reads the `Type` field from a scripted-entity table literal (e.g.
 /// `ENT.Type = "nextbot"`).
-fn resolve_registered_scripted_ent_type(table_expr: &LuaTableExpr) -> Option<String> {
+fn resolve_registered_scripted_ent_type(table_expr: &LuaTableExpr) -> Option<(String, TextRange)> {
     let field = find_table_field_by_name(table_expr, "Type")?;
     let value_expr = field.get_value_expr()?;
-    extract_scoped_base_name(&value_expr)
+    extract_scoped_base_name(&value_expr).map(|name| (name, field.get_range()))
 }
 
 /// Maps `ENT.Type` values to the annotation class that provides the
@@ -5183,7 +5186,13 @@ fn synthesize_scoped_base_assignments_with(
                 let Some(base_name) = extract_scoped_base_name(value_expr) else {
                     continue;
                 };
-                add_scoped_super_type_if_missing(db, &class_decl_id, file_id, &base_name);
+                add_scoped_super_type_if_missing(
+                    db,
+                    &class_decl_id,
+                    file_id,
+                    value_expr.get_range(),
+                    &base_name,
+                );
                 synthesize_baseclass_member(
                     db,
                     file_id,
@@ -5203,7 +5212,13 @@ fn synthesize_scoped_base_assignments_with(
                 let Some(super_name) = super_type_for_entity_type(&type_name) else {
                     continue;
                 };
-                add_scoped_super_type_if_missing(db, &class_decl_id, file_id, super_name);
+                add_scoped_super_type_if_missing(
+                    db,
+                    &class_decl_id,
+                    file_id,
+                    value_expr.get_range(),
+                    super_name,
+                );
             }
         }
     }
@@ -5215,21 +5230,19 @@ fn add_scoped_super_type_if_missing(
     db: &mut DbIndex,
     class_decl_id: &LuaTypeDeclId,
     file_id: FileId,
+    source_range: TextRange,
     super_name: &str,
 ) {
     let super_type = LuaType::Ref(LuaTypeDeclId::global(super_name));
     if super_type == LuaType::Ref(class_decl_id.clone()) {
         return;
     }
-    let has_super = db
-        .get_type_index()
-        .get_super_types_iter(class_decl_id)
-        .map(|mut supers| supers.any(|existing_super| existing_super == &super_type))
-        .unwrap_or(false);
-    if !has_super {
-        db.get_type_index_mut()
-            .add_super_type(class_decl_id.clone(), file_id, super_type);
-    }
+    db.get_type_index_mut().add_super_type_if_missing(
+        class_decl_id.clone(),
+        file_id,
+        source_range,
+        super_type,
+    );
 }
 
 fn extract_scoped_base_name(expr: &LuaExpr) -> Option<String> {
@@ -5692,8 +5705,12 @@ fn synthesize_inheritance_base(
     materialize_scoped_gamemode_base(db, file_id, class_name_prefix, &effective_base_name);
 
     let super_type = LuaType::Ref(LuaTypeDeclId::global(&effective_base_name));
-    db.get_type_index_mut()
-        .add_super_type_if_missing(class_decl_id.clone(), file_id, super_type);
+    db.get_type_index_mut().add_super_type_if_missing(
+        class_decl_id.clone(),
+        file_id,
+        source_syntax_id.get_range(),
+        super_type,
+    );
     synthesize_baseclass_member(
         db,
         file_id,
@@ -6313,8 +6330,15 @@ fn synthesize_vgui_register_file_target(
         resolve_load_dependency_target(db, source_file_id, LuaDependencyKind::Include, path)?;
     // `vgui.RegisterFile` gives a temporary PANEL table the same runtime
     // default as `vgui.Register`: without an explicit Base it derives Panel.
-    let base_panel = find_target_panel_base_assignment(db, target_file_id)
-        .unwrap_or_else(|| "Panel".to_string());
+    let (base_panel, base_source_range) = find_target_panel_base_assignment(db, target_file_id)
+        .unwrap_or_else(|| {
+            let file_range = db
+                .get_vfs()
+                .get_syntax_tree(&target_file_id)
+                .map(|tree| tree.get_chunk_node().syntax().text_range())
+                .unwrap_or_default();
+            ("Panel".to_string(), file_range)
+        });
 
     let class_decl_id = LuaTypeDeclId::local(
         target_file_id,
@@ -6361,15 +6385,12 @@ fn synthesize_vgui_register_file_target(
     }
 
     let super_type = LuaType::Ref(LuaTypeDeclId::global(&base_panel));
-    let has_super = db
-        .get_type_index()
-        .get_super_types_iter(&class_decl_id)
-        .map(|mut supers| supers.any(|existing_super| existing_super == &super_type))
-        .unwrap_or(false);
-    if !has_super {
-        db.get_type_index_mut()
-            .add_super_type(class_decl_id.clone(), target_file_id, super_type);
-    }
+    db.get_type_index_mut().add_super_type_if_missing(
+        class_decl_id.clone(),
+        target_file_id,
+        base_source_range,
+        super_type,
+    );
 
     let target_panel_decl_ids = ensure_register_file_panel_decls(db, target_file_id)?;
     let panel_decl_id = *target_panel_decl_ids.first()?;
@@ -6478,7 +6499,7 @@ fn ensure_register_file_panel_decls(db: &mut DbIndex, file_id: FileId) -> Option
     Some(vec![decl_id])
 }
 
-fn find_target_panel_base_assignment(db: &DbIndex, file_id: FileId) -> Option<String> {
+fn find_target_panel_base_assignment(db: &DbIndex, file_id: FileId) -> Option<(String, TextRange)> {
     let tree = db.get_vfs().get_syntax_tree(&file_id)?;
     let chunk = tree.get_chunk_node();
     let mut base_name = None;
@@ -6499,7 +6520,7 @@ fn find_target_panel_base_assignment(db: &DbIndex, file_id: FileId) -> Option<St
                 continue;
             }
             if let Some(name) = exprs.get(idx).and_then(lua_expr_string_literal) {
-                base_name = Some(name);
+                base_name = Some((name, index_expr.get_range()));
             }
         }
     }
@@ -6881,15 +6902,12 @@ fn synthesize_panel_class_with_id(
     // Set super type from base panel
     if let Some(base_name) = base_panel {
         let super_type = LuaType::Ref(LuaTypeDeclId::global(base_name));
-        let has_super = db
-            .get_type_index()
-            .get_super_types_iter(&class_decl_id)
-            .map(|mut supers| supers.any(|existing_super| existing_super == &super_type))
-            .unwrap_or(false);
-        if !has_super {
-            db.get_type_index_mut()
-                .add_super_type(class_decl_id.clone(), file_id, super_type);
-        }
+        db.get_type_index_mut().add_super_type_if_missing(
+            class_decl_id.clone(),
+            file_id,
+            call.syntax_id.get_range(),
+            super_type,
+        );
         synthesize_panel_baseclass_member(db, file_id, &class_decl_id, base_name, call_kind, call);
     }
 

--- a/crates/glua_code_analysis/src/compilation/analyzer/infer_cache_manager.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/infer_cache_manager.rs
@@ -46,7 +46,11 @@ impl InferCacheManager {
         let infer_cache = self.get_infer_cache(file_id);
         for pending in pending_type_decls {
             debug_assert_eq!(pending.file_id, file_id);
-            infer_cache.add_pending_str_tpl_type_decl(pending.type_decl_id, pending.super_type);
+            infer_cache.add_pending_str_tpl_type_decl(
+                pending.source_range,
+                pending.type_decl_id,
+                pending.super_type,
+            );
         }
         for dependency in guard_dependencies {
             infer_cache.add_inferred_guard_dependency(dependency);

--- a/crates/glua_code_analysis/src/compilation/analyzer/local_inference/mod.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/local_inference/mod.rs
@@ -1,7 +1,7 @@
 mod evidence;
 mod solver;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{cmp::Ordering, collections::HashMap, sync::Arc};
 
 use rustc_hash::FxHashMap;
 
@@ -213,6 +213,18 @@ struct NestedUnguardedChildCandidates {
     children: HashMap<crate::LuaTypeDeclId, FxHashSet<LuaMemberKey>>,
     receivers: FxHashSet<InFiled<glua_parser::LuaSyntaxId>>,
     source: InFiled<glua_parser::LuaSyntaxId>,
+}
+
+fn compare_unguarded_child_candidates(
+    left: &LuaTypeDeclId,
+    left_display_name: &str,
+    right: &LuaTypeDeclId,
+    right_display_name: &str,
+) -> Ordering {
+    left_display_name
+        .cmp(right_display_name)
+        .then_with(|| left.get_name().cmp(right.get_name()))
+        .then_with(|| left.stable_cmp(right))
 }
 
 pub(super) fn stabilize_unguarded_children(
@@ -482,18 +494,17 @@ pub(super) fn stabilize_unguarded_children(
             .filter_map(|(child_id, keys)| (keys.len() == max_score).then_some(child_id))
             .collect::<Vec<_>>();
         winners.sort_by(|left, right| {
-            db.get_type_index()
+            let left_display_name = db
+                .get_type_index()
                 .get_type_decl(left)
                 .map(|decl| decl.get_name())
-                .unwrap_or_else(|| left.get_name())
-                .cmp(
-                    db.get_type_index()
-                        .get_type_decl(right)
-                        .map(|decl| decl.get_name())
-                        .unwrap_or_else(|| right.get_name()),
-                )
-                .then_with(|| left.get_name().cmp(right.get_name()))
-                .then_with(|| left.stable_cmp(right))
+                .unwrap_or_else(|| left.get_name());
+            let right_display_name = db
+                .get_type_index()
+                .get_type_decl(right)
+                .map(|decl| decl.get_name())
+                .unwrap_or_else(|| right.get_name());
+            compare_unguarded_child_candidates(left, left_display_name, right, right_display_name)
         });
         let Some(source) = winners
             .iter()
@@ -558,17 +569,17 @@ pub(super) fn stabilize_unguarded_children(
             .filter_map(|(child_id, keys)| (keys.len() == max_score).then_some(child_id))
             .collect::<Vec<_>>();
         winners.sort_by(|left, right| {
-            db.get_type_index()
+            let left_display_name = db
+                .get_type_index()
                 .get_type_decl(left)
                 .map(|decl| decl.get_name())
-                .unwrap_or_else(|| left.get_name())
-                .cmp(
-                    db.get_type_index()
-                        .get_type_decl(right)
-                        .map(|decl| decl.get_name())
-                        .unwrap_or_else(|| right.get_name()),
-                )
-                .then_with(|| left.get_name().cmp(right.get_name()))
+                .unwrap_or_else(|| left.get_name());
+            let right_display_name = db
+                .get_type_index()
+                .get_type_decl(right)
+                .map(|decl| decl.get_name())
+                .unwrap_or_else(|| right.get_name());
+            compare_unguarded_child_candidates(left, left_display_name, right, right_display_name)
         });
         let typ = LuaType::from_vec(winners.iter().cloned().map(LuaType::Ref).collect());
         let mut support = Vec::new();
@@ -1489,9 +1500,13 @@ fn declaration_base_type(
 
 #[cfg(test)]
 mod tests {
+    use std::cmp::Ordering;
+
     use glua_parser::{LuaAstNode, LuaIndexExpr, LuaParser, ParserConfig};
 
-    use super::is_assignment_target;
+    use crate::{FileId, LuaTypeDeclId};
+
+    use super::{compare_unguarded_child_candidates, is_assignment_target};
 
     fn parse_index_expr(code: &str) -> LuaIndexExpr {
         LuaParser::parse(code, ParserConfig::default())
@@ -1513,5 +1528,27 @@ mod tests {
         let index_expr = parse_index_expr("result = value.ChildOnly");
 
         assert!(!is_assignment_target(&index_expr));
+    }
+
+    #[test]
+    fn unguarded_child_candidate_order_breaks_global_local_name_ties() {
+        let global = LuaTypeDeclId::global("SharedName");
+        let local = LuaTypeDeclId::local(FileId::new(1), "SharedName");
+
+        assert_eq!(
+            compare_unguarded_child_candidates(&global, "SharedName", &local, "SharedName"),
+            Ordering::Less
+        );
+    }
+
+    #[test]
+    fn unguarded_child_candidate_order_breaks_local_file_name_ties() {
+        let first = LuaTypeDeclId::local(FileId::new(1), "SharedName");
+        let second = LuaTypeDeclId::local(FileId::new(2), "SharedName");
+
+        assert_eq!(
+            compare_unguarded_child_candidates(&first, "SharedName", &second, "SharedName"),
+            Ordering::Less
+        );
     }
 }

--- a/crates/glua_code_analysis/src/compilation/analyzer/lua/for_range_stat.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/lua/for_range_stat.rs
@@ -165,6 +165,7 @@ pub fn infer_for_range_iter_expr_func(
         cache,
         substitutor: &mut substitutor,
         call_expr: None,
+        source_range: iter_exprs[0].get_range(),
     };
     let params = doc_function
         .get_params()

--- a/crates/glua_code_analysis/src/compilation/analyzer/unresolve/find_decl_function.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/unresolve/find_decl_function.rs
@@ -10,7 +10,7 @@ use crate::{
         LuaOperatorMetaMethod, LuaTupleType, LuaType, LuaTypeDeclId, LuaUnionType,
     },
     infer_expr, instantiate_type_generic,
-    semantic::InferGuard,
+    semantic::{InferGuard, visible_super_types_in_workspace_for_file_at_offset},
 };
 
 type FunctionTypeResult = Result<LuaType, InferFailReason>;
@@ -51,6 +51,25 @@ fn get_member_id(cache: &mut LuaInferCache, index_member_expr: &LuaIndexMemberEx
             let syntax_id = table_field.get_syntax_id();
             LuaMemberId::new(syntax_id, file_id)
         }
+    }
+}
+
+fn visible_super_types_for_index(
+    db: &DbIndex,
+    cache: &LuaInferCache,
+    type_decl_id: &LuaTypeDeclId,
+    index_expr: &LuaIndexMemberExpr,
+) -> Option<Vec<LuaType>> {
+    if let Some(workspace_id) = db.get_module_index().get_workspace_id(cache.get_file_id()) {
+        visible_super_types_in_workspace_for_file_at_offset(
+            db,
+            type_decl_id,
+            workspace_id,
+            cache.get_file_id(),
+            index_expr.get_position(),
+        )
+    } else {
+        db.get_type_index().get_super_types(type_decl_id)
     }
 }
 
@@ -218,9 +237,12 @@ fn find_custom_type_function_member(
         }
     }
 
-    if type_decl.is_class()
-        && let Some(super_types) = type_index.get_super_types(&prefix_type_id)
-    {
+    let super_types = if type_decl.is_class() {
+        visible_super_types_for_index(db, cache, &prefix_type_id, &index_expr)
+    } else {
+        None
+    };
+    if let Some(super_types) = super_types {
         deep_guard.next();
         for super_type in super_types {
             let result = find_function_type_by_member_key(
@@ -367,7 +389,8 @@ fn index_generic_members_from_super_generics(
     };
 
     let type_decl_id = type_decl.get_id();
-    if let Some(super_types) = type_index.get_super_types(&type_decl_id) {
+    if let Some(super_types) = visible_super_types_for_index(db, cache, &type_decl_id, &index_expr)
+    {
         super_types.iter().find_map(|super_type| {
             let super_type = instantiate_type_generic(db, super_type, substitutor);
             find_function_type_by_member_key(
@@ -624,7 +647,8 @@ fn find_member_by_index_custom_type(
 
     // find member by key in super
     if type_decl.is_class()
-        && let Some(super_types) = type_index.get_super_types(prefix_type_id)
+        && let Some(super_types) =
+            visible_super_types_for_index(db, cache, prefix_type_id, &index_expr)
     {
         deep_guard.next();
         for super_type in super_types {
@@ -818,7 +842,7 @@ fn find_member_by_index_generic(
     }
 
     // for supers
-    if let Some(supers) = type_index.get_super_types(&type_decl_id) {
+    if let Some(supers) = visible_super_types_for_index(db, cache, &type_decl_id, &index_expr) {
         for super_type in supers {
             let result = find_function_type_by_operator(
                 db,

--- a/crates/glua_code_analysis/src/compilation/analyzer/unresolve/mod.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/unresolve/mod.rs
@@ -248,18 +248,12 @@ fn materialize_pending_str_tpl_type_decls(db: &mut DbIndex, infer_manager: &mut 
             );
         }
 
-        let has_super = db
-            .get_type_index()
-            .get_super_types_iter(&pending.type_decl_id)
-            .map(|mut supers| supers.any(|existing_super| existing_super == &pending.super_type))
-            .unwrap_or(false);
-        if !has_super {
-            db.get_type_index_mut().add_super_type(
-                pending.type_decl_id.clone(),
-                pending.file_id,
-                pending.super_type,
-            );
-        }
+        db.get_type_index_mut().add_super_type_if_missing(
+            pending.type_decl_id.clone(),
+            pending.file_id,
+            pending.source_range,
+            pending.super_type,
+        );
     }
 }
 

--- a/crates/glua_code_analysis/src/compilation/analyzer/unresolve/resolve.rs
+++ b/crates/glua_code_analysis/src/compilation/analyzer/unresolve/resolve.rs
@@ -1979,15 +1979,12 @@ fn materialize_str_tpl_class_from_call(
     }
 
     let super_type = LuaType::Ref(constraint);
-    let has_super = db
-        .get_type_index()
-        .get_super_types_iter(&class_decl_id)
-        .map(|mut supers| supers.any(|existing_super| existing_super == &super_type))
-        .unwrap_or(false);
-    if !has_super {
-        db.get_type_index_mut()
-            .add_super_type(class_decl_id, file_id, super_type);
-    }
+    db.get_type_index_mut().add_super_type_if_missing(
+        class_decl_id,
+        file_id,
+        arg_expr.get_range(),
+        super_type,
+    );
 
     Ok(())
 }
@@ -2067,15 +2064,12 @@ fn try_resolve_constructor_param(
             && type_decl.is_class()
         {
             let root_type = LuaType::Ref(root_type_id.clone());
-            let has_super = db
-                .get_type_index()
-                .get_super_types_iter(&target_id)
-                .map(|mut supers| supers.any(|existing_super| existing_super == &root_type))
-                .unwrap_or(false);
-            if !has_super {
-                db.get_type_index_mut()
-                    .add_super_type(target_id.clone(), file_id, root_type);
-            }
+            db.get_type_index_mut().add_super_type_if_missing(
+                target_id.clone(),
+                file_id,
+                call_expr.get_range(),
+                root_type,
+            );
         }
     }
 

--- a/crates/glua_code_analysis/src/compilation/test/closure_param_infer_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/closure_param_infer_test.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod test {
     use crate::{
-        Emmyrc, GmodHookKind, LuaMemberKey, LuaType, LuaTypeDeclId, VirtualWorkspace,
+        Emmyrc, GmodHookKind, GmodRealm, LuaMemberKey, LuaType, LuaTypeDeclId, VirtualWorkspace,
         semantic::find_members_with_key_in_workspace_for_file,
     };
     use glua_parser::{LuaAstNode, LuaExpr, LuaIndexExpr, LuaNameExpr};
@@ -999,13 +999,15 @@ mod test {
     }
 
     fn infer_scripted_class_param_from_workspace_super_edge(
-        enable_isolation: bool,
+        enable_isolation: Option<bool>,
         current_super: Option<(&str, &str)>,
     ) -> LuaType {
         let mut ws = VirtualWorkspace::new();
         let mut emmyrc = ws.get_emmyrc();
         emmyrc.gmod.enabled = true;
-        emmyrc.workspace.enable_isolation = enable_isolation;
+        if let Some(enable_isolation) = enable_isolation {
+            emmyrc.workspace.enable_isolation = enable_isolation;
+        }
         ws.update_emmyrc(emmyrc);
 
         let other_workspace = ws
@@ -1023,8 +1025,6 @@ mod test {
             &other_uri,
             Some(
                 r#"
-                ---@class WrongBase
-                ---@field BuildCPanel fun(panel: string)
                 ---@class TOOL.context_test : WrongBase
                 TOOL = {}
                 "#
@@ -1033,10 +1033,16 @@ mod test {
         );
 
         let (base_contract, class_contract) = current_super.map_or_else(
-            || (String::new(), "---@class TOOL.context_test".to_string()),
+            || (
+                "---@class WrongBase\n---@field CustomRun fun(value: string)\nlocal WrongBase = {}"
+                    .to_string(),
+                "---@class TOOL.context_test".to_string(),
+            ),
             |(base, param_type)| {
                 (
-                    format!("---@class {base}\n---@field BuildCPanel fun(panel: {param_type})"),
+                    format!(
+                        "---@class WrongBase\n---@field CustomRun fun(value: string)\nlocal WrongBase = {{}}\n---@class {base}\n---@field CustomRun fun(value: {param_type})\nlocal {base} = {{}}"
+                    ),
                     format!("---@class TOOL.context_test : {base}"),
                 )
             },
@@ -1049,8 +1055,8 @@ mod test {
                 {class_contract}
                 TOOL = {{}}
 
-                function TOOL.BuildCPanel(panel)
-                    inherited_workspace_param = panel
+                function TOOL.CustomRun(value)
+                    inherited_workspace_param = value
                 end
                 "#
             ),
@@ -1062,8 +1068,16 @@ mod test {
     #[test]
     fn inherited_scripted_class_param_ignores_other_main_workspace_edges_with_isolation() {
         assert_eq!(
+            infer_scripted_class_param_from_workspace_super_edge(Some(true), None),
+            LuaType::Unknown
+        );
+    }
+
+    #[test]
+    fn inherited_scripted_class_param_uses_current_edge_with_isolation() {
+        assert_eq!(
             infer_scripted_class_param_from_workspace_super_edge(
-                true,
+                Some(true),
                 Some(("RightBase", "number")),
             ),
             LuaType::Number
@@ -1074,7 +1088,7 @@ mod test {
     fn inherited_scripted_class_param_prefers_current_workspace_edge_without_isolation() {
         assert_eq!(
             infer_scripted_class_param_from_workspace_super_edge(
-                false,
+                Some(false),
                 Some(("RightBase", "number")),
             ),
             LuaType::Number
@@ -1082,50 +1096,255 @@ mod test {
     }
 
     #[test]
-    fn inherited_scripted_class_param_keeps_other_main_workspace_edges_without_isolation() {
+    fn inherited_scripted_class_param_keeps_other_main_workspace_edges_by_default() {
         assert_eq!(
-            infer_scripted_class_param_from_workspace_super_edge(false, None),
+            infer_scripted_class_param_from_workspace_super_edge(None, None),
             LuaType::String
         );
     }
 
     #[test]
-    fn inherited_member_contract_rejects_realm_incompatible_super_edges() {
+    fn inherited_member_contract_rejects_branch_realm_edges_at_every_hop() {
         let mut ws = VirtualWorkspace::new();
         let mut emmyrc = ws.get_emmyrc();
         emmyrc.gmod.enabled = true;
         ws.update_emmyrc(emmyrc);
-        ws.def_file(
-            "cl_contract.lua",
-            r#"
+        let edge_source = |realm| {
+            format!(
+                r#"
             ---@class WrongBase
             ---@field Run fun(value: string)
-            ---@class RealmChild : WrongBase
-            local RealmChild = {}
-            "#,
-        );
+
+            if {realm} then
+                ---@class RealmMid : WrongBase
+                local RealmMid = {{}}
+            end
+            "#
+            )
+        };
+        let edge_uri = ws.virtual_url_generator.new_uri("sh_contract.lua");
+        ws.analysis
+            .update_file_by_uri(&edge_uri, Some(edge_source("CLIENT")))
+            .expect("client edge file");
         ws.def_file(
-            "sv_contract.lua",
+            "sh_override.lua",
             r#"
             ---@class RightBase
             ---@field Run fun(value: number)
-            ---@class RealmChild : RightBase
-            local RealmChild = {}
-            "#,
-        );
-        ws.def_file(
-            "sv_override.lua",
-            r#"
-            ---@class RealmChild
+
+            ---@class RealmMid : RightBase
+            local RealmMid = {}
+
+            ---@class RealmChild : RealmMid
             local RealmChild = {}
 
-            function RealmChild.Run(value)
-                realm_edge_param = value
+            if SERVER then
+                function RealmChild.Run(value)
+                    realm_edge_param = value
+                end
             end
             "#,
         );
 
         assert_eq!(ws.expr_ty("realm_edge_param"), LuaType::Number);
+    }
+
+    #[test]
+    fn registered_entity_contract_uses_base_source_realm() {
+        let mut ws = VirtualWorkspace::new();
+        let mut emmyrc = ws.get_emmyrc();
+        emmyrc.gmod.enabled = true;
+        ws.update_emmyrc(emmyrc);
+        ws.def_gmod_call_arg_builtins();
+        let registration_file_id = ws.def_file(
+            "lua/sh_registration.lua",
+            r#"
+            ---@class WrongEntityBase
+            ---@field Run fun(value: string)
+            local WrongEntityBase = {}
+
+            if CLIENT then
+                DEFINE_BASECLASS("WrongEntityBase")
+            end
+
+            local ENT = {}
+            scripted_ents.Register(ENT, "RealmRegisteredEntity")
+            "#,
+        );
+        ws.def_file(
+            "lua/sv_override.lua",
+            r#"
+            ---@class RightEntityBase
+            ---@field Run fun(value: number)
+            local RightEntityBase = {}
+
+            ---@class RealmRegisteredEntity : RightEntityBase
+            local RealmRegisteredEntity = {}
+
+            function RealmRegisteredEntity.Run(value)
+                registered_entity_realm_param = value
+            end
+            "#,
+        );
+
+        let db = ws.get_db_mut();
+        let wrong_base = LuaType::Ref(LuaTypeDeclId::global("WrongEntityBase"));
+        let wrong_edge = db
+            .get_type_index()
+            .get_super_type_entries(&LuaTypeDeclId::global("RealmRegisteredEntity"))
+            .and_then(|entries| entries.iter().find(|entry| entry.value.typ == wrong_base))
+            .expect("registered entity base edge");
+        assert_eq!(wrong_edge.file_id, registration_file_id);
+        assert_eq!(
+            db.get_gmod_infer_index()
+                .get_realm_at_offset(&registration_file_id, wrong_edge.value.source_range.start()),
+            GmodRealm::Client
+        );
+
+        assert_eq!(ws.expr_ty("registered_entity_realm_param"), LuaType::Number);
+    }
+
+    #[test]
+    fn inherited_member_contract_rejects_isolated_intermediate_edge() {
+        let mut ws = VirtualWorkspace::new();
+        let mut emmyrc = ws.get_emmyrc();
+        emmyrc.gmod.enabled = true;
+        emmyrc.workspace.enable_isolation = true;
+        ws.update_emmyrc(emmyrc);
+
+        let other_workspace = ws
+            .virtual_url_generator
+            .base
+            .parent()
+            .expect("virtual workspace parent")
+            .join("other_workspace");
+        ws.analysis.add_main_workspace(other_workspace.clone());
+        let other_uri =
+            lsp_types::Uri::parse_from_file_path(&other_workspace.join("lua/foreign_contract.lua"))
+                .expect("other workspace uri");
+        ws.analysis.update_file_by_uri(
+            &other_uri,
+            Some(
+                r#"
+                ---@class WorkspaceMid : WorkspaceContract
+                local WorkspaceMid = {}
+                "#
+                .to_string(),
+            ),
+        );
+        ws.def_file(
+            "lua/current_override.lua",
+            r#"
+            ---@class WorkspaceContract
+            ---@field Run fun(value: string)
+            local WorkspaceContract = {}
+
+            ---@class WorkspaceMid
+            local WorkspaceMid = {}
+
+            ---@class WorkspaceChild : WorkspaceMid
+            local WorkspaceChild = {}
+
+            function WorkspaceChild.Run(value)
+                isolated_intermediate_param = value
+            end
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("isolated_intermediate_param"), LuaType::Unknown);
+    }
+
+    fn infer_cross_workspace_inherited_callback_call_params(
+        enable_isolation: bool,
+    ) -> [LuaType; 3] {
+        let mut ws = VirtualWorkspace::new();
+        let mut emmyrc = ws.get_emmyrc();
+        emmyrc.gmod.enabled = true;
+        emmyrc.workspace.enable_isolation = enable_isolation;
+        ws.update_emmyrc(emmyrc);
+
+        let other_workspace = ws
+            .virtual_url_generator
+            .base
+            .parent()
+            .expect("virtual workspace parent")
+            .join("other_workspace");
+        ws.analysis.add_main_workspace(other_workspace.clone());
+        let other_uri = lsp_types::Uri::parse_from_file_path(
+            &other_workspace.join("lua/foreign_callback_edges.lua"),
+        )
+        .expect("other workspace uri");
+        ws.analysis.update_file_by_uri(
+            &other_uri,
+            Some(
+                r#"
+                ---@class CallbackChild : CallbackBase
+                local CallbackChild = {}
+
+                ---@class GenericCallbackChild<T> : T
+                local GenericCallbackChild = {}
+
+                ---@class IndexCallbackChild : IndexCallbackBase
+                local IndexCallbackChild = {}
+                "#
+                .to_string(),
+            ),
+        );
+        ws.def_file(
+            "lua/current_callback_calls.lua",
+            r#"
+            ---@class CallbackBase
+            ---@field Run fun(callback: fun(value: string))
+            local CallbackBase = {}
+            ---@class CallbackChild
+            local CallbackChild = {}
+
+            ---@class GenericCallbackChild<T>
+            local GenericCallbackChild = {}
+
+            ---@class IndexCallbackBase
+            ---@field [string] fun(callback: fun(value: string))
+            local IndexCallbackBase = {}
+            ---@class IndexCallbackChild
+            local IndexCallbackChild = {}
+
+            ---@type CallbackChild
+            local direct
+            direct.Run(function(value)
+                direct_inherited_callback_param = value
+            end)
+
+            ---@type GenericCallbackChild<{ Run: fun(callback: fun(value: string)) }>
+            local generic
+            generic.Run(function(value)
+                generic_inherited_callback_param = value
+            end)
+
+            ---@type IndexCallbackChild
+            local indexed
+            indexed.Run(function(value)
+                index_inherited_callback_param = value
+            end)
+            "#,
+        );
+
+        [
+            ws.expr_ty("direct_inherited_callback_param"),
+            ws.expr_ty("generic_inherited_callback_param"),
+            ws.expr_ty("index_inherited_callback_param"),
+        ]
+    }
+
+    #[test]
+    fn inherited_callback_calls_filter_every_isolated_super_path() {
+        assert_eq!(
+            infer_cross_workspace_inherited_callback_call_params(false),
+            [LuaType::String, LuaType::String, LuaType::String]
+        );
+        assert_eq!(
+            infer_cross_workspace_inherited_callback_call_params(true),
+            [LuaType::Unknown, LuaType::Unknown, LuaType::Unknown]
+        );
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/compilation/test/closure_param_infer_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/closure_param_infer_test.rs
@@ -861,6 +861,38 @@ mod test {
     }
 
     #[test]
+    fn test_stool_buildcpanel_param_inherits_global_tool_contract() {
+        let mut ws = VirtualWorkspace::new();
+        let mut emmyrc = ws.get_emmyrc();
+        emmyrc.gmod.enabled = true;
+        ws.update_emmyrc(emmyrc);
+
+        let library_root = ws.virtual_url_generator.base.join("library");
+        ws.analysis.add_library_workspace(library_root);
+        ws.def_file(
+            "library/tool.lua",
+            r#"
+            ---@meta
+            ---@class ControlPanel
+            ---@type fun(panel: ControlPanel, ...any)
+            TOOL.BuildCPanel = nil
+            "#,
+        );
+        ws.def_file(
+            "lua/weapons/gmod_tool/stools/context_test.lua",
+            r#"
+            function TOOL.BuildCPanel(panel)
+                inferred_panel = panel
+            end
+            "#,
+        );
+
+        let ty = ws.expr_ty("inferred_panel");
+        let expected = ws.ty("ControlPanel");
+        assert_eq!(ws.humanize_type(ty), ws.humanize_type(expected));
+    }
+
+    #[test]
     fn test_gmod_hook_add_callback_params_infer_from_hook_name() {
         let mut ws = VirtualWorkspace::new();
         let mut emmyrc = ws.get_emmyrc();

--- a/crates/glua_code_analysis/src/compilation/test/closure_param_infer_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/closure_param_infer_test.rs
@@ -864,6 +864,32 @@ mod test {
     }
 
     #[test]
+    fn inherited_param_uses_later_superclass_with_usable_contract() {
+        let mut ws = VirtualWorkspace::new();
+
+        ws.def(
+            r#"
+            ---@class UntypedBase
+            ---@field Run function
+            local UntypedBase = {}
+
+            ---@class TypedBase
+            ---@field Run fun(value: string)
+            local TypedBase = {}
+
+            ---@class MultiBaseChild : UntypedBase, TypedBase
+            local MultiBaseChild = {}
+
+            function MultiBaseChild.Run(value)
+                later_super_param = value
+            end
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("later_super_param"), LuaType::String);
+    }
+
+    #[test]
     fn test_stool_buildcpanel_param_inherits_global_tool_contract() {
         let mut ws = VirtualWorkspace::new();
         let mut emmyrc = ws.get_emmyrc();

--- a/crates/glua_code_analysis/src/compilation/test/closure_param_infer_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/closure_param_infer_test.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod test {
-    use crate::{Emmyrc, GmodHookKind, LuaType, VirtualWorkspace};
+    use crate::{
+        Emmyrc, GmodHookKind, LuaMemberKey, LuaType, LuaTypeDeclId, VirtualWorkspace,
+        semantic::find_members_with_key_in_workspace_for_file,
+    };
     use glua_parser::{LuaAstNode, LuaExpr, LuaIndexExpr, LuaNameExpr};
 
     fn index_expr_type(ws: &VirtualWorkspace, file_id: crate::FileId, text: &str) -> LuaType {
@@ -889,6 +892,146 @@ mod test {
 
         let ty = ws.expr_ty("inferred_panel");
         let expected = ws.ty("ControlPanel");
+        assert_eq!(ws.humanize_type(ty), ws.humanize_type(expected));
+    }
+
+    #[test]
+    fn test_explicit_member_function_type_overrides_inherited_contract() {
+        let mut ws = VirtualWorkspace::new();
+        ws.def(
+            r#"
+            ---@class ExplicitParent
+            ---@field Run fun(value: string)
+            local ExplicitParent = {}
+
+            ---@class ExplicitChild : ExplicitParent
+            local ExplicitChild = {}
+
+            ---@type fun(value: number)
+            ExplicitChild.Run = function(value)
+                explicit_member_value = value
+            end
+            "#,
+        );
+
+        let ty = ws.expr_ty("explicit_member_value");
+        let expected = ws.ty("number");
+        assert_eq!(ws.humanize_type(ty), ws.humanize_type(expected));
+    }
+
+    #[test]
+    fn test_inherited_member_contract_respects_main_workspace_visibility() {
+        let mut ws = VirtualWorkspace::new();
+        let mut emmyrc = ws.get_emmyrc();
+        emmyrc.workspace.enable_isolation = true;
+        ws.update_emmyrc(emmyrc);
+        let other_workspace = ws
+            .virtual_url_generator
+            .base
+            .parent()
+            .expect("virtual workspace parent")
+            .join("other_workspace");
+        ws.analysis.add_main_workspace(other_workspace.clone());
+        let other_uri =
+            lsp_types::Uri::parse_from_file_path(&other_workspace.join("base.lua")).unwrap();
+        let other_file_id = ws
+            .analysis
+            .update_file_by_uri(
+                &other_uri,
+                Some(
+                    r#"
+            ---@class WorkspaceBase
+            ---@field Run fun(value: number)
+            "#
+                    .to_string(),
+                ),
+            )
+            .expect("other workspace file");
+        let main_file_id = ws.def_file(
+            "base.lua",
+            r#"
+            ---@class WorkspaceBase
+            ---@field Run fun(value: string)
+            "#,
+        );
+        let caller_file_id = ws.def_file(
+            "override.lua",
+            r#"
+            ---@class WorkspaceChild : WorkspaceBase
+            local WorkspaceChild = {}
+
+            function WorkspaceChild.Run(value)
+                workspace_member_value = value
+            end
+            "#,
+        );
+
+        let expected_contract = ws.ty("fun(value: string)");
+        let module_index = ws.analysis.compilation.get_db().get_module_index();
+        assert_ne!(
+            module_index.get_workspace_id(other_file_id),
+            module_index.get_workspace_id(main_file_id)
+        );
+        assert_eq!(
+            module_index.get_workspace_id(main_file_id),
+            module_index.get_workspace_id(caller_file_id)
+        );
+        let caller_workspace_id = module_index
+            .get_workspace_id(caller_file_id)
+            .expect("caller workspace");
+        let inherited_members = find_members_with_key_in_workspace_for_file(
+            ws.analysis.compilation.get_db(),
+            &LuaType::Ref(LuaTypeDeclId::global("WorkspaceBase")),
+            LuaMemberKey::Name("Run".into()),
+            false,
+            caller_workspace_id,
+            caller_file_id,
+        )
+        .expect("visible inherited member");
+        assert_eq!(
+            ws.humanize_type(inherited_members[0].typ.clone()),
+            ws.humanize_type(expected_contract)
+        );
+
+        let ty = ws.expr_ty("workspace_member_value");
+        let expected = ws.ty("string");
+        assert_eq!(ws.humanize_type(ty), ws.humanize_type(expected));
+    }
+
+    #[test]
+    fn test_inherited_member_contract_respects_realm_visibility() {
+        let mut ws = VirtualWorkspace::new();
+        let mut emmyrc = ws.get_emmyrc();
+        emmyrc.gmod.enabled = true;
+        ws.update_emmyrc(emmyrc);
+        ws.def_file(
+            "sv_contract.lua",
+            r#"
+            ---@class RealmBase
+            ---@field Run fun(value: number)
+            "#,
+        );
+        ws.def_file(
+            "cl_contract.lua",
+            r#"
+            ---@class RealmBase
+            ---@field Run fun(value: string)
+            "#,
+        );
+        ws.def_file(
+            "cl_override.lua",
+            r#"
+            ---@class RealmChild : RealmBase
+            local RealmChild = {}
+
+            function RealmChild.Run(value)
+                realm_member_value = value
+            end
+            "#,
+        );
+
+        let ty = ws.expr_ty("realm_member_value");
+        let expected = ws.ty("string");
         assert_eq!(ws.humanize_type(ty), ws.humanize_type(expected));
     }
 

--- a/crates/glua_code_analysis/src/compilation/test/closure_param_infer_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/closure_param_infer_test.rs
@@ -998,6 +998,136 @@ mod test {
         assert_eq!(ws.humanize_type(ty), ws.humanize_type(expected));
     }
 
+    fn infer_scripted_class_param_from_workspace_super_edge(
+        enable_isolation: bool,
+        current_super: Option<(&str, &str)>,
+    ) -> LuaType {
+        let mut ws = VirtualWorkspace::new();
+        let mut emmyrc = ws.get_emmyrc();
+        emmyrc.gmod.enabled = true;
+        emmyrc.workspace.enable_isolation = enable_isolation;
+        ws.update_emmyrc(emmyrc);
+
+        let other_workspace = ws
+            .virtual_url_generator
+            .base
+            .parent()
+            .expect("virtual workspace parent")
+            .join("other_workspace");
+        ws.analysis.add_main_workspace(other_workspace.clone());
+        let other_uri = lsp_types::Uri::parse_from_file_path(
+            &other_workspace.join("lua/weapons/gmod_tool/stools/context_test.lua"),
+        )
+        .expect("other workspace uri");
+        ws.analysis.update_file_by_uri(
+            &other_uri,
+            Some(
+                r#"
+                ---@class WrongBase
+                ---@field BuildCPanel fun(panel: string)
+                ---@class TOOL.context_test : WrongBase
+                TOOL = {}
+                "#
+                .to_string(),
+            ),
+        );
+
+        let (base_contract, class_contract) = current_super.map_or_else(
+            || (String::new(), "---@class TOOL.context_test".to_string()),
+            |(base, param_type)| {
+                (
+                    format!("---@class {base}\n---@field BuildCPanel fun(panel: {param_type})"),
+                    format!("---@class TOOL.context_test : {base}"),
+                )
+            },
+        );
+        ws.def_file(
+            "lua/weapons/gmod_tool/stools/context_test.lua",
+            &format!(
+                r#"
+                {base_contract}
+                {class_contract}
+                TOOL = {{}}
+
+                function TOOL.BuildCPanel(panel)
+                    inherited_workspace_param = panel
+                end
+                "#
+            ),
+        );
+
+        ws.expr_ty("inherited_workspace_param")
+    }
+
+    #[test]
+    fn inherited_scripted_class_param_ignores_other_main_workspace_edges_with_isolation() {
+        assert_eq!(
+            infer_scripted_class_param_from_workspace_super_edge(
+                true,
+                Some(("RightBase", "number")),
+            ),
+            LuaType::Number
+        );
+    }
+
+    #[test]
+    fn inherited_scripted_class_param_prefers_current_workspace_edge_without_isolation() {
+        assert_eq!(
+            infer_scripted_class_param_from_workspace_super_edge(
+                false,
+                Some(("RightBase", "number")),
+            ),
+            LuaType::Number
+        );
+    }
+
+    #[test]
+    fn inherited_scripted_class_param_keeps_other_main_workspace_edges_without_isolation() {
+        assert_eq!(
+            infer_scripted_class_param_from_workspace_super_edge(false, None),
+            LuaType::String
+        );
+    }
+
+    #[test]
+    fn inherited_member_contract_rejects_realm_incompatible_super_edges() {
+        let mut ws = VirtualWorkspace::new();
+        let mut emmyrc = ws.get_emmyrc();
+        emmyrc.gmod.enabled = true;
+        ws.update_emmyrc(emmyrc);
+        ws.def_file(
+            "cl_contract.lua",
+            r#"
+            ---@class WrongBase
+            ---@field Run fun(value: string)
+            ---@class RealmChild : WrongBase
+            local RealmChild = {}
+            "#,
+        );
+        ws.def_file(
+            "sv_contract.lua",
+            r#"
+            ---@class RightBase
+            ---@field Run fun(value: number)
+            ---@class RealmChild : RightBase
+            local RealmChild = {}
+            "#,
+        );
+        ws.def_file(
+            "sv_override.lua",
+            r#"
+            ---@class RealmChild
+            local RealmChild = {}
+
+            function RealmChild.Run(value)
+                realm_edge_param = value
+            end
+            "#,
+        );
+
+        assert_eq!(ws.expr_ty("realm_edge_param"), LuaType::Number);
+    }
+
     #[test]
     fn test_inherited_member_contract_respects_realm_visibility() {
         let mut ws = VirtualWorkspace::new();

--- a/crates/glua_code_analysis/src/compilation/test/infer_str_tpl_test.rs
+++ b/crates/glua_code_analysis/src/compilation/test/infer_str_tpl_test.rs
@@ -8,7 +8,7 @@ mod test {
     use tokio_util::sync::CancellationToken;
 
     use crate::{
-        DiagnosticCode, Emmyrc, LuaSignatureId, LuaType, LuaTypeDeclId, LuaUnionType,
+        DiagnosticCode, Emmyrc, GmodRealm, LuaSignatureId, LuaType, LuaTypeDeclId, LuaUnionType,
         VirtualWorkspace,
     };
     use smol_str::SmolStr;
@@ -960,6 +960,65 @@ mod test {
         assert!(
             super_types.contains(&LuaType::Ref(LuaTypeDeclId::global("Entity"))),
             "expected `sent_custom` to inherit `Entity`, got {super_types:?}"
+        );
+    }
+
+    #[gtest]
+    fn str_tpl_generated_super_type_keeps_call_source_realm() {
+        let mut ws = VirtualWorkspace::new();
+        let mut emmyrc = ws.get_emmyrc();
+        emmyrc.gmod.enabled = true;
+        ws.update_emmyrc(emmyrc);
+
+        let file_id = ws.def(
+            r#"
+                ---@class Entity
+                ---@field Run fun(value: string)
+
+                ents = {}
+
+                ---@generic T: Entity
+                ---@param class `T`
+                ---@return T
+                function ents.Create(class) end
+
+                if CLIENT then
+                    generated_entity = ents.Create("sent_realm_generated")
+                end
+            "#,
+        );
+        assert_eq!(
+            ws.expr_ty("generated_entity"),
+            ws.ty("sent_realm_generated")
+        );
+        ws.def_file(
+            "sv_generated_contract.lua",
+            r#"
+                ---@class GeneratedRightBase
+                ---@field Run fun(value: number)
+                local GeneratedRightBase = {}
+
+                ---@class sent_realm_generated : GeneratedRightBase
+                local GeneratedEntity = {}
+
+                function GeneratedEntity.Run(value)
+                    generated_realm_param = value
+                end
+            "#,
+        );
+        assert_eq!(ws.expr_ty("generated_realm_param"), LuaType::Number);
+
+        let db = ws.get_db_mut();
+        let edge = db
+            .get_type_index()
+            .get_super_type_entries(&LuaTypeDeclId::global("sent_realm_generated"))
+            .and_then(|entries| entries.first())
+            .expect("generated superclass edge");
+        assert_eq!(edge.file_id, file_id);
+        assert_eq!(
+            db.get_gmod_infer_index()
+                .get_realm_at_offset(&file_id, edge.value.source_range.start()),
+            GmodRealm::Client
         );
     }
 

--- a/crates/glua_code_analysis/src/db_index/type/mod.rs
+++ b/crates/glua_code_analysis/src/db_index/type/mod.rs
@@ -706,6 +706,13 @@ impl LuaTypeIndex {
             .map(|supers| supers.iter().map(|s| &s.value))
     }
 
+    pub(crate) fn get_super_types_with_file_iter(
+        &self,
+        decl_id: &LuaTypeDeclId,
+    ) -> Option<impl Iterator<Item = &InFiled<LuaType>> + '_> {
+        self.supers.get(decl_id).map(|supers| supers.iter())
+    }
+
     /// Get all direct subclasses of a given type
     /// Returns a vector of type declarations that directly inherit from the given type
     pub fn get_sub_types(&self, decl_id: &LuaTypeDeclId) -> Vec<&LuaTypeDecl> {

--- a/crates/glua_code_analysis/src/db_index/type/mod.rs
+++ b/crates/glua_code_analysis/src/db_index/type/mod.rs
@@ -35,6 +35,12 @@ pub struct LuaResolvedAliasType {
     pub typ: LuaType,
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub(crate) struct LuaSuperType {
+    pub(crate) source_range: TextRange,
+    pub(crate) typ: LuaType,
+}
+
 pub fn resolve_alias_type(db: &DbIndex, typ: &LuaType) -> LuaResolvedAliasType {
     let mut visited_aliases = HashSet::new();
     resolve_alias_type_inner(db, typ, None, &mut visited_aliases)
@@ -478,7 +484,7 @@ pub struct LuaTypeIndex {
     file_types: HashMap<FileId, Vec<LuaTypeDeclId>>,
     full_name_type_map: HashMap<LuaTypeDeclId, LuaTypeDecl>,
     generic_params: HashMap<LuaTypeDeclId, Vec<GenericParam>>,
-    supers: HashMap<LuaTypeDeclId, Vec<InFiled<LuaType>>>,
+    supers: HashMap<LuaTypeDeclId, Vec<InFiled<LuaSuperType>>>,
     types: HashMap<LuaTypeOwner, LuaTypeCache>,
     in_filed_type_owner: HashMap<FileId, HashSet<LuaTypeOwner>>,
     fact_metadata: HashMap<LuaTypeOwner, LuaTypeFactMetadata>,
@@ -658,23 +664,35 @@ impl LuaTypeIndex {
         self.generic_params.get(decl_id)
     }
 
-    pub fn add_super_type(&mut self, decl_id: LuaTypeDeclId, file_id: FileId, super_type: LuaType) {
-        self.supers
-            .entry(decl_id)
-            .or_default()
-            .push(InFiled::new(file_id, super_type));
+    pub fn add_super_type(
+        &mut self,
+        decl_id: LuaTypeDeclId,
+        file_id: FileId,
+        source_range: TextRange,
+        super_type: LuaType,
+    ) {
+        self.supers.entry(decl_id).or_default().push(InFiled::new(
+            file_id,
+            LuaSuperType {
+                source_range,
+                typ: super_type,
+            },
+        ));
     }
 
-    pub fn has_super_type_in_file(
+    fn has_super_type_at_source(
         &self,
         decl_id: &LuaTypeDeclId,
         file_id: FileId,
+        source_range: TextRange,
         super_type: &LuaType,
     ) -> bool {
         self.supers.get(decl_id).is_some_and(|supers| {
-            supers
-                .iter()
-                .any(|entry| entry.file_id == file_id && &entry.value == super_type)
+            supers.iter().any(|entry| {
+                entry.file_id == file_id
+                    && entry.value.source_range == source_range
+                    && &entry.value.typ == super_type
+            })
         })
     }
 
@@ -682,19 +700,20 @@ impl LuaTypeIndex {
         &mut self,
         decl_id: LuaTypeDeclId,
         file_id: FileId,
+        source_range: TextRange,
         super_type: LuaType,
     ) {
-        if self.has_super_type_in_file(&decl_id, file_id, &super_type) {
+        if self.has_super_type_at_source(&decl_id, file_id, source_range, &super_type) {
             return;
         }
 
-        self.add_super_type(decl_id, file_id, super_type);
+        self.add_super_type(decl_id, file_id, source_range, super_type);
     }
 
     pub fn get_super_types(&self, decl_id: &LuaTypeDeclId) -> Option<Vec<LuaType>> {
         self.supers
             .get(decl_id)
-            .map(|supers| supers.iter().map(|s| s.value.clone()).collect())
+            .map(|supers| supers.iter().map(|s| s.value.typ.clone()).collect())
     }
 
     pub fn get_super_types_iter(
@@ -703,14 +722,14 @@ impl LuaTypeIndex {
     ) -> Option<impl Iterator<Item = &LuaType> + '_> {
         self.supers
             .get(decl_id)
-            .map(|supers| supers.iter().map(|s| &s.value))
+            .map(|supers| supers.iter().map(|s| &s.value.typ))
     }
 
-    pub(crate) fn get_super_types_with_file_iter(
+    pub(crate) fn get_super_type_entries(
         &self,
         decl_id: &LuaTypeDeclId,
-    ) -> Option<impl Iterator<Item = &InFiled<LuaType>> + '_> {
-        self.supers.get(decl_id).map(|supers| supers.iter())
+    ) -> Option<&[InFiled<LuaSuperType>]> {
+        self.supers.get(decl_id).map(Vec::as_slice)
     }
 
     /// Get all direct subclasses of a given type
@@ -722,7 +741,7 @@ impl LuaTypeIndex {
         for (type_id, supers) in &self.supers {
             for super_filed in supers {
                 // Check if this super type references our target type
-                if let LuaType::Ref(super_id) = &super_filed.value {
+                if let LuaType::Ref(super_id) = &super_filed.value.typ {
                     if super_id == decl_id {
                         // Found a subclass
                         if let Some(sub_decl) = self.full_name_type_map.get(type_id) {
@@ -1146,6 +1165,10 @@ impl LuaIndex for LuaTypeIndex {
                 self.remove_file_raw(file_id);
             }
         }
+        self.supers.retain(|_, supers| {
+            supers.retain(|super_type| !changed_files.contains(&super_type.file_id));
+            !supers.is_empty()
+        });
 
         self.definition_facts
             .retain(|definition, _| !changed_files.contains(&definition.file_id()));
@@ -1187,13 +1210,6 @@ impl LuaTypeIndex {
                             id.get_simple_name(),
                             file_id,
                         );
-                    }
-                }
-
-                if let Some(supers) = self.supers.get_mut(&id) {
-                    supers.retain(|s| s.file_id != file_id);
-                    if supers.is_empty() {
-                        self.supers.remove(&id);
                     }
                 }
 
@@ -1380,8 +1396,13 @@ mod batch_removal_tests {
         add_type(&mut index, survivor, "Survivor");
 
         let shared = LuaTypeDeclId::global("Shared");
-        index.add_super_type(shared.clone(), second, LuaType::String);
-        index.add_super_type(shared, survivor, LuaType::Number);
+        index.add_super_type(
+            shared.clone(),
+            second,
+            TextRange::default(),
+            LuaType::String,
+        );
+        index.add_super_type(shared, survivor, TextRange::default(), LuaType::Number);
 
         let first_owner = owner(first, 10);
         let second_owner = owner(second, 10);
@@ -1411,6 +1432,26 @@ mod batch_removal_tests {
             LuaTypeFact::certain(LuaType::Number),
         );
         index
+    }
+
+    #[test]
+    fn removing_edge_only_file_removes_its_super_types() {
+        let declaring_file = file_id(1);
+        let edge_file = file_id(2);
+        let type_id = LuaTypeDeclId::global("Shared");
+        let mut index = LuaTypeIndex::new();
+        add_type(&mut index, declaring_file, "Shared");
+        index.add_super_type(
+            type_id.clone(),
+            edge_file,
+            TextRange::new(10.into(), 20.into()),
+            LuaType::String,
+        );
+
+        index.remove_files(&[edge_file]);
+
+        assert!(index.get_super_type_entries(&type_id).is_none());
+        assert!(index.get_type_decl(&type_id).is_some());
     }
 
     fn type_cache_types(index: &LuaTypeIndex) -> HashMap<LuaTypeOwner, LuaType> {

--- a/crates/glua_code_analysis/src/db_index/type/mod.rs
+++ b/crates/glua_code_analysis/src/db_index/type/mod.rs
@@ -711,18 +711,25 @@ impl LuaTypeIndex {
     }
 
     pub fn get_super_types(&self, decl_id: &LuaTypeDeclId) -> Option<Vec<LuaType>> {
-        self.supers
-            .get(decl_id)
-            .map(|supers| supers.iter().map(|s| s.value.typ.clone()).collect())
+        self.get_super_types_iter(decl_id)
+            .map(|super_types| super_types.cloned().collect())
     }
 
     pub fn get_super_types_iter(
         &self,
         decl_id: &LuaTypeDeclId,
     ) -> Option<impl Iterator<Item = &LuaType> + '_> {
-        self.supers
-            .get(decl_id)
-            .map(|supers| supers.iter().map(|s| &s.value.typ))
+        self.supers.get(decl_id).map(|supers| {
+            supers
+                .iter()
+                .enumerate()
+                .filter_map(move |(index, super_type)| {
+                    supers[..index]
+                        .iter()
+                        .all(|previous| previous.value.typ != super_type.value.typ)
+                        .then_some(&super_type.value.typ)
+                })
+        })
     }
 
     pub(crate) fn get_super_type_entries(
@@ -1318,6 +1325,47 @@ pub fn first_param_may_not_self(typ: &LuaType) -> bool {
         return u.types().any(first_param_may_not_self);
     }
     false
+}
+
+#[cfg(test)]
+mod super_type_tests {
+    use rowan::TextRange;
+
+    use super::*;
+
+    #[test]
+    fn logical_super_type_accessors_deduplicate_source_edges() {
+        let mut index = LuaTypeIndex::new();
+        let child_id = LuaTypeDeclId::global("Child");
+        let parent_type = LuaType::Ref(LuaTypeDeclId::global("Parent"));
+        let edge_file = FileId::new(1);
+
+        index.add_super_type(
+            child_id.clone(),
+            edge_file,
+            TextRange::new(10.into(), 20.into()),
+            parent_type.clone(),
+        );
+        index.add_super_type(
+            child_id.clone(),
+            edge_file,
+            TextRange::new(30.into(), 40.into()),
+            parent_type.clone(),
+        );
+
+        let source_edge_count = index
+            .get_super_type_entries(&child_id)
+            .map_or(0, <[_]>::len);
+        let super_types = index.get_super_types(&child_id).unwrap_or_default();
+        let iter_super_types = index
+            .get_super_types_iter(&child_id)
+            .map(|types| types.cloned().collect::<Vec<_>>())
+            .unwrap_or_default();
+
+        assert_eq!(source_edge_count, 2);
+        assert_eq!(super_types, vec![parent_type.clone()]);
+        assert_eq!(iter_super_types, vec![parent_type]);
+    }
 }
 
 #[cfg(test)]

--- a/crates/glua_code_analysis/src/diagnostic/checker/check_param_count.rs
+++ b/crates/glua_code_analysis/src/diagnostic/checker/check_param_count.rs
@@ -535,12 +535,22 @@ fn inherited_type_callable_accepts_call_args(
         return false;
     }
 
-    let Some(super_types) = db.get_type_index().get_super_types_iter(type_id) else {
+    let super_types = match db.get_module_index().get_workspace_id(*file_id) {
+        Some(workspace_id) => crate::semantic::visible_super_types_in_workspace_for_file_at_offset(
+            db,
+            type_id,
+            workspace_id,
+            *file_id,
+            position,
+        ),
+        None => db.get_type_index().get_super_types(type_id),
+    };
+    let Some(super_types) = super_types else {
         return false;
     };
 
     for super_type in super_types {
-        let (LuaType::Def(super_id) | LuaType::Ref(super_id)) = super_type else {
+        let (LuaType::Def(super_id) | LuaType::Ref(super_id)) = &super_type else {
             continue;
         };
 

--- a/crates/glua_code_analysis/src/diagnostic/test/redundant_parameter_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/redundant_parameter_test.rs
@@ -1,5 +1,8 @@
 #[cfg(test)]
 mod test {
+    use lsp_types::NumberOrString;
+    use tokio_util::sync::CancellationToken;
+
     use crate::{DiagnosticCode, VirtualWorkspace};
 
     #[test]
@@ -47,6 +50,68 @@ mod test {
             }
         "#
         ));
+    }
+
+    fn inherited_callable_suppresses_redundant_parameter(enable_isolation: bool) -> bool {
+        let mut ws = VirtualWorkspace::new();
+        let mut emmyrc = ws.get_emmyrc();
+        emmyrc.gmod.enabled = true;
+        emmyrc.workspace.enable_isolation = enable_isolation;
+        ws.update_emmyrc(emmyrc);
+        ws.analysis
+            .diagnostic
+            .enable_only(DiagnosticCode::RedundantParameter);
+
+        let other_workspace = ws
+            .virtual_url_generator
+            .base
+            .parent()
+            .expect("virtual workspace parent")
+            .join("other_workspace");
+        ws.analysis.add_main_workspace(other_workspace.clone());
+        let other_uri = lsp_types::Uri::parse_from_file_path(
+            &other_workspace.join("lua/foreign_arity_edge.lua"),
+        )
+        .expect("other workspace uri");
+        ws.analysis.update_file_by_uri(
+            &other_uri,
+            Some(
+                r#"
+                ---@class ArityChild : ArityBase
+                local ArityChild = {}
+                "#
+                .to_string(),
+            ),
+        );
+        let file_id = ws.def_file(
+            "lua/current_arity.lua",
+            r#"
+            ---@class ArityBase
+            ---@field Run fun(first: string, second: string)
+            local ArityBase = {}
+
+            ---@class ArityChild
+            local ArityChild = {}
+
+            function ArityChild.Run(first) end
+            ArityChild.Run("first", "second")
+            "#,
+        );
+
+        let code = Some(NumberOrString::String(
+            DiagnosticCode::RedundantParameter.get_name().to_string(),
+        ));
+        ws.analysis
+            .diagnose_file(file_id, CancellationToken::new())
+            .unwrap_or_default()
+            .iter()
+            .all(|diagnostic| diagnostic.code != code)
+    }
+
+    #[test]
+    fn isolated_inherited_callable_does_not_suppress_redundant_parameter() {
+        assert!(inherited_callable_suppresses_redundant_parameter(false));
+        assert!(!inherited_callable_suppresses_redundant_parameter(true));
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/diagnostic/test/undefined_method_test.rs
+++ b/crates/glua_code_analysis/src/diagnostic/test/undefined_method_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::{DiagnosticCode, Emmyrc, VirtualWorkspace};
+    use crate::{DiagnosticCode, Emmyrc, LuaType, TypeVisitTrait, VirtualWorkspace};
     use glua_parser::{LuaAstNode, LuaAstToken};
     use lsp_types::{DiagnosticSeverity, NumberOrString};
     use tokio_util::sync::CancellationToken;
@@ -15,6 +15,18 @@ mod tests {
     fn has_code(diagnostics: &[lsp_types::Diagnostic], code: DiagnosticCode) -> bool {
         let code = Some(NumberOrString::String(code.get_name().to_string()));
         diagnostics.iter().any(|diagnostic| diagnostic.code == code)
+    }
+
+    fn contains_named_type(typ: &LuaType, name: &str) -> bool {
+        let mut found = false;
+        typ.visit_type(&mut |candidate| {
+            if let LuaType::Ref(id) | LuaType::Def(id) = candidate
+                && id.get_simple_name() == name
+            {
+                found = true;
+            }
+        });
+        found
     }
 
     fn gmod_diagnostics(source: &str) -> Vec<lsp_types::Diagnostic> {
@@ -519,6 +531,7 @@ mod tests {
             .get_semantic_model(file_id)
             .expect("semantic model");
 
+        let mut panel_local_types = Vec::new();
         let mut panel_locals = Vec::new();
         for local_name in semantic_model
             .get_root()
@@ -537,9 +550,10 @@ mod tests {
                             .clone()
                             .into(),
                     )
-                    .map(|info| ws.humanize_type(info.display_typ().clone()))
-                    .unwrap_or_else(|| "<no-info>".into());
-                panel_locals.push(ty);
+                    .map(|info| info.display_typ().clone())
+                    .unwrap_or(LuaType::Unknown);
+                panel_locals.push(ws.humanize_type(ty.clone()));
+                panel_local_types.push(ty);
             }
         }
 
@@ -554,7 +568,6 @@ mod tests {
                     .map(|ty| ws.humanize_type(ty))
             })
             .collect();
-
         let diagnostics = ws
             .analysis
             .diagnose_file(file_id, CancellationToken::new())
@@ -564,111 +577,16 @@ mod tests {
                 == Some(NumberOrString::String(
                     DiagnosticCode::UndefinedMethod.get_name().to_string(),
                 ))
-                && diagnostic.message.contains(
-                    "For more information on a specific command, type HELP command-name
-ASSOC          Displays or modifies file extension associations.
-ATTRIB         Displays or changes file attributes.
-BREAK          Sets or clears extended CTRL+C checking.
-BCDEDIT        Sets properties in boot database to control boot loading.
-CACLS          Displays or modifies access control lists (ACLs) of files.
-CALL           Calls one batch program from another.
-CD             Displays the name of or changes the current directory.
-CHCP           Displays or sets the active code page number.
-CHDIR          Displays the name of or changes the current directory.
-CHKDSK         Checks a disk and displays a status report.
-CHKNTFS        Displays or modifies the checking of disk at boot time.
-CLS            Clears the screen.
-CMD            Starts a new instance of the Windows command interpreter.
-COLOR          Sets the default console foreground and background colors.
-COMP           Compares the contents of two files or sets of files.
-COMPACT        Displays or alters the compression of files on NTFS partitions.
-CONVERT        Converts FAT volumes to NTFS.  You cannot convert the
-               current drive.
-COPY           Copies one or more files to another location.
-DATE           Displays or sets the date.
-DEL            Deletes one or more files.
-DIR            Displays a list of files and subdirectories in a directory.
-DISKPART       Displays or configures Disk Partition properties.
-DOSKEY         Edits command lines, recalls Windows commands, and 
-               creates macros.
-DRIVERQUERY    Displays current device driver status and properties.
-ECHO           Displays messages, or turns command echoing on or off.
-ENDLOCAL       Ends localization of environment changes in a batch file.
-ERASE          Deletes one or more files.
-EXIT           Quits the CMD.EXE program (command interpreter).
-FC             Compares two files or sets of files, and displays the 
-               differences between them.
-FIND           Searches for a text string in a file or files.
-FINDSTR        Searches for strings in files.
-FOR            Runs a specified command for each file in a set of files.
-FORMAT         Formats a disk for use with Windows.
-FSUTIL         Displays or configures the file system properties.
-FTYPE          Displays or modifies file types used in file extension 
-               associations.
-GOTO           Directs the Windows command interpreter to a labeled line in 
-               a batch program.
-GPRESULT       Displays Group Policy information for machine or user.
-HELP           Provides Help information for Windows commands.
-ICACLS         Display, modify, backup, or restore ACLs for files and 
-               directories.
-IF             Performs conditional processing in batch programs.
-LABEL          Creates, changes, or deletes the volume label of a disk.
-MD             Creates a directory.
-MKDIR          Creates a directory.
-MKLINK         Creates Symbolic Links and Hard Links
-MODE           Configures a system device.
-MORE           Displays output one screen at a time.
-MOVE           Moves one or more files from one directory to another 
-               directory.
-OPENFILES      Displays files opened by remote users for a file share.
-PATH           Displays or sets a search path for executable files.
-PAUSE          Suspends processing of a batch file and displays a message.
-POPD           Restores the previous value of the current directory saved by 
-               PUSHD.
-PRINT          Prints a text file.
-PROMPT         Changes the Windows command prompt.
-PUSHD          Saves the current directory then changes it.
-RD             Removes a directory.
-RECOVER        Recovers readable information from a bad or defective disk.
-REM            Records comments (remarks) in batch files or CONFIG.SYS.
-REN            Renames a file or files.
-RENAME         Renames a file or files.
-REPLACE        Replaces files.
-RMDIR          Removes a directory.
-ROBOCOPY       Advanced utility to copy files and directory trees
-SET            Displays, sets, or removes Windows environment variables.
-SETLOCAL       Begins localization of environment changes in a batch file.
-SC             Displays or configures services (background processes).
-SCHTASKS       Schedules commands and programs to run on a computer.
-SHIFT          Shifts the position of replaceable parameters in batch files.
-SHUTDOWN       Allows proper local or remote shutdown of machine.
-SORT           Sorts input.
-START          Starts a separate window to run a specified program or command.
-SUBST          Associates a path with a drive letter.
-SYSTEMINFO     Displays machine specific properties and configuration.
-TASKLIST       Displays all currently running tasks including services.
-TASKKILL       Kill or stop a running process or application.
-TIME           Displays or sets the system time.
-TITLE          Sets the window title for a CMD.EXE session.
-TREE           Graphically displays the directory structure of a drive or 
-               path.
-TYPE           Displays the contents of a text file.
-VER            Displays the Windows version.
-VERIFY         Tells Windows whether to verify that your files are written
-               correctly to a disk.
-VOL            Displays a disk volume label and serial number.
-XCOPY          Copies files and directory trees.
-WMIC           Displays WMI information inside interactive command shell.
-
-For more information on tools see the command-line reference in the online help.",
-                )
+                && diagnostic.message.contains("Help")
         });
         assert!(
             !help_undefined,
             "real glide transmission editor must not report undefined-method Help; panel_locals={panel_locals:?}; field_types={field_types:?}; diagnostics={diagnostics:?}"
         );
         assert!(
-            panel_locals.iter().any(|ty| ty.contains("ControlPanel")),
+            panel_local_types
+                .iter()
+                .any(|ty| contains_named_type(ty, "ControlPanel")),
             "expected ControlPanel for local panel from Glide.transmissionToolPanel, got panel_locals={panel_locals:?}; field_types={field_types:?}"
         );
     }

--- a/crates/glua_code_analysis/src/semantic/cache/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/cache/mod.rs
@@ -72,6 +72,7 @@ pub enum CacheEntry<T> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingStrTplTypeDecl {
     pub file_id: FileId,
+    pub source_range: TextRange,
     pub type_decl_id: LuaTypeDeclId,
     pub super_type: LuaType,
 }
@@ -182,11 +183,13 @@ impl LuaInferCache {
 
     pub fn add_pending_str_tpl_type_decl(
         &mut self,
+        source_range: TextRange,
         type_decl_id: LuaTypeDeclId,
         super_type: LuaType,
     ) {
         let pending = PendingStrTplTypeDecl {
             file_id: self.file_id,
+            source_range,
             type_decl_id,
             super_type,
         };

--- a/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/instantiate_type/instantiate_func_generic.rs
@@ -357,6 +357,7 @@ pub fn instantiate_func_generic(
         cache,
         substitutor: &mut substitutor,
         call_expr: Some(call_expr.clone()),
+        source_range: call_expr.get_range(),
     };
     if !generic_tpls.is_empty() {
         context.substitutor.add_need_infer_tpls(generic_tpls);

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_context.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_context.rs
@@ -1,4 +1,5 @@
 use glua_parser::LuaCallExpr;
+use rowan::TextRange;
 
 use crate::{DbIndex, LuaInferCache, TypeSubstitutor};
 
@@ -8,4 +9,5 @@ pub struct TplContext<'a> {
     pub cache: &'a mut LuaInferCache,
     pub substitutor: &'a mut TypeSubstitutor,
     pub call_expr: Option<LuaCallExpr>,
+    pub source_range: TextRange,
 }

--- a/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/generic/tpl_pattern/mod.rs
@@ -145,9 +145,11 @@ fn get_str_tpl_infer_type(
                         .get_type_decl(extend_type_decl_id)
                     && extend_type_decl.is_class()
                 {
-                    context
-                        .cache
-                        .add_pending_str_tpl_type_decl(type_decl_id, extend_type.clone());
+                    context.cache.add_pending_str_tpl_type_decl(
+                        context.source_range,
+                        type_decl_id,
+                        extend_type.clone(),
+                    );
                     ref_type
                 } else {
                     extend_type.clone()

--- a/crates/glua_code_analysis/src/semantic/infer/infer_index/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_index/mod.rs
@@ -46,12 +46,32 @@ use crate::{
         member::resolve_dynamic_field_member,
         member::resolve_member_item_with_realm,
         type_check::{self, check_type_compact},
+        visible_super_types_in_workspace_for_file_at_offset,
     },
 };
 
 use super::{InferFailReason, InferResult, infer_expr, infer_name::infer_global_type};
 
 type TableMemberLookupGuard = HashSet<InFiled<TextRange>>;
+
+fn visible_super_types_for_index(
+    db: &DbIndex,
+    cache: &LuaInferCache,
+    type_decl_id: &LuaTypeDeclId,
+    index_expr: &LuaIndexMemberExpr,
+) -> Option<Vec<LuaType>> {
+    if let Some(workspace_id) = db.get_module_index().get_workspace_id(cache.get_file_id()) {
+        visible_super_types_in_workspace_for_file_at_offset(
+            db,
+            type_decl_id,
+            workspace_id,
+            cache.get_file_id(),
+            index_expr.get_position(),
+        )
+    } else {
+        db.get_type_index().get_super_types(type_decl_id)
+    }
+}
 
 pub fn infer_index_expr(
     db: &DbIndex,
@@ -1744,7 +1764,8 @@ fn infer_custom_type_member(
         Some(index_expr.get_position()),
     ) {
         if type_decl.is_class()
-            && let Some(super_types) = type_index.get_super_types(&prefix_type_id)
+            && let Some(super_types) =
+                visible_super_types_for_index(db, cache, &prefix_type_id, &index_expr)
         {
             for super_type in super_types {
                 let result = infer_member_by_member_key_with_table_guard(
@@ -1810,7 +1831,8 @@ fn infer_custom_type_member(
     }
 
     if type_decl.is_class()
-        && let Some(super_types) = type_index.get_super_types(&prefix_type_id)
+        && let Some(super_types) =
+            visible_super_types_for_index(db, cache, &prefix_type_id, &index_expr)
     {
         for super_type in super_types {
             let result = infer_member_by_member_key_with_table_guard(
@@ -2250,7 +2272,8 @@ fn infer_generic_members_from_super_generics(
     };
 
     let type_decl_id = type_decl.get_id();
-    if let Some(super_types) = type_index.get_super_types(&type_decl_id) {
+    if let Some(super_types) = visible_super_types_for_index(db, cache, &type_decl_id, &index_expr)
+    {
         super_types.iter().find_map(|super_type| {
             let super_type = instantiate_type_generic(db, super_type, substitutor);
             infer_member_by_member_key_with_table_guard(
@@ -2783,7 +2806,8 @@ fn infer_member_by_index_custom_type(
 
     // find member by key in super
     if type_decl.is_class()
-        && let Some(super_types) = type_index.get_super_types(prefix_type_id)
+        && let Some(super_types) =
+            visible_super_types_for_index(db, cache, prefix_type_id, &index_expr)
     {
         for super_type in super_types {
             let result =
@@ -2966,7 +2990,7 @@ fn infer_member_by_index_generic(
     }
 
     // for supers
-    if let Some(supers) = type_index.get_super_types(&type_decl_id) {
+    if let Some(supers) = visible_super_types_for_index(db, cache, &type_decl_id, &index_expr) {
         for super_type in supers {
             let result = infer_member_by_operator(
                 db,

--- a/crates/glua_code_analysis/src/semantic/infer/infer_name.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_name.rs
@@ -24,9 +24,8 @@ use crate::{
             SelfRefId, VarRefId, infer_expr_narrow_type, infer_expr_narrow_type_with_self_base,
         },
         member::{
-            find_inherited_members_with_key,
-            find_inherited_members_with_key_in_workspace_for_file_at_offset, find_members_with_key,
-            merge_open_table_types,
+            find_members_with_key, find_members_with_key_in_workspace_for_file_at_offset,
+            merge_open_table_types, visible_super_types_in_workspace_for_file_at_offset,
         },
         resolve_registered_vgui_method_context_for_func,
         semantic_info::resolve_global_decl_id,
@@ -1249,23 +1248,41 @@ fn find_param_type_from_inherited_members(
         .get_member(&current_member_id)?
         .get_key()
         .clone();
-    let member_infos = match db.get_module_index().get_workspace_id(caller_file_id) {
-        Some(workspace_id) => find_inherited_members_with_key_in_workspace_for_file_at_offset(
+    let caller_workspace_id = db.get_module_index().get_workspace_id(caller_file_id);
+    let super_types = match caller_workspace_id {
+        Some(workspace_id) => visible_super_types_in_workspace_for_file_at_offset(
             db,
             owner_id,
-            key,
-            false,
             workspace_id,
             caller_file_id,
             caller_position,
         ),
-        None => find_inherited_members_with_key(db, owner_id, key, false),
+        None => db.get_type_index().get_super_types(owner_id),
     }?;
-    for member_info in member_infos {
-        if let Some(param_type) =
-            find_param_type_from_type(db, member_info.typ, param_idx, colon_define, is_dots)
-        {
-            return Some(param_type);
+
+    for super_type in super_types {
+        let member_infos = match caller_workspace_id {
+            Some(workspace_id) => find_members_with_key_in_workspace_for_file_at_offset(
+                db,
+                &super_type,
+                key.clone(),
+                false,
+                workspace_id,
+                caller_file_id,
+                caller_position,
+            ),
+            None => find_members_with_key(db, &super_type, key.clone(), false),
+        };
+        let Some(member_infos) = member_infos else {
+            continue;
+        };
+
+        for member_info in member_infos {
+            if let Some(param_type) =
+                find_param_type_from_type(db, member_info.typ, param_idx, colon_define, is_dots)
+            {
+                return Some(param_type);
+            }
         }
     }
 

--- a/crates/glua_code_analysis/src/semantic/infer/infer_name.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_name.rs
@@ -784,6 +784,16 @@ fn infer_param_inner(
     }
 
     if let Some(current_member_id) = member_id {
+        if let Some(param_type) = find_param_type_from_inherited_members(
+            db,
+            current_member_id,
+            param_idx,
+            colon_define,
+            decl.get_name() == "...",
+        ) {
+            return Ok((param_type, ParamInferenceSource::Concrete));
+        }
+
         let member_decl_type = find_decl_member_type(db, current_member_id)?;
         let param_type = find_param_type_from_type(
             db,
@@ -1215,6 +1225,36 @@ fn find_param_type_from_sibling_members(
     }
 
     final_type
+}
+
+fn find_param_type_from_inherited_members(
+    db: &DbIndex,
+    current_member_id: LuaMemberId,
+    param_idx: usize,
+    colon_define: bool,
+    is_dots: bool,
+) -> Option<LuaType> {
+    let member_index = db.get_member_index();
+    let owner = member_index.get_current_owner(&current_member_id)?;
+    let owner_id = owner.get_type_id()?;
+    let key = member_index
+        .get_member(&current_member_id)?
+        .get_key()
+        .clone();
+    for super_type in db.get_type_index().get_super_types_iter(owner_id)? {
+        let Some(member_infos) = find_members_with_key(db, super_type, key.clone(), false) else {
+            continue;
+        };
+        for member_info in member_infos {
+            if let Some(param_type) =
+                find_param_type_from_type(db, member_info.typ, param_idx, colon_define, is_dots)
+            {
+                return Some(param_type);
+            }
+        }
+    }
+
+    None
 }
 
 fn find_param_type_from_outer_factory_member(

--- a/crates/glua_code_analysis/src/semantic/infer/infer_name.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_name.rs
@@ -24,7 +24,8 @@ use crate::{
             SelfRefId, VarRefId, infer_expr_narrow_type, infer_expr_narrow_type_with_self_base,
         },
         member::{
-            find_members_with_key, find_members_with_key_in_workspace_for_file_at_offset,
+            find_inherited_members_with_key,
+            find_inherited_members_with_key_in_workspace_for_file_at_offset, find_members_with_key,
             merge_open_table_types,
         },
         resolve_registered_vgui_method_context_for_func,
@@ -1248,77 +1249,23 @@ fn find_param_type_from_inherited_members(
         .get_member(&current_member_id)?
         .get_key()
         .clone();
-    let module_index = db.get_module_index();
-    let caller_workspace_id = module_index.get_workspace_id(caller_file_id);
-    let caller_realm = db
-        .get_gmod_infer_index()
-        .get_realm_at_offset(&caller_file_id, caller_position);
-    let mut super_types = db
-        .get_type_index()
-        .get_super_types_with_file_iter(owner_id)?
-        .filter_map(|super_type| {
-            if db.get_emmyrc().gmod.enabled
-                && !caller_realm.is_compatible_with(
-                    db.get_gmod_infer_index()
-                        .get_realm_file_metadata(&super_type.file_id)
-                        .map_or(crate::GmodRealm::Unknown, |metadata| {
-                            metadata.inferred_realm
-                        }),
-                )
-            {
-                return None;
-            }
-
-            let (workspace_key, is_other_workspace) =
-                if let Some(caller_workspace_id) = caller_workspace_id {
-                    let candidate_workspace_id = module_index
-                        .get_workspace_id(super_type.file_id)
-                        .unwrap_or(crate::WorkspaceId::MAIN);
-                    let workspace_key = module_index
-                        .workspace_resolution_key(caller_workspace_id, candidate_workspace_id)?;
-                    (
-                        Some(workspace_key),
-                        candidate_workspace_id != caller_workspace_id,
-                    )
-                } else {
-                    (None, false)
-                };
-
-            Some((
-                workspace_key,
-                is_other_workspace,
-                super_type.file_id,
-                &super_type.value,
-            ))
-        })
-        .collect::<Vec<_>>();
-    // Keep visible cross-workspace edges as fallbacks while preferring this root.
-    super_types.sort_by_key(|(workspace_key, is_other_workspace, file_id, _)| {
-        (*workspace_key, *is_other_workspace, file_id.id)
-    });
-
-    for (_, _, _, super_type) in super_types {
-        let member_infos = match caller_workspace_id {
-            Some(workspace_id) => find_members_with_key_in_workspace_for_file_at_offset(
-                db,
-                super_type,
-                key.clone(),
-                false,
-                workspace_id,
-                caller_file_id,
-                caller_position,
-            ),
-            None => find_members_with_key(db, super_type, key.clone(), false),
-        };
-        let Some(member_infos) = member_infos else {
-            continue;
-        };
-        for member_info in member_infos {
-            if let Some(param_type) =
-                find_param_type_from_type(db, member_info.typ, param_idx, colon_define, is_dots)
-            {
-                return Some(param_type);
-            }
+    let member_infos = match db.get_module_index().get_workspace_id(caller_file_id) {
+        Some(workspace_id) => find_inherited_members_with_key_in_workspace_for_file_at_offset(
+            db,
+            owner_id,
+            key,
+            false,
+            workspace_id,
+            caller_file_id,
+            caller_position,
+        ),
+        None => find_inherited_members_with_key(db, owner_id, key, false),
+    }?;
+    for member_info in member_infos {
+        if let Some(param_type) =
+            find_param_type_from_type(db, member_info.typ, param_idx, colon_define, is_dots)
+        {
+            return Some(param_type);
         }
     }
 

--- a/crates/glua_code_analysis/src/semantic/infer/infer_name.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_name.rs
@@ -1248,8 +1248,56 @@ fn find_param_type_from_inherited_members(
         .get_member(&current_member_id)?
         .get_key()
         .clone();
-    let caller_workspace_id = db.get_module_index().get_workspace_id(caller_file_id);
-    for super_type in db.get_type_index().get_super_types_iter(owner_id)? {
+    let module_index = db.get_module_index();
+    let caller_workspace_id = module_index.get_workspace_id(caller_file_id);
+    let caller_realm = db
+        .get_gmod_infer_index()
+        .get_realm_at_offset(&caller_file_id, caller_position);
+    let mut super_types = db
+        .get_type_index()
+        .get_super_types_with_file_iter(owner_id)?
+        .filter_map(|super_type| {
+            if db.get_emmyrc().gmod.enabled
+                && !caller_realm.is_compatible_with(
+                    db.get_gmod_infer_index()
+                        .get_realm_file_metadata(&super_type.file_id)
+                        .map_or(crate::GmodRealm::Unknown, |metadata| {
+                            metadata.inferred_realm
+                        }),
+                )
+            {
+                return None;
+            }
+
+            let (workspace_key, is_other_workspace) =
+                if let Some(caller_workspace_id) = caller_workspace_id {
+                    let candidate_workspace_id = module_index
+                        .get_workspace_id(super_type.file_id)
+                        .unwrap_or(crate::WorkspaceId::MAIN);
+                    let workspace_key = module_index
+                        .workspace_resolution_key(caller_workspace_id, candidate_workspace_id)?;
+                    (
+                        Some(workspace_key),
+                        candidate_workspace_id != caller_workspace_id,
+                    )
+                } else {
+                    (None, false)
+                };
+
+            Some((
+                workspace_key,
+                is_other_workspace,
+                super_type.file_id,
+                &super_type.value,
+            ))
+        })
+        .collect::<Vec<_>>();
+    // Keep visible cross-workspace edges as fallbacks while preferring this root.
+    super_types.sort_by_key(|(workspace_key, is_other_workspace, file_id, _)| {
+        (*workspace_key, *is_other_workspace, file_id.id)
+    });
+
+    for (_, _, _, super_type) in super_types {
         let member_infos = match caller_workspace_id {
             Some(workspace_id) => find_members_with_key_in_workspace_for_file_at_offset(
                 db,

--- a/crates/glua_code_analysis/src/semantic/infer/infer_name.rs
+++ b/crates/glua_code_analysis/src/semantic/infer/infer_name.rs
@@ -23,7 +23,10 @@ use crate::{
         infer::narrow::{
             SelfRefId, VarRefId, infer_expr_narrow_type, infer_expr_narrow_type_with_self_base,
         },
-        member::{find_members_with_key, merge_open_table_types},
+        member::{
+            find_members_with_key, find_members_with_key_in_workspace_for_file_at_offset,
+            merge_open_table_types,
+        },
         resolve_registered_vgui_method_context_for_func,
         semantic_info::resolve_global_decl_id,
     },
@@ -784,16 +787,6 @@ fn infer_param_inner(
     }
 
     if let Some(current_member_id) = member_id {
-        if let Some(param_type) = find_param_type_from_inherited_members(
-            db,
-            current_member_id,
-            param_idx,
-            colon_define,
-            decl.get_name() == "...",
-        ) {
-            return Ok((param_type, ParamInferenceSource::Concrete));
-        }
-
         let member_decl_type = find_decl_member_type(db, current_member_id)?;
         let param_type = find_param_type_from_type(
             db,
@@ -803,6 +796,18 @@ fn infer_param_inner(
             decl.get_name() == "...",
         );
         if let Some(param_type) = param_type {
+            return Ok((param_type, ParamInferenceSource::Concrete));
+        }
+
+        if let Some(param_type) = find_param_type_from_inherited_members(
+            db,
+            current_member_id,
+            param_idx,
+            colon_define,
+            decl.get_name() == "...",
+            decl.get_file_id(),
+            decl.get_position(),
+        ) {
             return Ok((param_type, ParamInferenceSource::Concrete));
         }
 
@@ -1233,6 +1238,8 @@ fn find_param_type_from_inherited_members(
     param_idx: usize,
     colon_define: bool,
     is_dots: bool,
+    caller_file_id: FileId,
+    caller_position: TextSize,
 ) -> Option<LuaType> {
     let member_index = db.get_member_index();
     let owner = member_index.get_current_owner(&current_member_id)?;
@@ -1241,8 +1248,21 @@ fn find_param_type_from_inherited_members(
         .get_member(&current_member_id)?
         .get_key()
         .clone();
+    let caller_workspace_id = db.get_module_index().get_workspace_id(caller_file_id);
     for super_type in db.get_type_index().get_super_types_iter(owner_id)? {
-        let Some(member_infos) = find_members_with_key(db, super_type, key.clone(), false) else {
+        let member_infos = match caller_workspace_id {
+            Some(workspace_id) => find_members_with_key_in_workspace_for_file_at_offset(
+                db,
+                super_type,
+                key.clone(),
+                false,
+                workspace_id,
+                caller_file_id,
+                caller_position,
+            ),
+            None => find_members_with_key(db, super_type, key.clone(), false),
+        };
+        let Some(member_infos) = member_infos else {
             continue;
         };
         for member_info in member_infos {

--- a/crates/glua_code_analysis/src/semantic/member/find_members.rs
+++ b/crates/glua_code_analysis/src/semantic/member/find_members.rs
@@ -128,50 +128,6 @@ pub fn find_members_with_key_in_workspace_for_file_at_offset(
     )
 }
 
-pub(crate) fn find_inherited_members_with_key(
-    db: &DbIndex,
-    type_decl_id: &LuaTypeDeclId,
-    member_key: LuaMemberKey,
-    find_all: bool,
-) -> FindMembersResult {
-    let ctx = FindMembersContext::new(InferGuard::new());
-    find_super_type_members(
-        db,
-        type_decl_id,
-        &ctx,
-        &FindMemberFilter::ByKey {
-            member_key,
-            find_all,
-        },
-    )
-}
-
-pub(crate) fn find_inherited_members_with_key_in_workspace_for_file_at_offset(
-    db: &DbIndex,
-    type_decl_id: &LuaTypeDeclId,
-    member_key: LuaMemberKey,
-    find_all: bool,
-    workspace_id: WorkspaceId,
-    file_id: FileId,
-    caller_position: TextSize,
-) -> FindMembersResult {
-    let ctx = FindMembersContext::new_with_workspace_file_and_position(
-        InferGuard::new(),
-        workspace_id,
-        file_id,
-        caller_position,
-    );
-    find_super_type_members(
-        db,
-        type_decl_id,
-        &ctx,
-        &FindMemberFilter::ByKey {
-            member_key,
-            find_all,
-        },
-    )
-}
-
 pub(crate) fn visible_super_types_in_workspace_for_file_at_offset(
     db: &DbIndex,
     type_decl_id: &LuaTypeDeclId,

--- a/crates/glua_code_analysis/src/semantic/member/find_members.rs
+++ b/crates/glua_code_analysis/src/semantic/member/find_members.rs
@@ -336,8 +336,8 @@ fn find_custom_type_members(
 ) -> FindMembersResult {
     ctx.infer_guard().check(type_decl_id).ok()?;
     let type_index = db.get_type_index();
-    let type_decl = type_index.get_type_decl(type_decl_id)?;
-    if type_decl.is_alias() {
+    let type_decl = type_index.get_type_decl(type_decl_id);
+    if let Some(type_decl) = type_decl.filter(|decl| decl.is_alias()) {
         if let Some(origin) = type_decl.get_alias_origin(db, None) {
             return find_members_guard(db, &origin, ctx, filter);
         } else {
@@ -407,7 +407,7 @@ fn find_custom_type_members(
         }
     }
 
-    if type_decl.is_class()
+    if type_decl.is_some_and(|decl| decl.is_class())
         && let Some(super_types) = type_index.get_super_types(type_decl_id)
     {
         for super_type in super_types {
@@ -1401,6 +1401,34 @@ mod tests {
         assert_eq!(members[0].key, key);
         assert_eq!(members[0].typ, LuaType::String);
         assert_eq!(members[0].property_owner_id, Some(shared_member.into()));
+    }
+
+    #[test]
+    fn find_ref_members_include_global_path_without_type_declaration() {
+        let mut db = make_db();
+        let type_decl_id = LuaTypeDeclId::global("TOOL");
+        let member_id = make_member_id(FileId::new(19), 1);
+        let key = LuaMemberKey::Name("BuildCPanel".into());
+        let owner = LuaMemberOwner::GlobalPath(GlobalId::new(type_decl_id.get_name()));
+
+        db.get_member_index_mut().add_member(
+            owner,
+            LuaMember::new(
+                member_id,
+                key.clone(),
+                LuaMemberFeature::FileFieldDecl,
+                None,
+            ),
+        );
+        bind_member_type(&mut db, member_id, LuaType::Function);
+
+        let members = find_members_with_key(&db, &LuaType::Ref(type_decl_id), key.clone(), false)
+            .expect("global-path member should resolve without a nominal type declaration");
+
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0].key, key);
+        assert_eq!(members[0].typ, LuaType::Function);
+        assert_eq!(members[0].property_owner_id, Some(member_id.into()));
     }
 
     #[test]

--- a/crates/glua_code_analysis/src/semantic/member/find_members.rs
+++ b/crates/glua_code_analysis/src/semantic/member/find_members.rs
@@ -128,6 +128,67 @@ pub fn find_members_with_key_in_workspace_for_file_at_offset(
     )
 }
 
+pub(crate) fn find_inherited_members_with_key(
+    db: &DbIndex,
+    type_decl_id: &LuaTypeDeclId,
+    member_key: LuaMemberKey,
+    find_all: bool,
+) -> FindMembersResult {
+    let ctx = FindMembersContext::new(InferGuard::new());
+    find_super_type_members(
+        db,
+        type_decl_id,
+        &ctx,
+        &FindMemberFilter::ByKey {
+            member_key,
+            find_all,
+        },
+    )
+}
+
+pub(crate) fn find_inherited_members_with_key_in_workspace_for_file_at_offset(
+    db: &DbIndex,
+    type_decl_id: &LuaTypeDeclId,
+    member_key: LuaMemberKey,
+    find_all: bool,
+    workspace_id: WorkspaceId,
+    file_id: FileId,
+    caller_position: TextSize,
+) -> FindMembersResult {
+    let ctx = FindMembersContext::new_with_workspace_file_and_position(
+        InferGuard::new(),
+        workspace_id,
+        file_id,
+        caller_position,
+    );
+    find_super_type_members(
+        db,
+        type_decl_id,
+        &ctx,
+        &FindMemberFilter::ByKey {
+            member_key,
+            find_all,
+        },
+    )
+}
+
+pub(crate) fn visible_super_types_in_workspace_for_file_at_offset(
+    db: &DbIndex,
+    type_decl_id: &LuaTypeDeclId,
+    workspace_id: WorkspaceId,
+    file_id: FileId,
+    caller_position: TextSize,
+) -> Option<Vec<LuaType>> {
+    let ctx = FindMembersContext::new_with_workspace_file_and_position(
+        InferGuard::new(),
+        workspace_id,
+        file_id,
+        caller_position,
+    );
+    super_types_for_context(db, type_decl_id, &ctx)
+        .map(|super_types| super_types.into_iter().cloned().collect())
+}
+
 #[derive(Clone)]
 struct FindMembersContext {
     infer_guard: InferGuardRef,
@@ -211,6 +272,10 @@ impl FindMembersContext {
 
     fn file_id(&self) -> Option<FileId> {
         self.file_id
+    }
+
+    fn workspace_id(&self) -> Option<WorkspaceId> {
+        self.workspace_id
     }
 
     fn has_workspace_scope(&self) -> bool {
@@ -408,17 +473,11 @@ fn find_custom_type_members(
     }
 
     if type_decl.is_some_and(|decl| decl.is_class())
-        && let Some(super_types) = type_index.get_super_types(type_decl_id)
+        && let Some(super_members) = find_super_type_members(db, type_decl_id, ctx, filter)
     {
-        for super_type in super_types {
-            let instantiated_super = ctx.instantiate_type(db, &super_type);
-            if let Some(super_members) = find_members_guard(db, &instantiated_super, ctx, filter) {
-                members.extend(super_members);
-
-                if should_stop_collecting(members.len(), filter) {
-                    return Some(members);
-                }
-            }
+        members.extend(super_members);
+        if should_stop_collecting(members.len(), filter) {
+            return Some(members);
         }
     }
 
@@ -427,6 +486,96 @@ fn find_custom_type_members(
     }
 
     Some(members)
+}
+
+fn find_super_type_members(
+    db: &DbIndex,
+    type_decl_id: &LuaTypeDeclId,
+    ctx: &FindMembersContext,
+    filter: &FindMemberFilter,
+) -> FindMembersResult {
+    let mut members = Vec::new();
+    for super_type in super_types_for_context(db, type_decl_id, ctx)? {
+        let instantiated_super = ctx.instantiate_type(db, super_type);
+        if let Some(super_members) = find_members_guard(db, &instantiated_super, ctx, filter) {
+            members.extend(super_members);
+            if should_stop_collecting(members.len(), filter) {
+                break;
+            }
+        }
+    }
+
+    Some(members)
+}
+
+fn super_types_for_context<'a>(
+    db: &'a DbIndex,
+    type_decl_id: &LuaTypeDeclId,
+    ctx: &FindMembersContext,
+) -> Option<Vec<&'a LuaType>> {
+    let entries = db.get_type_index().get_super_type_entries(type_decl_id)?;
+    let Some(caller_workspace_id) = ctx.workspace_id() else {
+        return Some(entries.iter().map(|entry| &entry.value.typ).collect());
+    };
+    let caller_file_id = ctx.file_id()?;
+    let infer_index = db.get_gmod_infer_index();
+    let caller_realm = ctx.caller_position().map_or_else(
+        || {
+            infer_index
+                .get_realm_file_metadata(&caller_file_id)
+                .map_or(crate::GmodRealm::Unknown, |metadata| {
+                    metadata.inferred_realm
+                })
+        },
+        |position| infer_index.get_realm_at_offset(&caller_file_id, position),
+    );
+    let module_index = db.get_module_index();
+    let mut visible = entries
+        .iter()
+        .filter_map(|entry| {
+            if db.get_emmyrc().gmod.enabled
+                && !caller_realm.is_compatible_with(
+                    infer_index
+                        .get_realm_at_offset(&entry.file_id, entry.value.source_range.start()),
+                )
+            {
+                return None;
+            }
+
+            let candidate_workspace_id = module_index
+                .get_workspace_id(entry.file_id)
+                .unwrap_or(crate::WorkspaceId::MAIN);
+            let workspace_key = module_index
+                .workspace_resolution_key(caller_workspace_id, candidate_workspace_id)?;
+            Some((
+                workspace_key,
+                candidate_workspace_id != caller_workspace_id,
+                entry.file_id,
+                entry.value.source_range,
+                &entry.value.typ,
+            ))
+        })
+        .collect::<Vec<_>>();
+    visible.sort_by_key(
+        |(workspace_key, is_other_workspace, file_id, source_range, _)| {
+            (
+                *workspace_key,
+                *is_other_workspace,
+                file_id.id,
+                u32::from(source_range.start()),
+                u32::from(source_range.end()),
+            )
+        },
+    );
+    let mut seen_super_types = HashSet::new();
+    visible.retain(|(_, _, _, _, super_type)| seen_super_types.insert(*super_type));
+
+    Some(
+        visible
+            .into_iter()
+            .map(|(_, _, _, _, super_type)| super_type)
+            .collect(),
+    )
 }
 
 fn find_owner_members(
@@ -1164,12 +1313,13 @@ mod tests {
     use rowan::{TextRange, TextSize};
 
     use super::{
-        find_members_in_workspace_for_file, find_members_with_key,
-        find_members_with_key_in_workspace_for_file,
+        FindMembersContext, find_members_in_workspace_for_file, find_members_with_key,
+        find_members_with_key_in_workspace_for_file, super_types_for_context,
     };
     use crate::{
         DbIndex, DynamicFieldOwner, Emmyrc, FileId, GlobalId, GmodRealm, GmodRealmFileMetadata,
-        InFiled, LuaMemberKey, LuaType, LuaTypeCache, LuaTypeDecl, LuaTypeDeclId, WorkspaceId,
+        InFiled, InferGuard, LuaMemberKey, LuaType, LuaTypeCache, LuaTypeDecl, LuaTypeDeclId,
+        WorkspaceId,
         db_index::{
             LuaDeclTypeKind, LuaMember, LuaMemberFeature, LuaMemberId, LuaMemberOwner,
             WorkspaceKind,
@@ -1233,6 +1383,43 @@ mod tests {
     fn bind_member_type(db: &mut DbIndex, member_id: LuaMemberId, typ: LuaType) {
         db.get_type_index_mut()
             .bind_type(member_id.into(), LuaTypeCache::InferType(typ));
+    }
+
+    #[test]
+    fn visible_super_types_deduplicate_equivalent_edges() {
+        let mut db = make_db();
+        let (workspace_a, _, _) = configure_workspaces(&mut db);
+        let caller_file = FileId::new(1);
+        let edge_file = FileId::new(2);
+        let module_index = db.get_module_index_mut();
+        module_index.add_module_by_path(caller_file, "C:/Users/username/ProjectA/caller.lua");
+        module_index.add_module_by_path(edge_file, "C:/Users/username/ProjectA/edges.lua");
+
+        let child_id = LuaTypeDeclId::global("Child");
+        let parent_type = LuaType::Ref(LuaTypeDeclId::global("Parent"));
+        add_type_decl(&mut db, caller_file, child_id.clone());
+        db.get_type_index_mut().add_super_type(
+            child_id.clone(),
+            edge_file,
+            TextRange::new(10.into(), 20.into()),
+            parent_type.clone(),
+        );
+        db.get_type_index_mut().add_super_type(
+            child_id.clone(),
+            edge_file,
+            TextRange::new(30.into(), 40.into()),
+            parent_type.clone(),
+        );
+
+        let context = FindMembersContext::new_with_workspace_file_and_position(
+            InferGuard::new(),
+            workspace_a,
+            caller_file,
+            TextSize::new(0),
+        );
+        let visible = super_types_for_context(&db, &child_id, &context).expect("super types");
+
+        assert_eq!(visible, vec![&parent_type]);
     }
 
     fn set_file_realms(db: &mut DbIndex, file_realms: &[(FileId, GmodRealm)]) {

--- a/crates/glua_code_analysis/src/semantic/member/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/member/mod.rs
@@ -12,11 +12,7 @@ use crate::{
     semantic::type_check::check_type_compact,
 };
 pub use find_index::find_index_operations;
-pub(crate) use find_members::{
-    find_inherited_members_with_key,
-    find_inherited_members_with_key_in_workspace_for_file_at_offset,
-    visible_super_types_in_workspace_for_file_at_offset,
-};
+pub(crate) use find_members::visible_super_types_in_workspace_for_file_at_offset;
 pub use find_members::{
     find_members, find_members_in_workspace_for_file, find_members_in_workspace_for_file_at_offset,
     find_members_with_key, find_members_with_key_in_workspace_for_file,

--- a/crates/glua_code_analysis/src/semantic/member/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/member/mod.rs
@@ -12,6 +12,11 @@ use crate::{
     semantic::type_check::check_type_compact,
 };
 pub use find_index::find_index_operations;
+pub(crate) use find_members::{
+    find_inherited_members_with_key,
+    find_inherited_members_with_key_in_workspace_for_file_at_offset,
+    visible_super_types_in_workspace_for_file_at_offset,
+};
 pub use find_members::{
     find_members, find_members_in_workspace_for_file, find_members_in_workspace_for_file_at_offset,
     find_members_with_key, find_members_with_key_in_workspace_for_file,

--- a/crates/glua_code_analysis/src/semantic/mod.rs
+++ b/crates/glua_code_analysis/src/semantic/mod.rs
@@ -49,6 +49,7 @@ pub(crate) use member::infer_raw_member_type_with_cache;
 pub(crate) use member::member_key_matches_type;
 pub(crate) use member::merge_open_table_types;
 pub(crate) use member::resolve_dynamic_field_member;
+pub(crate) use member::visible_super_types_in_workspace_for_file_at_offset;
 use reference::is_reference_to;
 use rowan::{NodeOrToken, TextRange};
 pub(crate) use semantic_info::{


### PR DESCRIPTION
## Summary

- stabilize ordering when nested child inference candidates otherwise tie
- inherit scripted TOOL callback parameter contracts without replacing explicit local annotations
- scope inherited member lookup by workspace, realm, file, and source position
- restore synthesized global-path member lookup and repair the Glide help regression

## Why

Tied nested candidates lacked a total ordering, and synthesized scripted owners could select an unrelated or invisible callback contract. This made inference depend on insertion order and could infer the wrong TOOL parameter type.

## Validation

- cargo test --workspace --all-targets --all-features (2,954 analyzer tests passed; 5 intentionally ignored; all workspace crates passed)
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- changed-file pre-commit hooks
- independent merge-readiness review