### PR TITLE
Harden documentation CLI exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,7 @@ dependencies = [
  "schemars 1.0.4",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_with",
  "smol_str",
  "tokio-util",
@@ -2480,6 +2481,17 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
  "serde",
  "serde_core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ lsp-server = "0.7.9"
 tokio = { version = "1.48", features = ["full"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+serde_path_to_error = "0.1.20"
 rowan = { version = "0.16.1" }
 notify = { version = "8.2.0", features = ["serde"] }
 lsp_types = { version = "0.1.0", package = "emmy_lsp_types" }

--- a/crates/glua_code_analysis/Cargo.toml
+++ b/crates/glua_code_analysis/Cargo.toml
@@ -34,6 +34,7 @@ glua_diagnostic_macro.workspace = true
 aho-corasick.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_path_to_error.workspace = true
 lsp_types.workspace = true
 schemars.workspace = true
 rowan.workspace = true

--- a/crates/glua_code_analysis/src/config/config_loader.rs
+++ b/crates/glua_code_analysis/src/config/config_loader.rs
@@ -1,85 +1,281 @@
-use std::path::PathBuf;
+use std::{
+    error::Error,
+    fmt,
+    path::{Path, PathBuf},
+};
 
+use serde::de::IntoDeserializer;
 use serde_json::Value;
+use serde_path_to_error::{Path as SerdePath, Segment};
 
 use crate::{config::lua_loader::load_lua_config, read_file_with_encoding};
 
 use super::{Emmyrc, flatten_config::FlattenConfigObject};
 
-pub fn load_configs_raw(config_files: Vec<PathBuf>, partial_emmyrcs: Option<Vec<Value>>) -> Value {
-    let mut config_jsons = Vec::new();
+#[derive(Debug)]
+pub enum ConfigLoadError {
+    Read {
+        path: PathBuf,
+    },
+    Parse {
+        path: PathBuf,
+        message: String,
+    },
+    Invalid {
+        config_files: Vec<PathBuf>,
+        message: String,
+    },
+}
+
+impl fmt::Display for ConfigLoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigLoadError::Read { path } => {
+                write!(f, "failed to read config file \"{}\"", path.display())
+            }
+            ConfigLoadError::Parse { path, message } => {
+                write!(
+                    f,
+                    "failed to parse config file \"{}\": {message}",
+                    path.display()
+                )
+            }
+            ConfigLoadError::Invalid {
+                config_files,
+                message,
+            } => {
+                if config_files.is_empty() {
+                    write!(f, "failed to apply config: {message}")
+                } else {
+                    let paths = config_files
+                        .iter()
+                        .map(|path| format!("\"{}\"", path.display()))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    write!(f, "failed to apply config from {paths}: {message}")
+                }
+            }
+        }
+    }
+}
+
+impl Error for ConfigLoadError {}
+
+struct ConfigLayer {
+    value: Value,
+    source: Option<PathBuf>,
+}
+
+fn load_config_file(config_file: &Path) -> Result<Value, ConfigLoadError> {
+    log::info!("Loading config file: {:?}", config_file);
+    let config_content =
+        read_file_with_encoding(config_file, "utf-8").ok_or_else(|| ConfigLoadError::Read {
+            path: config_file.to_path_buf(),
+        })?;
+
+    let config_value = if config_file.extension().and_then(|s| s.to_str()) == Some("lua") {
+        load_lua_config(&config_content).map_err(|message| ConfigLoadError::Parse {
+            path: config_file.to_path_buf(),
+            message,
+        })?
+    } else {
+        serde_json::from_str(&config_content).map_err(|error| ConfigLoadError::Parse {
+            path: config_file.to_path_buf(),
+            message: error.to_string(),
+        })?
+    };
+
+    Ok(normalize_to_emmyrc_json(config_value))
+}
+
+fn load_config_layers_impl(
+    config_files: &[PathBuf],
+    partial_emmyrcs: Option<Vec<Value>>,
+    strict: bool,
+) -> Result<Vec<ConfigLayer>, ConfigLoadError> {
+    let mut config_layers = Vec::new();
 
     for config_file in config_files {
-        log::info!("Loading config file: {:?}", config_file);
-        let config_content = match read_file_with_encoding(&config_file, "utf-8") {
-            Some(content) => content,
-            None => {
-                log::error!(
-                    "Failed to read config file: {:?}, error: File not found or unreadable",
-                    config_file
-                );
-                continue;
-            }
-        };
-
-        let config_value = if config_file.extension().and_then(|s| s.to_str()) == Some("lua") {
-            match load_lua_config(&config_content) {
-                Ok(value) => value,
-                Err(e) => {
-                    log::error!(
-                        "Failed to parse lua config file: {:?}, error: {:?}",
-                        config_file,
-                        e
-                    );
-                    continue;
-                }
-            }
-        } else {
-            match serde_json::from_str(&config_content) {
-                Ok(json) => json,
-                Err(e) => {
-                    log::error!(
-                        "Failed to parse config file: {:?}, error: {:?}",
-                        config_file,
-                        e
-                    );
-                    continue;
-                }
-            }
-        };
-
-        config_jsons.push(normalize_to_emmyrc_json(config_value));
+        match load_config_file(config_file) {
+            Ok(value) => config_layers.push(ConfigLayer {
+                value,
+                source: Some(config_file.clone()),
+            }),
+            Err(error) if strict => return Err(error),
+            Err(error) => log::error!("{error}"),
+        }
     }
 
     if let Some(partial_emmyrcs) = partial_emmyrcs {
         for partial_emmyrc in partial_emmyrcs {
-            config_jsons.push(normalize_to_emmyrc_json(partial_emmyrc));
+            config_layers.push(ConfigLayer {
+                value: normalize_to_emmyrc_json(partial_emmyrc),
+                source: None,
+            });
         }
     }
 
-    if config_jsons.is_empty() {
+    if config_layers.is_empty() {
         log::info!("No valid config file found.");
+    }
+
+    Ok(config_layers)
+}
+
+fn merge_config_layers(config_layers: Vec<ConfigLayer>) -> Value {
+    config_layers.into_iter().fold(
+        Value::Object(Default::default()),
+        |mut merged, config_layer| {
+            merge_values(&mut merged, config_layer.value);
+            merged
+        },
+    )
+}
+
+fn load_configs_raw_impl(
+    config_files: &[PathBuf],
+    partial_emmyrcs: Option<Vec<Value>>,
+    strict: bool,
+) -> Result<Value, ConfigLoadError> {
+    let config_layers = load_config_layers_impl(config_files, partial_emmyrcs, strict)?;
+    Ok(merge_config_layers(config_layers))
+}
+
+pub fn load_configs_raw(config_files: Vec<PathBuf>, partial_emmyrcs: Option<Vec<Value>>) -> Value {
+    load_configs_raw_impl(&config_files, partial_emmyrcs, false).unwrap_or_else(|error| {
+        log::error!("{error}");
         Value::Object(Default::default())
-    } else {
-        config_jsons
-            .into_iter()
-            .fold(Value::Object(Default::default()), |mut acc, item| {
-                merge_values(&mut acc, item);
-                acc
-            })
+    })
+}
+
+pub fn try_load_configs(
+    config_files: Vec<PathBuf>,
+    partial_emmyrcs: Option<Vec<Value>>,
+) -> Result<Emmyrc, ConfigLoadError> {
+    let config_layers = load_config_layers_impl(&config_files, partial_emmyrcs, true)?;
+    deserialize_config_layers_ignoring_invalid_values(config_layers)
+}
+
+pub fn load_configs(config_files: Vec<PathBuf>, partial_emmyrcs: Option<Vec<Value>>) -> Emmyrc {
+    load_config_layers_impl(&config_files, partial_emmyrcs, false)
+        .and_then(deserialize_config_layers_ignoring_invalid_values)
+        .unwrap_or_else(|error| {
+            log::error!("{error}");
+            Emmyrc::default()
+        })
+}
+
+fn deserialize_config_layers_ignoring_invalid_values(
+    config_layers: Vec<ConfigLayer>,
+) -> Result<Emmyrc, ConfigLoadError> {
+    let mut merged = Value::Object(Default::default());
+    let mut emmyrc = Emmyrc::default();
+
+    for config_layer in config_layers {
+        let ConfigLayer { mut value, source } = config_layer;
+
+        loop {
+            let mut candidate = merged.clone();
+            merge_values(&mut candidate, value.clone());
+
+            let result = serde_path_to_error::deserialize(candidate.clone().into_deserializer());
+            let error = match result {
+                Ok(candidate_emmyrc) => {
+                    merged = candidate;
+                    emmyrc = candidate_emmyrc;
+                    break;
+                }
+                Err(error) => error,
+            };
+            let path = error.path().clone();
+            let path_text = path.to_string();
+            let message = error.inner().to_string();
+
+            if !remove_value_at_path(&mut value, &path) {
+                return Err(ConfigLoadError::Invalid {
+                    config_files: source.into_iter().collect(),
+                    message: format!("at `{path_text}`: {message}"),
+                });
+            }
+
+            if let Some(source) = &source {
+                log::warn!(
+                    "Ignoring invalid config value at `{path_text}` from \"{}\": {message}",
+                    source.display()
+                );
+            } else {
+                log::warn!("Ignoring invalid config value at `{path_text}`: {message}");
+            }
+        }
+    }
+
+    Ok(emmyrc)
+}
+
+fn remove_value_at_path(config: &mut Value, path: &SerdePath) -> bool {
+    let segments = path.iter().collect::<Vec<_>>();
+    remove_value_at_segments(config, &segments)
+}
+
+fn remove_value_at_segments(value: &mut Value, segments: &[&Segment]) -> bool {
+    let Some((segment, remaining)) = segments.split_first() else {
+        return false;
+    };
+    let is_last = remaining.is_empty();
+
+    match segment {
+        Segment::Map { key } => {
+            let Some(object) = value.as_object_mut() else {
+                return false;
+            };
+            if is_last {
+                object.remove(key).is_some()
+            } else {
+                object
+                    .get_mut(key)
+                    .is_some_and(|child| remove_value_at_segments(child, remaining))
+            }
+        }
+        Segment::Seq { index } => {
+            let Some(array) = value.as_array_mut() else {
+                return false;
+            };
+            if is_last {
+                if *index < array.len() {
+                    array.remove(*index);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                array
+                    .get_mut(*index)
+                    .is_some_and(|child| remove_value_at_segments(child, remaining))
+            }
+        }
+        Segment::Enum { variant } => {
+            if let Some(child) = value
+                .as_object_mut()
+                .and_then(|object| object.get_mut(variant))
+            {
+                if is_last {
+                    *child = Value::Null;
+                    true
+                } else {
+                    remove_value_at_segments(child, remaining)
+                }
+            } else if is_last {
+                false
+            } else {
+                remove_value_at_segments(value, remaining)
+            }
+        }
+        Segment::Unknown => false,
     }
 }
 
 fn normalize_to_emmyrc_json(config: Value) -> Value {
     FlattenConfigObject::parse(config).to_emmyrc()
-}
-
-pub fn load_configs(config_files: Vec<PathBuf>, partial_emmyrcs: Option<Vec<Value>>) -> Emmyrc {
-    let emmyrc_json_value = load_configs_raw(config_files, partial_emmyrcs);
-    serde_json::from_value(emmyrc_json_value).unwrap_or_else(|err| {
-        log::error!("Failed to parse config: error: {:?}", err);
-        Emmyrc::default()
-    })
 }
 
 fn merge_values(base: &mut Value, overlay: Value) {
@@ -109,7 +305,7 @@ fn merge_values(base: &mut Value, overlay: Value) {
 mod tests {
     use serde_json::json;
 
-    use super::merge_values;
+    use super::{merge_values, try_load_configs};
     use crate::config::flatten_config::FlattenConfigObject;
 
     #[test]
@@ -197,5 +393,47 @@ mod tests {
             merged["diagnostics"]["disable"],
             json!(["call-non-callable"])
         );
+    }
+
+    #[test]
+    fn try_load_configs_ignores_invalid_value_and_keeps_valid_fields() {
+        let config = try_load_configs(
+            Vec::new(),
+            Some(vec![json!({
+                "workspace": {
+                    "encoding": {
+                        "unexpected": true
+                    },
+                    "ignoreDir": [".claude"]
+                }
+            })]),
+        )
+        .expect("an invalid field should not reject the remaining config");
+
+        assert_eq!(config.workspace.ignore_dir, vec![".claude"]);
+    }
+
+    #[test]
+    fn try_load_configs_ignores_invalid_overlay_and_keeps_previous_value() {
+        let config = try_load_configs(
+            Vec::new(),
+            Some(vec![
+                json!({
+                    "workspace": {
+                        "encoding": "windows-1252"
+                    }
+                }),
+                json!({
+                    "workspace": {
+                        "encoding": {
+                            "unexpected": true
+                        }
+                    }
+                }),
+            ]),
+        )
+        .expect("an invalid overlay should preserve the previous valid value");
+
+        assert_eq!(config.workspace.encoding, "windows-1252");
     }
 }

--- a/crates/glua_code_analysis/src/config/mod.rs
+++ b/crates/glua_code_analysis/src/config/mod.rs
@@ -8,7 +8,7 @@ mod test;
 
 use std::{collections::HashMap, path::Path};
 
-pub use config_loader::{load_configs, load_configs_raw};
+pub use config_loader::{ConfigLoadError, load_configs, load_configs_raw, try_load_configs};
 pub use configs::{
     DiagnosticSeveritySetting, DocSyntax, EmmyLibraryConfig, EmmyLibraryItem, EmmyrcCodeAction,
     EmmyrcCodeLens, EmmyrcCompletion, EmmyrcDiagnostic, EmmyrcDoc, EmmyrcDocumentColor,

--- a/crates/glua_code_analysis/src/vfs/loader.rs
+++ b/crates/glua_code_analysis/src/vfs/loader.rs
@@ -108,19 +108,23 @@ pub fn load_workspace_files(
                     Err(_) => return WalkState::Continue,
                 };
                 let path = entry.path();
+                let file_type = entry.file_type();
                 if exclude_dirs.iter().any(|d| path.starts_with(d)) {
-                    if entry.file_type().is_some_and(|t| t.is_dir()) {
+                    if file_type.is_some_and(|t| t.is_dir()) {
                         return WalkState::Skip;
                     }
-                    return WalkState::Continue;
-                }
-                if !entry.file_type().is_some_and(|t| t.is_file()) {
                     return WalkState::Continue;
                 }
                 let Ok(relative) = path.strip_prefix(&root_path) else {
                     return WalkState::Continue;
                 };
                 if exclude_set.is_match(relative) {
+                    if file_type.is_some_and(|t| t.is_dir()) {
+                        return WalkState::Skip;
+                    }
+                    return WalkState::Continue;
+                }
+                if !file_type.is_some_and(|t| t.is_file()) {
                     return WalkState::Continue;
                 }
                 if !include_set.is_match(relative) {
@@ -167,9 +171,34 @@ pub fn read_file_with_encoding(path: &Path, encoding: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{LuaFileInfo, normalize_path_for_ordering, sort_lua_files_by_normalized_path};
+    use std::{
+        fs,
+        path::PathBuf,
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
     use googletest::prelude::*;
-    use std::path::PathBuf;
+
+    use super::{
+        LuaFileInfo, load_workspace_files, normalize_path_for_ordering,
+        sort_lua_files_by_normalized_path,
+    };
+
+    fn temp_workspace() -> PathBuf {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock must be after the Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "glua_ls_loader_test_{}_{}_{}",
+            std::process::id(),
+            timestamp,
+            NEXT_ID.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
 
     #[test]
     fn vfs_loader_normalizes_slashes_and_trailing_separator() {
@@ -218,5 +247,38 @@ mod tests {
         expect_that!(result, ok(anything()));
         let files = result.unwrap();
         expect_that!(files.len(), eq(0));
+    }
+
+    #[test]
+    fn load_workspace_files_prunes_directory_matching_exclude_glob() {
+        let workspace = temp_workspace();
+        let excluded = workspace.join(".claude").join("worktrees").join("copy");
+        fs::create_dir_all(&excluded).expect("excluded test directory should be created");
+        fs::write(workspace.join("main.lua"), "return true")
+            .expect("main test file should be written");
+        fs::write(excluded.join("duplicate.lua"), "return false")
+            .expect("excluded test file should be written");
+
+        let files = load_workspace_files(
+            &workspace,
+            &["**/*.lua".to_string()],
+            &[".claude".to_string()],
+            &[],
+            None,
+        )
+        .expect("workspace files should load");
+        let loaded_paths = files
+            .iter()
+            .map(|file| {
+                PathBuf::from(&file.path)
+                    .strip_prefix(&workspace)
+                    .expect("loaded file should remain inside the workspace")
+                    .to_path_buf()
+            })
+            .collect::<Vec<_>>();
+
+        fs::remove_dir_all(&workspace).expect("test workspace should be removed");
+
+        assert_eq!(loaded_paths, vec![PathBuf::from("main.lua")]);
     }
 }

--- a/crates/glua_doc_cli/README.md
+++ b/crates/glua_doc_cli/README.md
@@ -18,7 +18,7 @@
 - **🔧 Highly Customizable**:
     - Override the default templates with `--override-template` to match your project's branding.
     - Inject custom content into the main page using the `--mixin` option to add guides, tutorials, or other static pages.
-- **📦 Multiple Output Formats**: Generate documentation in **Markdown** or **JSON** for maximum flexibility.
+- **📦 Multiple Output Formats**: Generate MkDocs-compatible **Markdown** or structured **JSON** for maximum flexibility.
 - **🤝 CI/CD Ready**: Automate your documentation publishing workflow with seamless integration into services like GitHub Actions.
 
 ---
@@ -37,9 +37,9 @@ Alternatively, you can grab pre-built binaries from the [**GitHub Releases**](ht
 
 ### Basic Usage
 
-Generate documentation for all Lua files in the `src` directory and output to the default `./docs` folder:
+Generate documentation for all Lua files in the `src` directory. The default output directory is `./output`:
 ```shell
-glua_doc_cli ./src -o ./docs
+glua_doc_cli ./src
 ```
 
 ### Advanced Usage
@@ -51,6 +51,20 @@ Output the documentation structure as a JSON file for custom processing:
 glua_doc_cli . -f json -o ./api.json
 ```
 
+Use `stdout` as the output destination to pipe JSON to another program:
+```shell
+glua_doc_cli . --output-format json --output stdout
+```
+
+#### Build an HTML Site
+
+The Markdown format writes documentation pages and an `mkdocs.yml` project. It does not compile HTML itself. Install [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) and build the generated project:
+```shell
+pip install mkdocs-material
+glua_doc_cli . --output-format markdown --output ./output
+mkdocs build --config-file ./output/mkdocs.yml
+```
+
 #### Customize Site Name
 
 Set a custom name for the generated documentation site:
@@ -58,11 +72,34 @@ Set a custom name for the generated documentation site:
 glua_doc_cli . -o ./docs --site-name "My Awesome Project"
 ```
 
-#### Ignore Files
+#### Exclude Files or Directories
 
-Exclude certain directories or files from the documentation:
+Exclude a workspace-relative file, directory, or glob. A directory path prunes the complete subtree:
 ```shell
-glua_doc_cli . -o ./docs --ignore "third_party/**,test/**"
+glua_doc_cli . -o ./docs --exclude ".claude,third_party/**,test/**"
+```
+
+---
+
+## Configuration and Requirements
+
+- At least one workspace file or directory is required.
+- If `.gluarc.json` exists in the first workspace, it is used exclusively.
+- Otherwise, configuration is loaded in this order: `.luarc.json`, `.emmyrc.json`, then `.emmyrc.lua`.
+- Unsupported configuration value shapes are ignored one field at a time with a warning, while valid settings continue to apply. Unreadable or malformed configuration files still stop generation. Use `--no-config` to skip configuration discovery entirely.
+- Annotation folders should be configured as `workspace.library` entries. Passing an annotation folder as another positional workspace marks it as project code and includes it in the export.
+
+Example annotation library configuration:
+```json
+{
+  "workspace": {
+    "library": [
+      {
+        "path": "C:/path/to/annotations-gmod-glua-ls/output"
+      }
+    ]
+  }
+}
 ```
 
 ---
@@ -109,9 +146,9 @@ Arguments:
 
 Options:
   -c, --config <CONFIG>                        Configuration file paths. If not provided, ".gluarc.json" takes priority; otherwise ".luarc.json" and legacy Emmy config files are searched in the workspace directory
+      --no-config                              Do not discover or load a workspace configuration file
       --include <INCLUDE>                      Comma separated list of include patterns. Patterns must follow glob syntax. It will override the default include patterns.
-      --ignore <EXCLUDE>                       Comma separated list of exclude patterns. Patterns must follow glob syntax(deprecated, use --exclude instead)
-      --exclude <EXCLUDE>                      Comma separated list of exclude patterns. Patterns must follow glob syntax. Exclude patterns take precedence over include patterns
+      --exclude <EXCLUDE>                      Comma separated list of workspace-relative paths or glob patterns. Exclude patterns take precedence over include patterns
   -f, --output-format <OUTPUT_FORMAT>          Specify output format [default: markdown] [possible values: json, markdown]
   -o, --output <OUTPUT>                        Specify output destination (can be stdout when output_format is json) [default: ./output]
       --override-template <OVERRIDE_TEMPLATE>  The path of the override template

--- a/crates/glua_doc_cli/src/bin/glua_doc_cli.rs
+++ b/crates/glua_doc_cli/src/bin/glua_doc_cli.rs
@@ -1,10 +1,33 @@
 use glua_doc_cli::{CmdArgs, Parser, run_doc_cli};
 use mimalloc::MiMalloc;
+use std::{process::ExitCode, thread};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+const DOC_CLI_STACK_SIZE: usize = 16 * 1024 * 1024;
+
+fn main() -> ExitCode {
     let cmd_args = CmdArgs::parse();
-    run_doc_cli(cmd_args)
+    let worker = thread::Builder::new()
+        .name("glua-doc-cli".to_string())
+        .stack_size(DOC_CLI_STACK_SIZE)
+        .spawn(move || match run_doc_cli(cmd_args) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(error) => {
+                eprintln!("ERROR: {error}");
+                ExitCode::FAILURE
+            }
+        });
+
+    match worker {
+        Ok(worker) => worker.join().unwrap_or_else(|_| {
+            eprintln!("ERROR: documentation worker panicked");
+            ExitCode::FAILURE
+        }),
+        Err(error) => {
+            eprintln!("ERROR: failed to start documentation worker: {error}");
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/crates/glua_doc_cli/src/cmd_args.rs
+++ b/crates/glua_doc_cli/src/cmd_args.rs
@@ -10,6 +10,10 @@ pub struct CmdArgs {
     #[arg(short, long, value_delimiter = ',')]
     pub config: Option<Vec<PathBuf>>,
 
+    /// Do not discover or load a workspace configuration file
+    #[arg(long, conflicts_with = "config")]
+    pub no_config: bool,
+
     /// Deprecated, use [WORKSPACE] instead
     #[arg(short, long, num_args = 1..)]
     pub input: Vec<PathBuf>,
@@ -18,8 +22,7 @@ pub struct CmdArgs {
     #[arg(num_args = 1..)]
     pub workspace: Vec<PathBuf>,
 
-    /// Comma separated list of exclude patterns
-    /// Patterns must follow glob syntax
+    /// Comma separated list of workspace-relative paths or glob patterns to exclude
     /// Exclude patterns take precedence over include patterns
     #[arg(long = "exclude", alias = "ignore", value_delimiter = ',')]
     pub exclude_pattern: Option<Vec<String>>,

--- a/crates/glua_doc_cli/src/init.rs
+++ b/crates/glua_doc_cli/src/init.rs
@@ -1,9 +1,10 @@
 use fern::Dispatch;
 use glua_code_analysis::{
-    EmmyLuaAnalysis, WorkspaceFolder, collect_workspace_files, load_configs, update_code_style,
+    EmmyLuaAnalysis, WorkspaceFolder, collect_workspace_files, try_load_configs, update_code_style,
 };
 use log::LevelFilter;
 use std::{
+    error::Error,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -67,7 +68,7 @@ pub fn load_workspace(
     config_paths: Option<Vec<PathBuf>>,
     exclude_pattern: Option<Vec<String>>,
     include_pattern: Option<Vec<String>>,
-) -> Option<EmmyLuaAnalysis> {
+) -> Result<EmmyLuaAnalysis, Box<dyn Error>> {
     let (config_files, config_root): (Vec<PathBuf>, PathBuf) =
         if let Some(config_paths) = config_paths {
             (
@@ -81,7 +82,7 @@ pub fn load_workspace(
             )
         };
 
-    let mut emmyrc = load_configs(config_files, None);
+    let mut emmyrc = try_load_configs(config_files, None)?;
     log::info!(
         "Pre processing configurations using root: \"{}\"",
         config_root.display()
@@ -138,7 +139,7 @@ pub fn load_workspace(
         .collect();
     analysis.update_files_by_path(files);
 
-    Some(analysis)
+    Ok(analysis)
 }
 
 fn discover_config_files_in_order(root: &Path) -> Vec<PathBuf> {

--- a/crates/glua_doc_cli/src/json_generator/export.rs
+++ b/crates/glua_doc_cli/src/json_generator/export.rs
@@ -8,13 +8,13 @@ use glua_code_analysis::{
 use glua_parser::VisibilityKind;
 use rowan::TextRange;
 
-pub fn export(db: &DbIndex) -> Index {
-    Index {
+pub fn export(db: &DbIndex) -> Result<Index, serde_json::Error> {
+    Ok(Index {
         modules: export_modules(db),
         types: export_types(db),
         globals: export_globals(db),
-        config: db.get_emmyrc().clone(),
-    }
+        config: serde_json::to_value(db.get_emmyrc())?,
+    })
 }
 
 fn export_modules(db: &DbIndex) -> Vec<Module> {
@@ -23,7 +23,7 @@ fn export_modules(db: &DbIndex) -> Vec<Module> {
     let modules = module_index.get_module_infos();
     let vfs = db.get_vfs();
 
-    modules
+    let mut exported = modules
         .into_iter()
         .filter(|module| module_index.is_main(&module.file_id))
         .filter_map(|module| {
@@ -46,10 +46,12 @@ fn export_modules(db: &DbIndex) -> Vec<Module> {
                 .unwrap_or_default();
 
             let namespace = type_index.get_file_namespace(&module.file_id).cloned();
-            let using = type_index
+            let mut using = type_index
                 .get_file_using_namespace(&module.file_id)
                 .cloned()
                 .unwrap_or_default();
+            using.sort();
+            using.dedup();
 
             Some(Module {
                 name: module.full_module_name.clone(),
@@ -61,7 +63,14 @@ fn export_modules(db: &DbIndex) -> Vec<Module> {
                 using,
             })
         })
-        .collect()
+        .collect::<Vec<_>>();
+    exported.sort_by(|a, b| {
+        a.name
+            .cmp(&b.name)
+            .then_with(|| a.file.cmp(&b.file))
+            .then_with(|| a.namespace.cmp(&b.namespace))
+    });
+    exported
 }
 
 fn export_types(db: &DbIndex) -> Vec<Type> {
@@ -69,7 +78,7 @@ fn export_types(db: &DbIndex) -> Vec<Type> {
     let module_index = db.get_module_index();
     let types = type_index.get_all_types();
 
-    types
+    let mut exported = types
         .into_iter()
         .filter(|type_decl| {
             type_decl
@@ -88,7 +97,13 @@ fn export_types(db: &DbIndex) -> Vec<Type> {
                 None
             }
         })
-        .collect()
+        .collect::<Vec<_>>();
+    exported.sort_by(|a, b| {
+        type_name(a)
+            .cmp(type_name(b))
+            .then_with(|| type_locations(a).cmp(type_locations(b)))
+    });
+    exported
 }
 
 fn export_globals(db: &DbIndex) -> Vec<Global> {
@@ -98,7 +113,7 @@ fn export_globals(db: &DbIndex) -> Vec<Global> {
     let vfs = db.get_vfs();
     let globals = global_index.get_all_global_decl_ids();
 
-    globals
+    let mut exported = globals
         .into_iter()
         .filter(|global| module_index.is_main(&global.file_id))
         .filter_map(|global| {
@@ -125,7 +140,43 @@ fn export_globals(db: &DbIndex) -> Vec<Global> {
                 })),
             }
         })
-        .collect()
+        .collect::<Vec<_>>();
+    exported.sort_by(|a, b| {
+        global_name(a)
+            .cmp(global_name(b))
+            .then_with(|| global_location(a).cmp(&global_location(b)))
+    });
+    exported
+}
+
+fn type_name(typ: &Type) -> &str {
+    match typ {
+        Type::Class(class) => &class.name,
+        Type::Enum(enumeration) => &enumeration.name,
+        Type::Alias(alias) => &alias.name,
+    }
+}
+
+fn type_locations(typ: &Type) -> &[Loc] {
+    match typ {
+        Type::Class(class) => &class.loc,
+        Type::Enum(enumeration) => &enumeration.loc,
+        Type::Alias(alias) => &alias.loc,
+    }
+}
+
+fn global_name(global: &Global) -> &str {
+    match global {
+        Global::Table(table) => &table.name,
+        Global::Field(field) => &field.name,
+    }
+}
+
+fn global_location(global: &Global) -> Option<&Loc> {
+    match global {
+        Global::Table(table) => table.loc.as_ref(),
+        Global::Field(field) => field.loc.as_ref(),
+    }
 }
 
 fn export_class(db: &DbIndex, type_decl: &LuaTypeDecl) -> Class {
@@ -345,14 +396,20 @@ fn export_property(db: &DbIndex, semantic_decl: &LuaSemanticDeclId) -> Property 
                 LuaDeprecated::DeprecatedWithMessage(msg) => Some(msg.to_string()),
             }),
             tag_content: property.tag_content().map(|tag_content| {
-                tag_content
+                let mut tags = tag_content
                     .get_all_tags()
                     .iter()
                     .map(|(name, content)| TagNameContent {
                         tag_name: name.clone(),
                         content: content.clone(),
                     })
-                    .collect()
+                    .collect::<Vec<_>>();
+                tags.sort_by(|a, b| {
+                    a.tag_name
+                        .cmp(&b.tag_name)
+                        .then_with(|| a.content.cmp(&b.content))
+                });
+                tags
             }),
         },
         None => Default::default(),
@@ -361,11 +418,13 @@ fn export_property(db: &DbIndex, semantic_decl: &LuaSemanticDeclId) -> Property 
 
 fn export_loc_for_type(db: &DbIndex, type_decl: &LuaTypeDecl) -> Vec<Loc> {
     let vfs = db.get_vfs();
-    type_decl
+    let mut locations = type_decl
         .get_locations()
         .iter()
         .filter_map(|loc| export_loc(vfs, loc.file_id, loc.range))
-        .collect()
+        .collect::<Vec<_>>();
+    locations.sort();
+    locations
 }
 
 fn export_loc(vfs: &Vfs, file_id: FileId, range: TextRange) -> Option<Loc> {

--- a/crates/glua_doc_cli/src/json_generator/json_types.rs
+++ b/crates/glua_doc_cli/src/json_generator/json_types.rs
@@ -1,5 +1,5 @@
-use glua_code_analysis::Emmyrc;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::path::PathBuf;
 
 #[derive(Debug, Serialize, Deserialize, Default)]
@@ -7,7 +7,7 @@ pub struct Index {
     pub modules: Vec<Module>,
     pub types: Vec<Type>,
     pub globals: Vec<Global>,
-    pub config: Emmyrc,
+    pub config: Value,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -150,7 +150,7 @@ pub struct TypeVar {
     pub base: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Loc {
     pub file: PathBuf,
     pub line: usize,

--- a/crates/glua_doc_cli/src/json_generator/mod.rs
+++ b/crates/glua_doc_cli/src/json_generator/mod.rs
@@ -1,5 +1,10 @@
 use crate::OutputDestination;
 use glua_code_analysis::EmmyLuaAnalysis;
+use std::{
+    ffi::OsStr,
+    fs::File,
+    io::{self, BufWriter, Write},
+};
 
 mod export;
 mod json_types;
@@ -11,7 +16,12 @@ pub fn generate_json(
     let db = analysis.compilation.get_db();
 
     let output = match output {
-        OutputDestination::File(output) if output.extension() == Some("json".as_ref()) => {
+        OutputDestination::File(output)
+            if output
+                .extension()
+                .and_then(OsStr::to_str)
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("json")) =>
+        {
             if let Some(parent) = output.parent()
                 && !parent.exists()
             {
@@ -32,15 +42,22 @@ pub fn generate_json(
         OutputDestination::Stdout => OutputDestination::Stdout,
     };
 
-    let data = export::export(db);
+    let data = export::export(db)?;
 
     match output {
         OutputDestination::Stdout => {
-            println!("{}", serde_json::to_string_pretty(&data)?);
+            let stdout = io::stdout();
+            let mut writer = BufWriter::new(stdout.lock());
+            serde_json::to_writer_pretty(&mut writer, &data)?;
+            writeln!(writer)?;
+            writer.flush()?;
         }
         OutputDestination::File(json_path) => {
             log::info!("Writing JSON to: {:?}", json_path);
-            std::fs::write(&json_path, serde_json::to_string_pretty(&data)?)?;
+            let mut writer = BufWriter::new(File::create(&json_path)?);
+            serde_json::to_writer_pretty(&mut writer, &data)?;
+            writeln!(writer)?;
+            writer.flush()?;
             eprintln!("Documentation JSON exported to {:?}", json_path);
         }
     }

--- a/crates/glua_doc_cli/src/lib.rs
+++ b/crates/glua_doc_cli/src/lib.rs
@@ -40,18 +40,18 @@ pub fn run_doc_cli(mut cmd_args: CmdArgs) -> Result<(), Box<dyn std::error::Erro
         .ok_or("Failed to load workspace")?
         .clone();
 
-    let analysis = match init::load_workspace(
+    let config_paths = if cmd_args.no_config {
+        Some(Vec::new())
+    } else {
+        cmd_args.config
+    };
+    let analysis = init::load_workspace(
         main_path.clone(),
         workspaces.clone(),
-        cmd_args.config,
+        config_paths,
         cmd_args.exclude_pattern,
         cmd_args.include_pattern,
-    ) {
-        Some(analysis) => analysis,
-        None => {
-            return Err("Failed to load workspace".into());
-        }
-    };
+    )?;
 
     match cmd_args.output_format {
         Format::Markdown => markdown_generator::generate_markdown(

--- a/crates/glua_doc_cli/tests/cli_integration.rs
+++ b/crates/glua_doc_cli/tests/cli_integration.rs
@@ -1,0 +1,161 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::Command,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use serde_json::Value;
+
+fn temp_workspace(name: &str) -> PathBuf {
+    static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock must be after the Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "glua_doc_cli_{name}_{}_{}_{}",
+        std::process::id(),
+        timestamp,
+        NEXT_ID.fetch_add(1, Ordering::Relaxed)
+    ))
+}
+
+#[test]
+fn json_export_prunes_directory_matching_exclude_path() {
+    let workspace = temp_workspace("exclude");
+    let excluded = workspace.join(".claude").join("worktrees").join("copy");
+    fs::create_dir_all(&excluded).expect("excluded test directory should be created");
+    fs::write(workspace.join("main.lua"), "MainOnly = true")
+        .expect("main test file should be written");
+    fs::write(
+        excluded.join("duplicate.lua"),
+        "DuplicateShouldNotLoad = true",
+    )
+    .expect("excluded test file should be written");
+    let json_path = workspace.join("api.json");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_glua_doc_cli"))
+        .args([
+            "--no-config",
+            "--exclude",
+            ".claude",
+            "--output-format",
+            "json",
+            "--output",
+        ])
+        .arg(&json_path)
+        .arg(&workspace)
+        .output()
+        .expect("documentation CLI should run");
+    assert!(
+        output.status.success(),
+        "documentation CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let data: serde_json::Value = serde_json::from_slice(
+        &fs::read(&json_path).expect("documentation JSON should be written"),
+    )
+    .expect("documentation output should be valid JSON");
+    let global_names = data["globals"]
+        .as_array()
+        .expect("globals should be an array")
+        .iter()
+        .filter_map(|global| global["name"].as_str())
+        .collect::<Vec<_>>();
+
+    fs::remove_dir_all(&workspace).expect("test workspace should be removed");
+
+    assert_eq!(global_names, vec!["MainOnly"]);
+}
+
+#[test]
+fn invalid_config_field_is_ignored_without_discarding_valid_settings() {
+    let workspace = temp_workspace("invalid_config");
+    let ignored = workspace.join(".claude").join("worktrees").join("copy");
+    fs::create_dir_all(&ignored).expect("ignored test directory should be created");
+    fs::write(workspace.join("main.lua"), "MainOnly = true")
+        .expect("main test file should be written");
+    fs::write(
+        ignored.join("duplicate.lua"),
+        "DuplicateShouldNotLoad = true",
+    )
+    .expect("ignored test file should be written");
+    fs::write(
+        workspace.join(".luarc.json"),
+        r#"{
+            "workspace.encoding": {"unexpected": true},
+            "workspace.ignoreDir": [".claude"]
+        }"#,
+    )
+    .expect("invalid config fixture should be written");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_glua_doc_cli"))
+        .args(["--output-format", "json", "--output", "stdout"])
+        .arg(&workspace)
+        .output()
+        .expect("documentation CLI should run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success()
+            && stderr.contains(".luarc.json")
+            && stderr.contains("workspace.encoding")
+            && stderr.contains("invalid type: map, expected a string"),
+        "unexpected CLI result (status {}): {stderr}",
+        output.status
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should contain valid JSON");
+    let global_names = json["globals"]
+        .as_array()
+        .expect("globals should be an array")
+        .iter()
+        .filter_map(|global| global["name"].as_str())
+        .collect::<Vec<_>>();
+
+    fs::remove_dir_all(&workspace).expect("test workspace should be removed");
+
+    assert_eq!(global_names, vec!["MainOnly"]);
+}
+
+#[test]
+fn invalid_higher_priority_config_value_preserves_valid_lower_priority_value() {
+    let workspace = temp_workspace("config_precedence");
+    fs::create_dir_all(&workspace).expect("test workspace should be created");
+    fs::write(
+        workspace.join(".luarc.json"),
+        r#"{"workspace.encoding": "windows-1252"}"#,
+    )
+    .expect("lower-priority config fixture should be written");
+    fs::write(
+        workspace.join(".emmyrc.json"),
+        r#"{"workspace.encoding": {"unexpected": true}}"#,
+    )
+    .expect("higher-priority config fixture should be written");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_glua_doc_cli"))
+        .args(["--output-format", "json", "--output", "stdout"])
+        .arg(&workspace)
+        .output()
+        .expect("documentation CLI should run");
+    assert!(
+        output.status.success(),
+        "documentation CLI failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should contain valid JSON");
+    let encoding = json["config"]["workspace"]["encoding"]
+        .as_str()
+        .expect("exported config encoding should be a string")
+        .to_string();
+
+    fs::remove_dir_all(&workspace).expect("test workspace should be removed");
+
+    assert_eq!(encoding, "windows-1252");
+}


### PR DESCRIPTION
## Summary

- prune excluded directories before workspace traversal so paths such as `.claude/worktrees` are not analyzed
- tolerate invalid config values without discarding valid settings or lower-priority values
- run documentation generation on a larger worker stack and stream deterministic JSON output
- document the CLI behavior and add end-to-end JSON export coverage

## Why

The documentation CLI could descend into duplicated worktrees, lose valid configuration after one invalid value, and overflow the release binary's default Windows stack while analyzing a large workspace such as CityRP.

## Validation

- `cargo test -p glua_doc_cli --offline`
- `cargo test -p glua_code_analysis --offline` (2,997 passed, 5 ignored)
- Clippy with warnings denied for both affected crates
- `cargo fmt --all -- --check`
- CityRP JSON and Markdown export checks, including deterministic JSON output and a low-main-stack executable test